### PR TITLE
fix fillrange for stepstyle on pyplot

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -221,6 +221,12 @@ function py_stepstyle(seriestype::Symbol)
     return "default"
 end
 
+function py_fillstepstyle(seriestype::Symbol)
+    seriestype == :steppost && return "post"
+    seriestype == :steppre && return "pre"
+    return nothing
+end
+
 # # untested... return a FontProperties object from a Plots.Font
 # function py_font(font::Font)
 #     pyfont.pymember("FontProperties")(
@@ -868,7 +874,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             dim1, expand_data(fillrange[1], n), expand_data(fillrange[2], n)
         end
 
-        handle = ax[f](args...;
+        handle = ax[f](args..., trues(n), false, py_fillstepstyle(st);
             zorder = series[:series_plotindex],
             facecolor = py_fillcolor(series),
             linewidths = 0


### PR DESCRIPTION
```julia
using Plots, pyplot()
y = rand(10)
plot(
    plot(y, seriestype = :steppre, fillrange = 0),
    plot(y, seriestype = :steppost, fillrange = 0),
    )
```
used to produce this:
![pyplot_fill_old](https://cloud.githubusercontent.com/assets/16589944/26091541/2ae229fe-3a0c-11e7-966f-ed0f14f9bbe0.png)
With this PR it behaves as expected:
![pyplot_fill_new](https://cloud.githubusercontent.com/assets/16589944/26091574/55a094fa-3a0c-11e7-831a-88ad459679f0.png)
