### PR TITLE
Fix small issues with response to :dpi value.

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -232,7 +232,7 @@ const _plot_defaults = KW(
     :html_output_format          => :auto,
     :inset_subplots              => nothing,   # optionally pass a vector of (parent,bbox) tuples which are
                                                # the parent layout and the relative bounding box of inset subplots
-    :dpi                         => DPI,        # dots per inch for images, etc
+    :dpi                         => DEFAULT_DPI, # dots per inch for images, etc
     :display_type                => :auto,
     :extra_kwargs                => KW(),
 )

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -2,10 +2,12 @@
 # NOTE: (0,0) is the top-left !!!
 
 # allow pixels and percentages
-const px = AbsoluteLength(0.254)
-const pct = Length{:pct, Float64}(1.0)
+const LENGTH_POINT = AbsoluteLength(MM_PER_POINT)
+const px = LENGTH_POINT #malaforge: Hack.  Should deprecate.
+#const px = AbsoluteLength(0.254) #Old def assumed 100 dpi... why?
+const pct = Length{:pct, Float64}(1.0) #Represents 1%
 
-to_pixels(m::AbsoluteLength) = m.value / 0.254
+to_pixels(m::AbsoluteLength) = m.value / MM_PER_POINT #malaforge: should be called "to_point"
 
 const _cbar_width = 5mm
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -857,17 +857,18 @@ end
 # Some conversion functions
 # note: I borrowed these conversion constants from Compose.jl's Measure
 
-const PX_PER_INCH   = 100
-const DPI           = PX_PER_INCH
+const DTPPOINTS_PER_INCH = 72 #Typography (desktop publishing) points per inch
+const DEFAULT_DPI   = DTPPOINTS_PER_INCH
 const MM_PER_INCH   = 25.4
-const MM_PER_PX     = MM_PER_INCH / PX_PER_INCH
 
-inch2px(inches::Real)   = float(inches * PX_PER_INCH)
-px2inch(px::Real)       = float(px / PX_PER_INCH)
 inch2mm(inches::Real)   = float(inches * MM_PER_INCH)
 mm2inch(mm::Real)       = float(mm / MM_PER_INCH)
-px2mm(px::Real)         = float(px * MM_PER_PX)
-mm2px(mm::Real)         = float(px / MM_PER_PX)
+px2inch(px::Float64, dpi::Float64) = px / dpi
+px2inch(px::Real, dpi::Real) = px2inch(Float64(px), Float64(dpi))
+
+#Convert to typography "points":
+px2pt(px::Float64, dpi::Float64) = px * (DTPPOINTS_PER_INCH / dpi)
+px2pt(px::Real, dpi::Real) = px2pt(Float64(px), Float64(dpi))
 
 
 "Smallest x in plot"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -860,13 +860,14 @@ end
 const DTPPOINTS_PER_INCH = 72 #Typography (desktop publishing) points per inch
 const DEFAULT_DPI   = DTPPOINTS_PER_INCH
 const MM_PER_INCH   = 25.4
+const MM_PER_POINT  = MM_PER_INCH/DTPPOINTS_PER_INCH
 
 inch2mm(inches::Real)   = float(inches * MM_PER_INCH)
 mm2inch(mm::Real)       = float(mm / MM_PER_INCH)
 px2inch(px::Float64, dpi::Float64) = px / dpi
 px2inch(px::Real, dpi::Real) = px2inch(Float64(px), Float64(dpi))
-
-#Convert to typography "points":
+pt2inch(pt::Float64)    = pt / DTPPOINTS_PER_INCH
+pt2inch(pt::Real)       = pt2inch(Float64(pt))
 px2pt(px::Float64, dpi::Float64) = px * (DTPPOINTS_PER_INCH / dpi)
 px2pt(px::Real, dpi::Real) = px2pt(Float64(px), Float64(dpi))
 


### PR DESCRIPTION
Now line widths, etc are in pixels (like I assume was the intent for Plots.jl).

:dpi now only affects font sizes (because they are in points - not pixels)...  And grid line widths, I guess... because we don't seem to do the size mapping for those.

...But the main thing that :dpi changes is the size (in inches) of the image metadata...

As with other backends (presumably), the user must use the `size=(w,h)` keyword to control the saved image dimension.