### PR TITLE
enable standalone window for plotlyjs() backend

### DIFF
--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -102,8 +102,18 @@ _show(io::IO, ::MIME"image/png", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hac
 _show(io::IO, ::MIME"application/pdf", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "pdf")
 _show(io::IO, ::MIME"image/eps", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "eps")
 
+function write_temp_html(plt::Plot{PlotlyJSBackend})
+    filename = string(tempname(), ".html")
+    savefig(plt, filename)
+    filename
+end
+
 function _display(plt::Plot{PlotlyJSBackend})
-    display(plt.o)
+    if get(ENV, "PLOTS_USE_ATOM_PLOTPANE", true) in (true, 1, "1", "true", "yes")
+        display(plt.o)
+    else
+        standalone_html_window(plt)
+    end
 end
 
 

--- a/src/output.jl
+++ b/src/output.jl
@@ -302,6 +302,10 @@ function setup_atom()
                 Media.render(pane, Atom.div(".fill", Atom.HTML(stringmime(MIME("text/html"), plt))))
                 plt[:size] = sz
             end
+            # special handling for PlotlyJS
+            function Media.render(pane::Atom.PlotPane, plt::Plot{PlotlyJSBackend})
+                display(Plots.PlotsDisplay(), plt)
+            end
         else
             #
             function Media.render(pane::Atom.PlotPane, plt::Plot)
@@ -316,12 +320,6 @@ function setup_atom()
             display(Plots.PlotsDisplay(), plt)
             s = "PlotPane turned off.  The plotly and plotlyjs backends cannot render in the PlotPane due to javascript issues."
             Media.render(pane, Atom.div(Atom.HTML(s)))
-        end
-
-        # special handling for PlotlyJS to pass through to that render method
-        function Media.render(pane::Atom.PlotPane, plt::Plot{PlotlyJSBackend})
-            Plots.prepare_output(plt)
-            Media.render(pane, plt.o)
         end
     end
 end


### PR DESCRIPTION
enviroment variable `ENV["PLOTS_USE_ATOM_PLOTPANE"]`
is not working for both `plotly()` and `plotlyjs()` backend. 

but since saving to html is possible with #590
plotlyjs could use both `ATOM_PLOTPANE` and standalone window. 

this is simple fix I could've come up with. through It doesn't look so clean...