### PR TITLE
Change GR label for scatterplot

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1017,7 +1017,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 end
 
                 if series[:markershape] != :none
-                    gr_draw_markers(series, xpos-[0.06,0.02], [ypos,ypos], 10, nothing)
+                    gr_draw_markers(series, xpos - .035, ypos, 6, nothing)
                 end
 
                 if typeof(series[:label]) <: Array


### PR DESCRIPTION
From conversation in #693.  This changes the GR scatterplot labels from two markers to one smaller marker.

<img width="598" alt="screen shot 2017-02-22 at 10 42 26 am" src="https://cloud.githubusercontent.com/assets/8075494/23218928/a2685cda-f8eb-11e6-83e9-1dc5c81ff366.png">
