### PR TITLE
base histograms on StatsBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ Reexport
 FixedSizeArrays
 Measures
 Showoff
+StatsBase

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -9,6 +9,7 @@ using Base.Meta
 @reexport using PlotUtils
 @reexport using PlotThemes
 import Showoff
+import StatsBase
 
 export
     grid,

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -465,10 +465,6 @@ end
 end
 @deps histogram2d heatmap
 
-@recipe function f{T, E}(h::StatsBase.Histogram{T, 2, E})
-    seriestype := :bar
-    h.edges[1], h.weights
-end
 # ---------------------------------------------------------------------------
 # scatter 3d
 


### PR DESCRIPTION
This is a rewrite of the histogram functionality that passes the calculation of the histograms (the binning, weights etc) to the histogram functionality in StatsBase.

This makes for more intuitive bin edges in histograms, with good alignment to x axis tick marks, and also for better consistency of histogram bins (across Julia and with e.g. R).

All the user-facing interface is unchanged.