### PR TITLE
Avoid PyPlot colorbar label cropping

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1107,7 +1107,7 @@ function _update_min_padding!(sp::Subplot{PyPlotBackend})
     # optionally add the width of colorbar labels and colorbar to rightpad
     if haskey(sp.attr, :cbar_ax)
         bb = py_bbox(sp.attr[:cbar_handle][:ax][:get_yticklabels]())
-        sp.attr[:cbar_width] = _cbar_width + width(bb) + 1mm + (sp[:colorbar_title] == "" ? 0px : 30px)
+        sp.attr[:cbar_width] = _cbar_width + width(bb) + 2.3mm + (sp[:colorbar_title] == "" ? 0px : 30px)
         rightpad = rightpad + sp.attr[:cbar_width]
     end
 


### PR DESCRIPTION
This should solve the issue of colorbar label cropping in pyplot sins matplotlib2.0 discussed in https://github.com/JuliaPlots/Plots.jl/issues/670. (I'm not sure if it also solves https://github.com/JuliaPlots/Plots.jl/issues/603)

The issue was that the colorbar ticks were previously inside the colorbar, and now they are outside. Thus the width added to rightpad had to be increased. I found 2.3mm to be the minimal value without label cropping in all VRT images with colorbars:

![pyplot_4](https://cloud.githubusercontent.com/assets/16589944/25635282/e236e638-2f7d-11e7-8664-afd27cb3af70.png)

![pyplot_10](https://cloud.githubusercontent.com/assets/16589944/25635298/eef88f20-2f7d-11e7-81ba-3a846e597fd0.png)

![pyplot_22](https://cloud.githubusercontent.com/assets/16589944/25635305/f6e8e068-2f7d-11e7-9932-daed20975023.png)

![pyplot_24](https://cloud.githubusercontent.com/assets/16589944/25635316/0002ccfe-2f7e-11e7-958d-32852b021277.png)

![pyplot_28](https://cloud.githubusercontent.com/assets/16589944/25635325/058c495c-2f7e-11e7-91a2-9ce3db1ddb9c.png)

The old (cropping) behavior can be viewed in https://github.com/JuliaPlots/Plots.jl/issues/670.