### PR TITLE
Fix precompilation on 0.5: Fixes #823

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -6,7 +6,7 @@
 # This should cut down on boilerplate code and allow more focused dispatch on type
 # note: returns meta information... mainly for use with automatic labeling from DataFrames for now
 
-const FuncOrFuncs{F} = Union{F, Vector{F}, Matrix{F}}
+typealias FuncOrFuncs{F} Union{F, Vector{F}, Matrix{F}}
 
 all3D(d::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image), get(d, :seriestype, :none))
 


### PR DESCRIPTION
One deprecation on 0.6 is probably not as bad as a precompilation error on 0.5?

This fixes #823.