### PR TITLE
restore bar_width behavior for date x axis

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -792,11 +792,11 @@ abline!(args...; kw...) = abline!(current(), args...; kw...)
 # -------------------------------------------------
 # Dates
 
-dateformatter(dt) = string(convert(Date, convert(DateTime, dt)))
+dateformatter(dt) = string(convert(Date, dt))
 datetimeformatter(dt) = string(convert(DateTime, dt))
 
-@recipe f(::Type{Date}, dt::Date) = (dt -> convert(Int, convert(DateTime, dt)), dateformatter)
-@recipe f(::Type{DateTime}, dt::DateTime) = (dt -> convert(Int,dt), datetimeformatter)
+@recipe f(::Type{Date}, dt::Date) = (dt -> convert(Int, dt), dateformatter)
+@recipe f(::Type{DateTime}, dt::DateTime) = (dt -> convert(Int, dt), datetimeformatter)
 
 # -------------------------------------------------
 # Complex Numbers


### PR DESCRIPTION
This restores the `bar_width` behavior for `Date` x axis to the way it was before #720 as discussed in #748.
Now
```
bar(Date.(1:5), 1:5)
```
and
```
bar(Date.(1:5), 1:5, bar_width = 365)
```
return the same plot again.