### PR TITLE
Prevent inadvertent Conda ROOTENV initialization

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -89,10 +89,12 @@ function _initialize_backend(::PyPlotBackend)
       @eval begin
         # avoid Conda update that causes Segfault with qt >=4.8.6 on Ubuntu https://github.com/JuliaPy/PyPlot.jl/issues/234
         import Conda
-        kw = Conda._installed_packages_dict()
-        if (!haskey(kw,"qt") || (qt_version=get(kw,"qt",0)[1]!=v"4.8.5"))
-          print("\n If the code has a Segmentation fault error switch to qt v4.8.5 by pasting the following code into julia: \n \n")
-          print(add_backend_string(PyPlotBackend()))
+        if isfile(Conda.conda) # Using Conda-internal conda (instead of an external conda)
+            kw = Conda._installed_packages_dict()
+            if (!haskey(kw,"qt") || (qt_version=get(kw,"qt",0)[1]!=v"4.8.5"))
+              print("\n If the code has a Segmentation fault error switch to qt v4.8.5 by pasting the following code into julia: \n \n")
+              print(add_backend_string(PyPlotBackend()))
+            end
         end
       end
     end


### PR DESCRIPTION
Conda._installed_packages_dict() always runs Conda._install_conda(), even when using an external conda installation (e.g. via Anaconda).