### PR TITLE
wip: svg now saves static svg for plotlyjs + reliable IJulia output

### DIFF
--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -85,12 +85,9 @@ end
 
 # ----------------------------------------------------------------
 
-function _show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyJSBackend})
-    if isijulia() && !_use_remote[]
-        write(io, PlotlyJS.html_body(PlotlyJS.JupyterPlot(plt.o)))
-    else
-        show(io, MIME("text/html"), plt.o)
-    end
+function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend})
+    prepare_output(plt)
+    show(io, MIME("text/html"), plt.o)
 end
 
 function plotlyjs_save_hack(io::IO, plt::Plot{PlotlyJSBackend}, ext::String)
@@ -98,6 +95,7 @@ function plotlyjs_save_hack(io::IO, plt::Plot{PlotlyJSBackend}, ext::String)
     PlotlyJS.savefig(plt.o, tmpfn)
     write(io, read(open(tmpfn)))
 end
+_show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "svg")
 _show(io::IO, ::MIME"image/png", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "png")
 _show(io::IO, ::MIME"application/pdf", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "pdf")
 _show(io::IO, ::MIME"image/eps", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "eps")


### PR DESCRIPTION
Solves #750. I've added a specialized method to display html plots for PlotlyJS, so that it doesn't default to svg. Now svg can save the static image. The html can still be saved using for example `savefig("test.html")`.
As an added bonus, this method of showing html on IJulia doesn't have the flickering problem I used to experience when combining it with Interact.