### PR TITLE
Change cycle => _cycle

### DIFF
--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -783,7 +783,7 @@ function gl_bar(d, kw_args)
     hw = if bw == nothing
         ignorenan_mean(diff(x))
     else
-        Float64[cycle(bw,i)*0.5 for i=1:length(x)]
+        Float64[_cycle(bw,i)*0.5 for i=1:length(x)]
     end
 
     # make fillto a vector... default fills to 0
@@ -797,7 +797,7 @@ function gl_bar(d, kw_args)
     sx, sy = m[1,1], m[2,2]
     for i=1:ny
         center = x[i]
-        hwi = abs(cycle(hw,i)); yi = y[i]; fi = cycle(fillto,i)
+        hwi = abs(_cycle(hw,i)); yi = y[i]; fi = _cycle(fillto,i)
         if Plots.isvertical(d)
             sz = (hwi*sx, yi*sy)
         else
@@ -833,7 +833,7 @@ function gl_boxplot(d, kw_args)
     sx, sy = m[1,1], m[2,2]
     for (i,glabel) in enumerate(glabels)
         # filter y
-        values = y[filter(i -> cycle(x,i) == glabel, 1:length(y))]
+        values = y[filter(i -> _cycle(x,i) == glabel, 1:length(y))]
         # compute quantiles
         q1,q2,q3,q4,q5 = quantile(values, linspace(0,1,5))
         # notch
@@ -846,7 +846,7 @@ function gl_boxplot(d, kw_args)
 
         # make the shape
         center = Plots.discrete_value!(d[:subplot][:xaxis], glabel)[1]
-        hw = d[:bar_width] == nothing ? Plots._box_halfwidth*2 : cycle(d[:bar_width], i)
+        hw = d[:bar_width] == nothing ? Plots._box_halfwidth*2 : _cycle(d[:bar_width], i)
         l, m, r = center - hw/2, center, center + hw/2
 
         # internal nodes for notches
@@ -945,7 +945,7 @@ function scale_for_annotations!(series::Series, scaletype::Symbol = :pixels)
         msw, msh = anns.scalefactor
         offsets = Array(Vec2f0, length(anns.strs))
         series[:markersize] = map(1:length(anns.strs)) do i
-            str = cycle(anns.strs, i)
+            str = _cycle(anns.strs, i)
             # get the width and height of the string (in mm)
             sw, sh = text_size(str, anns.font.pointsize)
 
@@ -1058,7 +1058,7 @@ function _display(plt::Plot{GLVisualizeBackend}, visible = true)
                     kw = copy(kw_args)
                     fr = d[:fillrange]
                     ps = if all(x-> x >= 0, diff(d[:x])) # if is monotonic
-                        vcat(points, Point2f0[(points[i][1], cycle(fr, i)) for i=length(points):-1:1])
+                        vcat(points, Point2f0[(points[i][1], _cycle(fr, i)) for i=length(points):-1:1])
                     else
                         points
                     end
@@ -1231,7 +1231,7 @@ function gl_scatter(points, kw_args)
     if haskey(kw_args, :stroke_width)
         s = Reactive.value(kw_args[:scale])
         sw = kw_args[:stroke_width]
-        if sw*5 > cycle(Reactive.value(s), 1)[1] # restrict marker stroke to 1/10th of scale (and handle arrays of scales)
+        if sw*5 > _cycle(Reactive.value(s), 1)[1] # restrict marker stroke to 1/10th of scale (and handle arrays of scales)
             kw_args[:stroke_width] = s[1] / 5f0
         end
     end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -124,10 +124,10 @@ function gr_getcolorind(c)
     convert(Int, GR.inqcolorfromrgb(red(c), green(c), blue(c)))
 end
 
-gr_set_linecolor(c)   = GR.setlinecolorind(gr_getcolorind(cycle(c,1)))
-gr_set_fillcolor(c)   = GR.setfillcolorind(gr_getcolorind(cycle(c,1)))
-gr_set_markercolor(c) = GR.setmarkercolorind(gr_getcolorind(cycle(c,1)))
-gr_set_textcolor(c)   = GR.settextcolorind(gr_getcolorind(cycle(c,1)))
+gr_set_linecolor(c)   = GR.setlinecolorind(gr_getcolorind(_cycle(c,1)))
+gr_set_fillcolor(c)   = GR.setfillcolorind(gr_getcolorind(_cycle(c,1)))
+gr_set_markercolor(c) = GR.setmarkercolorind(gr_getcolorind(_cycle(c,1)))
+gr_set_textcolor(c)   = GR.settextcolorind(gr_getcolorind(_cycle(c,1)))
 
 # --------------------------------------------------------------------------------------
 
@@ -301,23 +301,23 @@ function gr_draw_markers(series::Series, x, y, msize, mz)
     shapes = series[:markershape]
     if shapes != :none
         for i=1:length(x)
-            msi = cycle(msize, i)
-            shape = cycle(shapes, i)
+            msi = _cycle(msize, i)
+            shape = _cycle(shapes, i)
             cfunc = isa(shape, Shape) ? gr_set_fillcolor : gr_set_markercolor
             cfuncind = isa(shape, Shape) ? GR.setfillcolorind : GR.setmarkercolorind
 
             # draw a filled in shape, slightly bigger, to estimate a stroke
             if series[:markerstrokewidth] > 0
-                cfunc(cycle(series[:markerstrokecolor], i)) #, series[:markerstrokealpha])
+                cfunc(_cycle(series[:markerstrokecolor], i)) #, series[:markerstrokealpha])
                 gr_draw_marker(x[i], y[i], msi + series[:markerstrokewidth], shape)
             end
 
             # draw the shape
             if mz == nothing
-                cfunc(cycle(series[:markercolor], i)) #, series[:markeralpha])
+                cfunc(_cycle(series[:markercolor], i)) #, series[:markeralpha])
             else
                 # pick a color from the pre-loaded gradient
-                ci = round(Int, 1000 + cycle(mz, i) * 255)
+                ci = round(Int, 1000 + _cycle(mz, i) * 255)
                 cfuncind(ci)
                 GR.settransparency(_gr_gradient_alpha[ci-999])
             end
@@ -808,9 +808,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     fr_from, fr_to = (is_2tuple(frng) ? frng : (y, frng))
                     for (i,rng) in enumerate(iter_segments(series[:x], series[:y]))
                         if length(rng) > 1
-                            gr_set_fillcolor(cycle(series[:fillcolor], i))
-                            fx = cycle(x, vcat(rng, reverse(rng)))
-                            fy = vcat(cycle(fr_from,rng), cycle(fr_to,reverse(rng)))
+                            gr_set_fillcolor(_cycle(series[:fillcolor], i))
+                            fx = _cycle(x, vcat(rng, reverse(rng)))
+                            fy = vcat(_cycle(fr_from,rng), _cycle(fr_to,reverse(rng)))
                             # @show i rng fx fy
                             GR.fillarea(fx, fy)
                         end
@@ -962,11 +962,11 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     x, y = series[:x][rng], series[:y][rng]
 
                     # draw the interior
-                    gr_set_fill(cycle(series[:fillcolor], i))
+                    gr_set_fill(_cycle(series[:fillcolor], i))
                     GR.fillarea(x, y)
 
                     # draw the shapes
-                    gr_set_line(series[:linewidth], :solid, cycle(series[:linecolor], i))
+                    gr_set_line(series[:linewidth], :solid, _cycle(series[:linecolor], i))
                     GR.polyline(x, y)
                 end
             end

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -265,8 +265,8 @@ For st in :shape:
             nmax = i
             if length(rng) > 1
                 linewidth = series[:linewidth]
-                linecolor = _inspectdr_mapcolor(cycle(series[:linecolor], i))
-                fillcolor = _inspectdr_mapcolor(cycle(series[:fillcolor], i))
+                linecolor = _inspectdr_mapcolor(_cycle(series[:linecolor], i))
+                fillcolor = _inspectdr_mapcolor(_cycle(series[:fillcolor], i))
                 line = InspectDR.line(
                     style=:solid, width=linewidth, color=linecolor
                 )
@@ -280,8 +280,8 @@ For st in :shape:
         i = (nmax >= 2? div(nmax, 2): nmax) #Must pick one set of colors for legend
         if i > 1 #Add dummy waveform for legend entry:
             linewidth = series[:linewidth]
-            linecolor = _inspectdr_mapcolor(cycle(series[:linecolor], i))
-            fillcolor = _inspectdr_mapcolor(cycle(series[:fillcolor], i))
+            linecolor = _inspectdr_mapcolor(_cycle(series[:linecolor], i))
+            fillcolor = _inspectdr_mapcolor(_cycle(series[:fillcolor], i))
             wfrm = InspectDR.add(plot, Float64[], Float64[], id=series[:label])
             wfrm.line = InspectDR.line(
                 style=:none, width=linewidth, #linewidth affects glyph

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -600,18 +600,18 @@ function plotly_series_shapes(plt::Plot, series::Series)
             :x => vcat(x[rng], x[rng[1]]),
             :y => vcat(y[rng], y[rng[1]]),
             :fill => "tozeroy",
-            :fillcolor => rgba_string(cycle(series[:fillcolor], i)),
+            :fillcolor => rgba_string(_cycle(series[:fillcolor], i)),
         ))
         if series[:markerstrokewidth] > 0
             d_out[:line] = KW(
-                :color => rgba_string(cycle(series[:linecolor], i)),
+                :color => rgba_string(_cycle(series[:linecolor], i)),
                 :width => series[:linewidth],
                 :dash => string(series[:linestyle]),
             )
         end
         d_out[:showlegend] = i==1 ? should_add_to_legend(series) : false
         plotly_polar!(d_out, series)
-        plotly_hover!(d_out, cycle(series[:hover], i))
+        plotly_hover!(d_out, _cycle(series[:hover], i))
         push!(d_outs, d_out)
     end
     d_outs

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -495,10 +495,10 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                 handle = if is3d(st)
                     for rng in iter_segments(x, y, z)
                         length(rng) < 2 && continue
-                        push!(segments, [(cycle(x,i),cycle(y,i),cycle(z,i)) for i in rng])
+                        push!(segments, [(_cycle(x,i),_cycle(y,i),_cycle(z,i)) for i in rng])
                     end
                     # for i=1:n
-                    #     segments[i] = [(cycle(x,i), cycle(y,i), cycle(z,i)), (cycle(x,i+1), cycle(y,i+1), cycle(z,i+1))]
+                    #     segments[i] = [(_cycle(x,i), _cycle(y,i), _cycle(z,i)), (_cycle(x,i+1), _cycle(y,i+1), _cycle(z,i+1))]
                     # end
                     lc = pyart3d.Line3DCollection(segments; kw...)
                     lc[:set_array](lz)
@@ -507,10 +507,10 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                 else
                     for rng in iter_segments(x, y)
                         length(rng) < 2 && continue
-                        push!(segments, [(cycle(x,i),cycle(y,i)) for i in rng])
+                        push!(segments, [(_cycle(x,i),_cycle(y,i)) for i in rng])
                     end
                     # for i=1:n
-                    #     segments[i] = [(cycle(x,i), cycle(y,i)), (cycle(x,i+1), cycle(y,i+1))]
+                    #     segments[i] = [(_cycle(x,i), _cycle(y,i)), (_cycle(x,i+1), _cycle(y,i+1))]
                     # end
                     lc = pycollections.LineCollection(segments; kw...)
                     lc[:set_array](lz)
@@ -581,16 +581,16 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             lw = py_dpi_scale(plt, series[:markerstrokewidth])
             for i=1:length(y)
                 extrakw[:c] = if series[:marker_z] == nothing
-                    py_color_fix(py_color(cycle(series[:markercolor],i)), x)
+                    py_color_fix(py_color(_cycle(series[:markercolor],i)), x)
                 else
                     extrakw[:c]
                 end
 
-                push!(handle, ax[:scatter](cycle(x,i), cycle(y,i);
+                push!(handle, ax[:scatter](_cycle(x,i), _cycle(y,i);
                     label = series[:label],
                     zorder = series[:series_plotindex] + 0.5,
-                    marker = py_marker(cycle(shapes,i)),
-                    s =  py_dpi_scale(plt, cycle(series[:markersize],i) .^ 2),
+                    marker = py_marker(_cycle(shapes,i)),
+                    s =  py_dpi_scale(plt, _cycle(series[:markersize],i) .^ 2),
                     edgecolors = msc,
                     linewidths = lw,
                     extrakw...
@@ -802,8 +802,8 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     path;
                     label = series[:label],
                     zorder = series[:series_plotindex],
-                    edgecolor = py_color(cycle(series[:linecolor], i)),
-                    facecolor = py_color(cycle(series[:fillcolor], i)),
+                    edgecolor = py_color(_cycle(series[:linecolor], i)),
+                    facecolor = py_color(_cycle(series[:fillcolor], i)),
                     linewidth = py_dpi_scale(plt, series[:linewidth]),
                     fill = true
                 )
@@ -1166,7 +1166,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                 # add a line/marker and a label
                 push!(handles, if series[:seriestype] == :shape
                     PyPlot.plt[:Line2D]((0,1),(0,0),
-                        color = py_color(cycle(series[:fillcolor],1)),
+                        color = py_color(_cycle(series[:fillcolor],1)),
                         linewidth = py_dpi_scale(plt, 4)
                     )
                 else

--- a/src/components.jl
+++ b/src/components.jl
@@ -446,7 +446,7 @@ function series_annotations_shapes!(series::Series, scaletype::Symbol = :pixels)
         msw,msh = anns.scalefactor
         msize = Float64[]
         shapes = Shape[begin
-            str = cycle(anns.strs,i)
+            str = _cycle(anns.strs,i)
 
             # get the width and height of the string (in mm)
             sw, sh = text_size(str, anns.font.pointsize)
@@ -462,7 +462,7 @@ function series_annotations_shapes!(series::Series, scaletype::Symbol = :pixels)
             # and then re-scale a copy of baseshape to match the w/h ratio
             maxscale = max(xscale, yscale)
             push!(msize, maxscale)
-            baseshape = cycle(get(anns.baseshape),i)
+            baseshape = _cycle(get(anns.baseshape),i)
             shape = scale(baseshape, msw*xscale/maxscale, msh*yscale/maxscale, (0,0))
         end for i=1:length(anns.strs)]
         series[:markershape] = shapes
@@ -479,13 +479,13 @@ end
 Base.start(ea::EachAnn) = 1
 Base.done(ea::EachAnn, i) = ea.anns == nothing || isempty(ea.anns.strs) || i > length(ea.y)
 function Base.next(ea::EachAnn, i)
-    tmp = cycle(ea.anns.strs,i)
+    tmp = _cycle(ea.anns.strs,i)
     str,fnt = if isa(tmp, PlotText)
         tmp.str, tmp.font
     else
         tmp, ea.anns.font
     end
-    ((cycle(ea.x,i), cycle(ea.y,i), str, fnt), i+1)
+    ((_cycle(ea.x,i), _cycle(ea.y,i), str, fnt), i+1)
 end
 
 annotations(::Void) = []

--- a/src/deprecated/backends/gadfly_shapes.jl
+++ b/src/deprecated/backends/gadfly_shapes.jl
@@ -84,7 +84,7 @@ function make_polygon(geom::ShapeGeometry, xs::AbstractArray, ys::AbstractArray,
     x = Compose.x_measure(xs[mod1(i, length(xs))])
     y = Compose.y_measure(ys[mod1(i, length(ys))])
     r = rs[mod1(i, length(rs))]
-    polys[i] = T[(x + r * sx, y + r * sy) for (sx,sy) in cycle(geom.vertices, i)]
+    polys[i] = T[(x + r * sx, y + r * sy) for (sx,sy) in _cycle(geom.vertices, i)]
   end
   Gadfly.polygon(polys, geom.tag)
 end

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -262,7 +262,7 @@ function _subplot_setup(plt::Plot, d::KW, kw_list::Vector{KW})
     for kw in kw_list
         # get the Subplot object to which the series belongs.
         sps = get(kw, :subplot, :auto)
-        sp = get_subplot(plt, cycle(sps == :auto ? plt.subplots : plt.subplots[sps], command_idx(kw_list,kw)))
+        sp = get_subplot(plt, _cycle(sps == :auto ? plt.subplots : plt.subplots[sps], command_idx(kw_list,kw)))
         kw[:subplot] = sp
 
         # extract subplot/axis attributes from kw and add to sp_attr

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -340,7 +340,7 @@ end
     hw = if bw == nothing
         0.5ignorenan_mean(diff(procx))
     else
-        Float64[0.5cycle(bw,i) for i=1:length(procx)]
+        Float64[0.5_cycle(bw,i) for i=1:length(procx)]
     end
 
     # make fillto a vector... default fills to 0

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -232,7 +232,7 @@ end
     for i=1:n
         rng = 3i-2:3i
         newx[rng] = [x[i], x[i], NaN]
-        newy[rng] = [cycle(fr,i), y[i], NaN]
+        newy[rng] = [_cycle(fr,i), y[i], NaN]
     end
     x := newx
     y := newy
@@ -284,16 +284,16 @@ end
     for rng in iter_segments(args...)
         length(rng) < 2 && continue
         ts = linspace(0, 1, npoints)
-        nanappend!(newx, map(t -> bezier_value(cycle(x,rng), t), ts))
-        nanappend!(newy, map(t -> bezier_value(cycle(y,rng), t), ts))
+        nanappend!(newx, map(t -> bezier_value(_cycle(x,rng), t), ts))
+        nanappend!(newy, map(t -> bezier_value(_cycle(y,rng), t), ts))
         if z != nothing
-            nanappend!(newz, map(t -> bezier_value(cycle(z,rng), t), ts))
+            nanappend!(newz, map(t -> bezier_value(_cycle(z,rng), t), ts))
         end
         if fr != nothing
-            nanappend!(newfr, map(t -> bezier_value(cycle(fr,rng), t), ts))
+            nanappend!(newfr, map(t -> bezier_value(_cycle(fr,rng), t), ts))
         end
         # if lz != nothing
-        #     lzrng = cycle(lz, rng) # the line_z's for this segment
+        #     lzrng = _cycle(lz, rng) # the line_z's for this segment
         #     push!(newlz, 0.0)
         #     append!(newlz, map(t -> lzrng[1+floor(Int, t * (length(rng)-1))], ts))
         # end
@@ -358,8 +358,8 @@ end
         yi = procy[i]
         if !isnan(yi)
             center = procx[i]
-            hwi = cycle(hw,i)
-            fi = cycle(fillto,i)
+            hwi = _cycle(hw,i)
+            fi = _cycle(fillto,i)
             push!(xseg, center-hwi, center-hwi, center+hwi, center+hwi, center-hwi)
             push!(yseg, yi, fi, fi, yi, yi)
         end
@@ -755,9 +755,9 @@ function error_coords(xorig, yorig, ebar)
     x, y = Array(float_extended_type(xorig), 0), Array(Float64, 0)
     # for each point, create a line segment from the bottom to the top of the errorbar
     for i = 1:max(length(xorig), length(yorig))
-        xi = cycle(xorig, i)
-        yi = cycle(yorig, i)
-        ebi = cycle(ebar, i)
+        xi = _cycle(xorig, i)
+        yi = _cycle(yorig, i)
+        ebi = _cycle(ebar, i)
         nanappend!(x, [xi, xi])
         e1, e2 = if istuple(ebi)
             first(ebi), last(ebi)
@@ -810,11 +810,11 @@ function quiver_using_arrows(d::KW)
     x, y = zeros(0), zeros(0)
     for i = 1:max(length(xorig), length(yorig))
         # get the starting position
-        xi = cycle(xorig, i)
-        yi = cycle(yorig, i)
+        xi = _cycle(xorig, i)
+        yi = _cycle(yorig, i)
 
         # get the velocity
-        vi = cycle(velocity, i)
+        vi = _cycle(velocity, i)
         vx, vy = if istuple(vi)
             first(vi), last(vi)
         elseif isscalar(vi)
@@ -847,12 +847,12 @@ function quiver_using_hack(d::KW)
     for i = 1:max(length(xorig), length(yorig))
 
         # get the starting position
-        xi = cycle(xorig, i)
-        yi = cycle(yorig, i)
+        xi = _cycle(xorig, i)
+        yi = _cycle(yorig, i)
         p = P2(xi, yi)
 
         # get the velocity
-        vi = cycle(velocity, i)
+        vi = _cycle(velocity, i)
         vx, vy = if istuple(vi)
             first(vi), last(vi)
         elseif isscalar(vi)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -192,7 +192,7 @@ function iter_segments(args...)
 end
 
 # helpers to figure out if there are NaN values in a list of array types
-anynan(i::Int, args::Tuple) = any(a -> !isfinite(cycle(a,i)), args)
+anynan(i::Int, args::Tuple) = any(a -> !isfinite(_cycle(a,i)), args)
 anynan(istart::Int, iend::Int, args::Tuple) = any(i -> anynan(i, args), istart:iend)
 allnan(istart::Int, iend::Int, args::Tuple) = all(i -> anynan(i, args), istart:iend)
 
@@ -243,19 +243,19 @@ notimpl() = error("This has not been implemented yet")
 isnothing(x::Void) = true
 isnothing(x) = false
 
-cycle(wrapper::InputWrapper, idx::Int) = wrapper.obj
-cycle(wrapper::InputWrapper, idx::AVec{Int}) = wrapper.obj
+_cycle(wrapper::InputWrapper, idx::Int) = wrapper.obj
+_cycle(wrapper::InputWrapper, idx::AVec{Int}) = wrapper.obj
 
-cycle(v::AVec, idx::Int) = v[mod1(idx, length(v))]
-cycle(v::AMat, idx::Int) = size(v,1) == 1 ? v[1, mod1(idx, size(v,2))] : v[:, mod1(idx, size(v,2))]
-cycle(v, idx::Int)       = v
+_cycle(v::AVec, idx::Int) = v[mod1(idx, length(v))]
+_cycle(v::AMat, idx::Int) = size(v,1) == 1 ? v[1, mod1(idx, size(v,2))] : v[:, mod1(idx, size(v,2))]
+_cycle(v, idx::Int)       = v
 
-cycle(v::AVec, indices::AVec{Int}) = map(i -> cycle(v,i), indices)
-cycle(v::AMat, indices::AVec{Int}) = map(i -> cycle(v,i), indices)
-cycle(v, indices::AVec{Int})       = fill(v, length(indices))
+_cycle(v::AVec, indices::AVec{Int}) = map(i -> _cycle(v,i), indices)
+_cycle(v::AMat, indices::AVec{Int}) = map(i -> _cycle(v,i), indices)
+_cycle(v, indices::AVec{Int})       = fill(v, length(indices))
 
-cycle(grad::ColorGradient, idx::Int) = cycle(grad.colors, idx)
-cycle(grad::ColorGradient, indices::AVec{Int}) = cycle(grad.colors, indices)
+_cycle(grad::ColorGradient, idx::Int) = _cycle(grad.colors, idx)
+_cycle(grad::ColorGradient, indices::AVec{Int}) = _cycle(grad.colors, indices)
 
 makevec(v::AVec) = v
 makevec{T}(v::T) = T[v]
@@ -292,7 +292,7 @@ function _expand_limits(lims, x)
   nothing
 end
 
-expand_data(v, n::Integer) = [cycle(v, i) for i=1:n]
+expand_data(v, n::Integer) = [_cycle(v, i) for i=1:n]
 
 # if the type exists in a list, replace the first occurence.  otherwise add it to the end
 function addOrReplace(v::AbstractVector, t::DataType, args...; kw...)
@@ -355,8 +355,8 @@ function convert_to_polar(x, y, r_extrema = calc_r_extrema(x, y))
     x = zeros(n)
     y = zeros(n)
     for i in 1:n
-        x[i] = cycle(r,i) * cos.(cycle(phi,i))
-        y[i] = cycle(r,i) * sin.(cycle(phi,i))
+        x[i] = _cycle(r,i) * cos.(_cycle(phi,i))
+        y[i] = _cycle(r,i) * sin.(_cycle(phi,i))
     end
     x, y
 end


### PR DESCRIPTION
There is a Base function named `cycle` which this is not. This makes the code rather confusing, especially since `Base.cycle` is used in other places. Additionally, this is then imported in other libraries, meaning it's an important function. This changes the name of this function to `_cycle` instead of shadowing the Base function to improve code clarity.