### PR TITLE
RFC: Update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
   # - osx
 julia:
   - 0.5
+  - 0.6
+
 matrix:
   allow_failures:
     - julia: nightly

--- a/test/install_wkhtmltoimage.sh
+++ b/test/install_wkhtmltoimage.sh
@@ -7,7 +7,7 @@ sudo apt-get -qq update
 
 sudo apt-get install -y xfonts-75dpi
 wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2/wkhtmltox-0.12.2_linux-trusty-amd64.deb
-sudo dpkg -i wkhtmltox-0.12.2_linux-trusty-amd64.deb || true
+sudo dpkg -i --depends wkhtmltox-0.12.2_linux-trusty-amd64.deb
 sudo apt-get -f install
 wkhtmltoimage http://www.google.com test.png
 ls

--- a/test/install_wkhtmltoimage.sh
+++ b/test/install_wkhtmltoimage.sh
@@ -7,7 +7,7 @@ sudo apt-get -qq update
 
 sudo apt-get install -y xfonts-75dpi
 wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2/wkhtmltox-0.12.2_linux-trusty-amd64.deb
-sudo dpkg -i --depends wkhtmltox-0.12.2_linux-trusty-amd64.deb
+sudo dpkg -i --force-depends wkhtmltox-0.12.2_linux-trusty-amd64.deb
 sudo apt-get -f install
 wkhtmltoimage http://www.google.com test.png
 ls

--- a/test/install_wkhtmltoimage.sh
+++ b/test/install_wkhtmltoimage.sh
@@ -7,7 +7,8 @@ sudo apt-get -qq update
 
 sudo apt-get install -y xfonts-75dpi
 wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2/wkhtmltox-0.12.2_linux-trusty-amd64.deb
-sudo dpkg -i wkhtmltox-0.12.2_linux-trusty-amd64.deb
+sudo dpkg -i wkhtmltox-0.12.2_linux-trusty-amd64.deb || true
+sudo apt-get -f install
 wkhtmltoimage http://www.google.com test.png
 ls
 

--- a/test/travis_commands.jl
+++ b/test/travis_commands.jl
@@ -9,7 +9,6 @@ Pkg.clone("https://github.com/JuliaPlots/PlotReferenceImages.jl.git")
 # Pkg.clone("https://github.com/JuliaStats/KernelDensity.jl.git")
 
 Pkg.clone("StatPlots")
-Pkg.checkout("PlotUtils")
 
 # Pkg.clone("https://github.com/JunoLab/Blink.jl.git")
 # Pkg.build("Blink")


### PR DESCRIPTION
`Plots.jl` tests are actually running now, instead of failing during installation.  The tests seem to be failing because the images produced are actually slightly different from the reference ones.  For example:

The reference image
![ref1](https://cloud.githubusercontent.com/assets/7328215/25814939/036fdcb0-33d4-11e7-8536-c4676c307e77.png)

compared to the generated image
![ref1](https://cloud.githubusercontent.com/assets/7328215/25814961/1acf6312-33d4-11e7-80c6-215af6023170.png)

Maybe due to the changes in Matplotlib 2.0?