### PR TITLE
Added logic to choose *round* DateTime tick positions

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -156,6 +156,13 @@ function optimal_ticks_and_labels(axis::Axis, ticks = nothing)
     scale = axis[:scale]
     sf = scalefunc(scale)
 
+    # If the axis input was a Date or DateTime use a special logic to find
+    # "round" Date(Time)s as ticks
+    # TODO: maybe: non-trivial scale (:ln, :log2, :log10) for date/datetime
+    if axis[:formatter] in (dateformatter, datetimeformatter) && scale == :identity
+        return optimize_datetime_ticks(amin, amax; k_min = 2, k_max = 4)
+    end
+
     # get a list of well-laid-out ticks
     scaled_ticks = if ticks == nothing
         optimize_ticks(

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -159,7 +159,7 @@ function optimal_ticks_and_labels(axis::Axis, ticks = nothing)
     # If the axis input was a Date or DateTime use a special logic to find
     # "round" Date(Time)s as ticks
     # TODO: maybe: non-trivial scale (:ln, :log2, :log10) for date/datetime
-    if axis[:formatter] in (dateformatter, datetimeformatter) && scale == :identity
+    if axis[:formatter] in (dateformatter, datetimeformatter) && ticks == nothing && scale == :identity
         return optimize_datetime_ticks(amin, amax; k_min = 2, k_max = 4)
     end
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -792,8 +792,11 @@ abline!(args...; kw...) = abline!(current(), args...; kw...)
 # -------------------------------------------------
 # Dates
 
-@recipe f(::Type{Date}, dt::Date) = (dt -> convert(Int,dt), dt -> string(convert(Date,dt)))
-@recipe f(::Type{DateTime}, dt::DateTime) = (dt -> convert(Int,dt), dt -> string(convert(DateTime,dt)))
+dateformatter(dt) = string(convert(Date, convert(DateTime, dt)))
+datetimeformatter(dt) = string(convert(DateTime, dt))
+
+@recipe f(::Type{Date}, dt::Date) = (dt -> convert(Int, convert(DateTime, dt)), dateformatter)
+@recipe f(::Type{DateTime}, dt::DateTime) = (dt -> convert(Int,dt), datetimeformatter)
 
 # -------------------------------------------------
 # Complex Numbers


### PR DESCRIPTION
implementation of https://github.com/JuliaPlots/Plots.jl/issues/714
requires https://github.com/JuliaPlots/PlotUtils.jl/pull/8

tested with:

```
using Plots

hourrange = DateTime(2017, 2, 22, 9, 31):Dates.Minute(15):DateTime(2017,2,22,12)
dayrange = DateTime(2017, 1, 30, 9):Dates.Minute(15):DateTime(2017, 2, 2, 14)
weekrange = DateTime(2017, 1, 30, 9):Dates.Minute(15):DateTime(2017, 2, 8, 14)
monthrange = DateTime(2016, 4, 1):Dates.Minute(15):DateTime(2017, 1, 30, 9)
yearrange = DateTime(2017):Dates.Day(1):DateTime(2018)-Dates.Day(1)

hourdata = randn(length(hourrange))
daydata = randn(length(dayrange))
weekdata = randn(length(weekrange))
monthdata = randn(length(monthrange))
yeardata = randn(length(yearrange))

@time plot(hourrange, hourdata)
@time plot(dayrange, daydata)
@time plot(weekrange, weekdata)
@time plot(monthrange, monthdata)
@time plot(yearrange, yeardata)
```
with `gr()` and `pyplot()`