### PR TITLE
path spaces fix stolen from http://stackoverflow.com/a/13692919

### DIFF
--- a/src/backends/web.jl
+++ b/src/backends/web.jl
@@ -27,7 +27,7 @@ function open_browser_window(filename::AbstractString)
         return run(`xdg-open $(filename)`)
     end
     @static if is_windows()
-        return run(`$(ENV["COMSPEC"]) /c start $(filename)`)
+        return run(`$(ENV["COMSPEC"]) /c start "" "$(filename)"`)
     end
     warn("Unknown OS... cannot open browser window.")
 end


### PR DESCRIPTION
Spaces in Windows paths resulted in improper DOS command. Fix designed
according to the above-referenced StackOverflow post.