### PR TITLE
Set limit for number of temporary files

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -117,7 +117,15 @@ function savefig(plt::Plot, fn::AbstractString)
 end
 savefig(fn::AbstractString) = savefig(current(), fn)
 
-
+function Base.tempname()
+    tempfile_limit = UInt32(30)
+    global tempname_counter = if isdefined(Plots, :tempname_counter)
+        tempname_counter + UInt32(1)
+    else
+        UInt32(1)
+    end
+    return tempname(tempname_counter % tempfile_limit)
+end
 # ---------------------------------------------------------
 
 gui(plt::Plot = current()) = display(PlotsDisplay(), plt)


### PR DESCRIPTION
This is for #645 
I think problem is that `Plots.jl` can potentially create several hundred temporary files, not that really matters... but just messy.
And since Juno Plot Pane is planning to introduce [plot history feature](https://github.com/JunoLab/atom-julia-client/issues/122) sometime in the future, it makes sense to store 'some' temporary files and make those names predictable for Juno to handle plot history.