### PR TITLE
Move new PlotExample to the end for VRT testing

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -172,24 +172,6 @@ PlotExample("",
     end)]
 ),
 
-PlotExample("Animation with subplots",
-    "The `layout` macro can be used to create an animation with subplots.",
-    [:(begin
-        l = @layout([[a; b] c])
-        p = plot(plot([sin,cos],1,leg=false),
-        scatter([atan,cos],1,leg=false),
-        plot(log,1,xlims=(1,10π),ylims=(0,5),leg=false),layout=l)
-
-        anim = Animation()
-        for x = linspace(1,10π,100)
-          plot(push!(p,x,Float64[sin(x),cos(x),atan(x),cos(x),log(x)]))
-          frame(anim)
-        end
-    end)]
-),
-
-
-
 PlotExample("Open/High/Low/Close",
     "Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y` argument.  This uses recipes to first convert the tuples to OHLC objects, and subsequently create a :path series with the appropriate line segments.",
     [:(begin
@@ -318,7 +300,23 @@ PlotExample("Boxplot and Violin series recipes",
         violin(singers, :VoicePart, :Height, line = 0, fill = (0.2, :blue))
         boxplot!(singers, :VoicePart, :Height, line = (2,:black), fill = (0.3, :orange))
     end)]
-)
+),
+
+PlotExample("Animation with subplots",
+    "The `layout` macro can be used to create an animation with subplots.",
+    [:(begin
+        l = @layout([[a; b] c])
+        p = plot(plot([sin,cos],1,leg=false),
+        scatter([atan,cos],1,leg=false),
+        plot(log,1,xlims=(1,10π),ylims=(0,5),leg=false),layout=l)
+
+        anim = Animation()
+        for x = linspace(1,10π,100)
+          plot(push!(p,x,Float64[sin(x),cos(x),atan(x),cos(x),log(x)]))
+          frame(anim)
+        end
+    end)]
+),
 
 ]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ facts("PyPlot") do
     @fact pyplot() --> Plots.PyPlotBackend()
     @fact backend() --> Plots.PyPlotBackend()
 
-    image_comparison_facts(:pyplot, skip=[6,26,31], eps=img_eps)
+    image_comparison_facts(:pyplot, skip=[6,25,30,31], eps=img_eps)
 end
 
 facts("GR") do
@@ -31,7 +31,7 @@ facts("GR") do
     @fact backend() --> Plots.GRBackend()
 
     if is_linux() && isinteractive()
-        image_comparison_facts(:gr, skip=[2,26,31], eps=img_eps)
+        image_comparison_facts(:gr, skip=[2,25,30,31], eps=img_eps)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ facts("PyPlot") do
     @fact pyplot() --> Plots.PyPlotBackend()
     @fact backend() --> Plots.PyPlotBackend()
 
-    image_comparison_facts(:pyplot, skip=[6,25,30], eps=img_eps)
+    image_comparison_facts(:pyplot, skip=[6,26,31], eps=img_eps)
 end
 
 facts("GR") do
@@ -31,7 +31,7 @@ facts("GR") do
     @fact backend() --> Plots.GRBackend()
 
     if is_linux() && isinteractive()
-        image_comparison_facts(:gr, skip=[2,25,30], eps=img_eps)
+        image_comparison_facts(:gr, skip=[2,26,31], eps=img_eps)
     end
 end
 


### PR DESCRIPTION
I moved the new PlotExample from #758 to the end.
Otherwise in the VRT you have to compare apples to oranges (starting with example 19).
Is there something speaking against this "change", like some intended order of the PlotExamples?

Also I skipped this new example in the VRT, because being an animation it takes a little longer than the other examples. However, it's not that long and it's probably a good thing to have more ReferenceImages for testing, so I could also include it. What do you think @mkborregaard ?
