### PR TITLE
Hack around world age issue PyPlot (fix #734)

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -210,7 +210,7 @@ function _plot_setup(plt::Plot, d::KW, kw_list::Vector{KW})
     # TODO: init subplots here
     _update_plot_args(plt, d)
     if !plt.init
-        plt.o = _create_backend_figure(plt)
+        plt.o = Base.invokelatest(_create_backend_figure, plt)
 
         # create the layout and subplots from the inputs
         plt.layout, plt.subplots, plt.spmap = build_layout(plt.attr)


### PR DESCRIPTION
This currently uses `Base.invokelatest` to get around the world age problem.  It decreases the performance by quite a bit though.  Before the PR (but after adding an `eval` before [`PyPlot.ioff()](https://github.com/JuliaPlots/Plots.jl/blob/master/src/backends/pyplot.jl#L90)), we have

```julia
julia> backend()
Plots.PyPlotBackend()

julia> @benchmark plot($rand(10))
BenchmarkTools.Trial:
  memory estimate:  117.05 KiB
  allocs estimate:  2008
  --------------
  minimum time:     426.443 μs (0.00% GC)
  median time:      432.476 μs (0.00% GC)
  mean time:        446.854 μs (2.76% GC)
  maximum time:     2.963 ms (81.89% GC)
  --------------
  samples:          10000
  evals/sample:     1
```
and after the PR, we have
```julia
julia> @benchmark plot($rand(10))
BenchmarkTools.Trial:
  memory estimate:  120.58 KiB
  allocs estimate:  2063
  --------------
  minimum time:     718.450 μs (0.00% GC)
  median time:      727.692 μs (0.00% GC)
  mean time:        751.499 μs (2.02% GC)
  maximum time:     4.293 ms (73.99% GC)
  --------------
  samples:          6627
  evals/sample:     1
```

Hopefully this isn't the permanent solution.  This PR is mainly to get a discussion going around the issue.