### PR TITLE
set dotted grid lines for pyplot

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1059,7 +1059,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             end
             if sp[:grid]
                 fgcolor = py_color(sp[:foreground_color_grid])
-                pyaxis[:grid](true, color = fgcolor)
+                pyaxis[:grid](true, color = fgcolor, linestyle = ":")
                 ax[:set_axisbelow](true)
             end
             py_set_axis_colors(ax, axis)


### PR DESCRIPTION
Some people asked for the pyplot grid to be dotted again after the change to matplotlib 2.0. This does that. (It is still black, though, most other backends seem to have it grey).