### PR TITLE
fixed segfault issue when qt>v4.8.5 on Ubuntu using pyplot

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -56,6 +56,34 @@ function add_backend_string(::PyPlotBackend)
         Pkg.build("PyPlot")
     end
     """
+    if !Plots.is_installed("PyPlot")
+        Pkg.add("PyPlot")
+    end
+    withenv("PYTHON" => "") do
+        Pkg.build("PyPlot")
+    end
+    import Conda          # TODO since this only known to occur on Ubuntu we could also check the user's OS here
+    Conda.add("qt=4.8.5") # run the old version of Conda
+    # TO AVOID:
+    # 1) Segfault when attempting to run pylplot
+        # caused by Conda update to Segfault with qt >=4.8.6 on Ubuntu https://github.com/JuliaPy/PyPlot.jl/issues/234
+    # 2) precomilation issue after updating Plots.jl
+        #=
+        INFO: Recompiling stale cache file /home/febbo/.julia/lib/v0.5/Plots.ji for module Plots.
+        ERROR: LoadError: Declaring __precompile__(false) is not allowed in files that are being precompiled.
+        in __precompile__(::Bool) at ./loading.jl:300
+        in include_from_node1(::String) at ./loading.jl:488
+        in macro expansion; at ./none:2 [inlined]
+        in anonymous at ./<missing>:?
+        in eval(::Module, ::Any) at ./boot.jl:234
+        in process_options(::Base.JLOptions) at ./client.jl:239
+        in _start() at ./client.jl:318
+        while loading /home/febbo/.julia/v0.5/Plots/src/Plots.jl, in expression starting on line 1
+        ERROR: LoadError: Failed to precompile Plots to /home/febbo/.julia/lib/v0.5/Plots.ji.
+        in compilecache(::String) at ./loading.jl:593
+        in require(::Symbol) at ./loading.jl:393
+        in include_from_node1(::String) at ./loading.jl:488
+        =#
 end
 
 function _initialize_backend(::PyPlotBackend)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -56,34 +56,6 @@ function add_backend_string(::PyPlotBackend)
         Pkg.build("PyPlot")
     end
     """
-    if !Plots.is_installed("PyPlot")
-        Pkg.add("PyPlot")
-    end
-    withenv("PYTHON" => "") do
-        Pkg.build("PyPlot")
-    end
-    import Conda          # TODO since this only known to occur on Ubuntu we could also check the user's OS here
-    Conda.add("qt=4.8.5") # run the old version of Conda
-    # TO AVOID:
-    # 1) Segfault when attempting to run pylplot
-        # caused by Conda update to Segfault with qt >=4.8.6 on Ubuntu https://github.com/JuliaPy/PyPlot.jl/issues/234
-    # 2) precomilation issue after updating Plots.jl
-        #=
-        INFO: Recompiling stale cache file /home/febbo/.julia/lib/v0.5/Plots.ji for module Plots.
-        ERROR: LoadError: Declaring __precompile__(false) is not allowed in files that are being precompiled.
-        in __precompile__(::Bool) at ./loading.jl:300
-        in include_from_node1(::String) at ./loading.jl:488
-        in macro expansion; at ./none:2 [inlined]
-        in anonymous at ./<missing>:?
-        in eval(::Module, ::Any) at ./boot.jl:234
-        in process_options(::Base.JLOptions) at ./client.jl:239
-        in _start() at ./client.jl:318
-        while loading /home/febbo/.julia/v0.5/Plots/src/Plots.jl, in expression starting on line 1
-        ERROR: LoadError: Failed to precompile Plots to /home/febbo/.julia/lib/v0.5/Plots.ji.
-        in compilecache(::String) at ./loading.jl:593
-        in require(::Symbol) at ./loading.jl:393
-        in include_from_node1(::String) at ./loading.jl:488
-        =#
 end
 
 function _initialize_backend(::PyPlotBackend)
@@ -109,7 +81,18 @@ function _initialize_backend(::PyPlotBackend)
         const pycollections = PyPlot.pywrap(PyPlot.pyimport("matplotlib.collections"))
         const pyart3d = PyPlot.pywrap(PyPlot.pyimport("mpl_toolkits.mplot3d.art3d"))
     end
-
+    if is_linux()
+      @eval begin
+        # avoid Conda update that causes Segfault with qt >=4.8.6 on Ubuntu https://github.com/JuliaPy/PyPlot.jl/issues/234
+        import Conda
+        kw = Conda._installed_packages_dict()
+        if (!haskey(kw,"qt") || (qt_version=get(kw,"qt",0)[1]!=v"4.8.5"))
+          print("\n Switching to qt v4.8.5!! \n")
+          Conda.add("qt=4.8.5")
+          error("\n Please RESTART julia to use qt v4.8.5!! \n If we did not error here, a Segmentation fault error would occur. \n \n")
+        end
+      end
+    end
     # we don't want every command to update the figure
     PyPlot.ioff()
 end


### PR DESCRIPTION
@tbreloff simply adding:
```
import Conda
Conda.add("qt=4.8.5")
```
to the ``function add_backend_string(::PyPlotBackend)`` did not work. For instance, if you run:
```
import Conda
Conda.add("qt=4.8.6")
```
then restart julia and run:
```
julia> using Plots

julia> plot(rand(30,3))

signal (11): Segmentation fault
while loading no file, in expression starting on line 0
unknown function (ip: 0x32735)
Allocations: 15516666 (Pool: 15515155; Big: 1511); GC: 27
Segmentation fault (core dumped)
febbo@febbo-HP-ZBook-17-G2:~/.julia/v0
```
So, it will never print out your warning message. So, I just automated it and told the user to restart julia.
