### PR TITLE
WIP: Allow specifying the number of ticks by passing an Integer to the ticks attribute

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -188,6 +188,23 @@ function optimal_ticks_and_labels(axis::Axis, ticks = nothing)
             k_min = 5, # minimum number of ticks
             k_max = 8, # maximum number of ticks
         )[1]
+    elseif typeof(ticks) <: Int
+        # only return ticks within the axis limits
+        filter(
+            ti -> sf(amin) <= ti <= sf(amax),
+            optimize_ticks(
+                sf(amin),
+                sf(amax);
+                # TODO: find a better configuration to return the chosen number
+                # of ticks
+                k_min = ticks + 1, # minimum number of ticks
+                k_max = ticks + 2, # maximum number of ticks
+                k_ideal = ticks + 2,
+                # `strict_span = false` rewards cases where the span of the
+                # chosen  ticks is not too much bigger than amin - amax:
+                strict_span = false,
+            )[1]
+        )
     else
         map(sf, filter(t -> amin <= t <= amax, ticks))
     end
@@ -226,7 +243,7 @@ function get_ticks(axis::Axis)
     elseif ticks == :auto
         # compute optimal ticks and labels
         optimal_ticks_and_labels(axis)
-    elseif typeof(ticks) <: AVec
+    elseif typeof(ticks) <: Union{AVec, Int}
         # override ticks, but get the labels
         optimal_ticks_and_labels(axis, ticks)
     elseif typeof(ticks) <: NTuple{2}

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -241,7 +241,7 @@ function get_ticks(axis::Axis)
     elseif typeof(ticks) <: Union{AVec, Int}
         # override ticks, but get the labels
         optimal_ticks_and_labels(axis, ticks)
-    elseif typeof(ticks) <: NTuple{2}
+    elseif typeof(ticks) <: NTuple{2, Any}
         # assuming we're passed (ticks, labels)
         ticks
     else

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -241,7 +241,7 @@ function get_ticks(axis::Axis)
     elseif typeof(ticks) <: Union{AVec, Int}
         # override ticks, but get the labels
         optimal_ticks_and_labels(axis, ticks)
-    elseif typeof(ticks) <: NTuple{2, Any}
+    elseif typeof(ticks) <: NTuple{2}
         # assuming we're passed (ticks, labels)
         ticks
     else

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -187,26 +187,21 @@ function optimal_ticks_and_labels(axis::Axis, ticks = nothing)
             sf(amax);
             k_min = 5, # minimum number of ticks
             k_max = 8, # maximum number of ticks
-        )[1], sf(amin), sf(amax)
+        )[1]
     elseif typeof(ticks) <: Int
         scaled_ticks, viewmin, viewmax = optimize_ticks(
             sf(amin),
             sf(amax);
-            # TODO: find a better configuration to return the chosen number
-            # of ticks
             k_min = ticks, # minimum number of ticks
             k_max = ticks, # maximum number of ticks
             k_ideal = ticks,
-            # k_min = ticks + 1, # minimum number of ticks
-            # k_max = ticks + 2, # maximum number of ticks
-            # k_ideal = ticks + 2,
             # `strict_span = false` rewards cases where the span of the
             # chosen  ticks is not too much bigger than amin - amax:
             strict_span = false,
         )
         axis[:lims] = map(invscalefunc(scale), (viewmin, viewmax))
     else
-        scaled_ticks = map(sf, (filter(t -> amin <= t <= amax, ticks), amin, amax))
+        scaled_ticks = map(sf, (filter(t -> amin <= t <= amax, ticks)))
     end
     unscaled_ticks = map(invscalefunc(scale), scaled_ticks)
 
@@ -503,10 +498,10 @@ end
 # compute the line segments which should be drawn for this axis
 function axis_drawing_info(sp::Subplot)
     xaxis, yaxis = sp[:xaxis], sp[:yaxis]
-    xticks = get_ticks(xaxis)
-    yticks = get_ticks(yaxis)
     xmin, xmax = axis_limits(xaxis)
     ymin, ymax = axis_limits(yaxis)
+    xticks = get_ticks(xaxis)
+    yticks = get_ticks(yaxis)
     spine_segs = Segments(2)
     grid_segs = Segments(2)
 


### PR DESCRIPTION
The discussion in https://github.com/JuliaPlots/PlotUtils.jl/pull/11 reminded me of this request https://github.com/JuliaPlots/Plots.jl/issues/462.
I think this would also provide an easy workaround for users in such degenerate cases, where only one tick is shown in a plot.

This is the first attempt to implement the option to set the desired number of ticks for an axis by passing an Integer to the `ticks`/`xticks`/`yticks`/`zticks` attributes. However, I did not yet manage to find the right configuration when calling `optimize_ticks` in order to always return correct number of ticks.

Here is the output of
```julia
plot([begin
        scatter(s[:,1], s[:,2])
        plot!(e1[:,1], e1[:,2], ticks = i, title = "ticks = $i")
    end for i in [0:5; 10; 15; 20]]..., label = "")
```
with the data of the example discussed in https://github.com/JuliaPlots/PlotUtils.jl/pull/11:

![nticks_strictspan_false_filter](https://cloud.githubusercontent.com/assets/16589944/25316862/2068e7ce-286e-11e7-9aac-a2cd64b423de.png)

There are too few ticks chosen in most cases. The issue is, that the algorithm in `optimize_ticks` returns ticks that can in general be outside the axis limits. I doubt that we want to extend the axis limits in those cases, thus the outlying ticks are dropped.

cc: @crbinz Maybe you have some useful input here, because you did such a great job identifying the problem in your degenerate example and because you are already familiar with the ticks scoring algorithm.
