### PR TITLE
Changing grid to Axis attribute from subplot

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -50,8 +50,6 @@ export
     yflip!,
     xaxis!,
     yaxis!,
-    xgrid!,
-    ygrid!,
 
     xlims,
     ylims,
@@ -197,8 +195,6 @@ xflip!(flip::Bool = true; kw...)                          = plot!(; xflip = flip
 yflip!(flip::Bool = true; kw...)                          = plot!(; yflip = flip, kw...)
 xaxis!(args...; kw...)                                    = plot!(; xaxis = args, kw...)
 yaxis!(args...; kw...)                                    = plot!(; yaxis = args, kw...)
-xgrid!(grid::Bool = true; kw...)                          = plot!(; xgrid = grid, kw...)
-ygrid!(grid::Bool = true; kw...)                          = plot!(; ygrid = grid, kw...)
 
 let PlotOrSubplot = Union{Plot, Subplot}
     title!(plt::PlotOrSubplot, s::AbstractString; kw...)                  = plot!(plt; title = s, kw...)
@@ -222,8 +218,6 @@ let PlotOrSubplot = Union{Plot, Subplot}
     yflip!(plt::PlotOrSubplot, flip::Bool = true; kw...)                  = plot!(plt; yflip = flip, kw...)
     xaxis!(plt::PlotOrSubplot, args...; kw...)                            = plot!(plt; xaxis = args, kw...)
     yaxis!(plt::PlotOrSubplot, args...; kw...)                            = plot!(plt; yaxis = args, kw...)
-    xgrid!(plt::PlotOrSubplot, grid::Bool = true; kw...)                  = plot!(plt; xgrid = grid, kw...)
-    ygrid!(plt::PlotOrSubplot, grid::Bool = true; kw...)                  = plot!(plt; ygrid = grid, kw...)
 end
 
 

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -50,6 +50,8 @@ export
     yflip!,
     xaxis!,
     yaxis!,
+    xgrid!,
+    ygrid!,
 
     xlims,
     ylims,
@@ -195,6 +197,8 @@ xflip!(flip::Bool = true; kw...)                          = plot!(; xflip = flip
 yflip!(flip::Bool = true; kw...)                          = plot!(; yflip = flip, kw...)
 xaxis!(args...; kw...)                                    = plot!(; xaxis = args, kw...)
 yaxis!(args...; kw...)                                    = plot!(; yaxis = args, kw...)
+xgrid!(grid::Bool = true; kw...)                          = plot!(; xgrid = grid, kw...)
+ygrid!(grid::Bool = true; kw...)                          = plot!(; ygrid = grid, kw...)
 
 let PlotOrSubplot = Union{Plot, Subplot}
     title!(plt::PlotOrSubplot, s::AbstractString; kw...)                  = plot!(plt; title = s, kw...)
@@ -218,6 +222,8 @@ let PlotOrSubplot = Union{Plot, Subplot}
     yflip!(plt::PlotOrSubplot, flip::Bool = true; kw...)                  = plot!(plt; yflip = flip, kw...)
     xaxis!(plt::PlotOrSubplot, args...; kw...)                            = plot!(plt; xaxis = args, kw...)
     yaxis!(plt::PlotOrSubplot, args...; kw...)                            = plot!(plt; yaxis = args, kw...)
+    xgrid!(plt::PlotOrSubplot, grid::Bool = true; kw...)                  = plot!(plt; xgrid = grid, kw...)
+    ygrid!(plt::PlotOrSubplot, grid::Bool = true; kw...)                  = plot!(plt; ygrid = grid, kw...)
 end
 
 

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -83,7 +83,6 @@ const _arg_desc = KW(
 :colorbar                 => "Bool (show the colorbar?) or Symbol (colorbar position).  Symbol values: `:none`, `:best`, `:right`, `:left`, `:top`, `:bottom`, `:legend` (matches legend value) (note: only some may be supported in each backend)",
 :clims 					  => "`:auto` or NTuple{2,Number}.  Fixes the limits of the colorbar.",
 :legendfont               => "Font. Font of legend items.",
-:grid                     => "Bool. Show the grid lines?",
 :annotations              => "(x,y,text) tuple(s).  Can be a single tuple or a list of them.  Text can be String or PlotText (created with `text(args...)`)  Add one-off text annotations at the x,y coordinates.",
 :projection               => "Symbol or String.  '3d' or 'polar'",
 :aspect_ratio             => "Symbol (:equal) or Number. Plot area is resized so that 1 y-unit is the same size as `apect_ratio` x-units.",
@@ -110,5 +109,6 @@ const _arg_desc = KW(
 :foreground_color_text    => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of tick labels.",
 :foreground_color_guide   => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of axis guides (axis labels).",
 :mirror                   => "Bool.  Switch the side of the tick labels (right or top).",
+:grid                     => "Bool. Show grid lines?"
 
 )

--- a/src/args.jl
+++ b/src/args.jl
@@ -249,7 +249,6 @@ const _subplot_defaults = KW(
     :colorbar                 => :legend,
     :clims                    => :auto,
     :legendfont               => font(8),
-    :grid                     => true,
     :annotations              => [],                # annotation tuples... list of (x,y,annotation)
     :projection               => :none,             # can also be :polar or :3d
     :aspect_ratio             => :none,             # choose from :none or :equal
@@ -279,6 +278,7 @@ const _axis_defaults = KW(
     :discrete_values => [],
     :formatter => :auto,
     :mirror => false,
+    :grid => true,
 )
 
 const _suppress_warnings = Set{Symbol}([
@@ -315,6 +315,7 @@ for letter in (:x,:y,:z)
     #             :foreground_color_guide,
     #             :discrete_values,
     #             :formatter,
+    #             :grid,
     #         )
         _axis_defaults_byletter[Symbol(letter,k)] = :match
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -635,7 +635,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         # @show xticks yticks #spine_segs grid_segs
 
         # draw the grid lines
-        if sp[:grid]
+        if axis[:grid]
             # gr_set_linecolor(sp[:foreground_color_grid])
             # GR.grid(xtick, ytick, 0, 0, majorx, majory)
             gr_set_line(1, :dot, sp[:foreground_color_grid])

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -212,7 +212,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
     letter = axis[:letter]
     ax = KW(
         :title      => axis[:guide],
-        :showgrid   => sp[:grid],
+        :showgrid   => axis[:grid],
         :zeroline   => false,
         :ticks      => "inside",
     )

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1063,7 +1063,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 #                ax[:set_axisbelow](true)
 #            end
             if axis[:grid]
-                fgcolor = py_color(axis[:foreground_color_grid])
+                fgcolor = py_color(sp[:foreground_color_grid])
                 pyaxis[:grid](true, color = fgcolor)
                 ax[:set_axisbelow](true)
             end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1057,11 +1057,11 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 lab[:set_family](axis[:tickfont].family)
                 lab[:set_rotation](axis[:rotation])
             end
-            if sp[:grid]
-                fgcolor = py_color(sp[:foreground_color_grid])
-                pyaxis[:grid](true, color = fgcolor)
-                ax[:set_axisbelow](true)
-            end
+#            if sp[:grid]
+#                fgcolor = py_color(sp[:foreground_color_grid])
+#                pyaxis[:grid](true, color = fgcolor)
+#                ax[:set_axisbelow](true)
+#            end
             py_set_axis_colors(ax, axis)
         end
 

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1063,7 +1063,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 #                ax[:set_axisbelow](true)
 #            end
             if axis[:grid]
-                fgcolor = py_color(axix[:foreground_color_grid])
+                fgcolor = py_color(axis[:foreground_color_grid])
                 pyaxis[:grid](true, color = fgcolor)
                 ax[:set_axisbelow](true)
             end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1062,6 +1062,11 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 #                pyaxis[:grid](true, color = fgcolor)
 #                ax[:set_axisbelow](true)
 #            end
+            if axis[:grid]
+                fgcolor = py_color(axix[:foreground_color_grid])
+                pyaxis[:grid](true, color = fgcolor)
+                ax[:set_axisbelow](true)
+            end
             py_set_axis_colors(ax, axis)
         end
 

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1057,11 +1057,6 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 lab[:set_family](axis[:tickfont].family)
                 lab[:set_rotation](axis[:rotation])
             end
-#            if sp[:grid]
-#                fgcolor = py_color(sp[:foreground_color_grid])
-#                pyaxis[:grid](true, color = fgcolor)
-#                ax[:set_axisbelow](true)
-#            end
             if axis[:grid]
                 fgcolor = py_color(sp[:foreground_color_grid])
                 pyaxis[:grid](true, color = fgcolor)


### PR DESCRIPTION
#675 Grid is now an Axis attribute so that grid lines can be enabled by x,y axis separately.

`plot(Plots.fakedata(100,10),layout=4,palette=[:grays :blues :heat :lightrainbow],bg_inside=[:orange :pink :yellow :green])`
`plot!(xflip=[true false false false], xgrid=[true false true false], ygrid=[true true false false])`
![grid1](https://cloud.githubusercontent.com/assets/10288252/23198818/04035886-f87f-11e6-9196-1b0f3ba376d9.png)

`plot(Plots.fakedata(100,10),layout=4,palette=[:grays :blues :heat :lightrainbow],bg_inside=[:orange :pink :yellow :green])`
`plot!(grid=[true true false false])`
![grid2](https://cloud.githubusercontent.com/assets/10288252/23198830/15bd7f0c-f87f-11e6-8b5d-8621f402a1a9.png)


