### PR TITLE
Remove import of Base.scale(!); fixes #687

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -174,7 +174,7 @@ function center(shape::Shape)
     Cx / 6A, Cy / 6A
 end
 
-function Base.scale!(shape::Shape, x::Real, y::Real = x, c = center(shape))
+function scale!(shape::Shape, x::Real, y::Real = x, c = center(shape))
     sx, sy = coords(shape)
     cx, cy = c
     for i=1:length(sx)
@@ -184,7 +184,7 @@ function Base.scale!(shape::Shape, x::Real, y::Real = x, c = center(shape))
     shape
 end
 
-function Base.scale(shape::Shape, x::Real, y::Real = x, c = center(shape))
+function scale(shape::Shape, x::Real, y::Real = x, c = center(shape))
     shapecopy = deepcopy(shape)
     scale!(shapecopy, x, y, c)
 end


### PR DESCRIPTION
Base.scale and Base.scale! were deprecated in v0.5 and removed in
v0.6-pre.alpha.  Removing their import permits use on v0.6- and
is fine since we REQUIRE v0.5 and above.