### PR TITLE
resetfontsizes: fixes #836

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -336,10 +336,10 @@ const _all_defaults = KW[
 ]
 
 # to be able to reset font sizes to initial values
-const _initial_fontsizes = Dict(:titlefont  => deepcopy(_subplot_defaults[:titlefont]),
-                                :legendfont => deepcopy(_subplot_defaults[:legendfont]),
-                                :tickfont   => deepcopy(_axis_defaults[:tickfont]),
-                                :guidefont  => deepcopy(_axis_defaults[:guidefont]))
+const _initial_fontsizes = Dict(:titlefont  => _subplot_defaults[:titlefont].pointsize,
+                                :legendfont => _subplot_defaults[:legendfont].pointsize,
+                                :tickfont   => _axis_defaults[:tickfont].pointsize,
+                                :guidefont  => _axis_defaults[:guidefont].pointsize)
 
 const _all_args = sort(collect(union(map(keys, _all_defaults)...)))
 
@@ -523,25 +523,6 @@ end
 
 function default(d::KW, k::Symbol)
     get(d, k, default(k))
-end
-
-# reset the defaults globally to values at startup
-
-"""
-`initial(key)` returns the intial value for that key
-"""
-
-function initial(k::Symbol)
-    k = get(_keyAliases, k, k)
-    for defaults in _all_initial_defaults
-        if haskey(defaults, k)
-            return defaults[k]
-        end
-    end
-    if haskey(_axis_initial_defaults, k)
-        return _axis_initial_defaults[k]
-    end
-    k in _suppress_warnings || error("Unknown key: ", k)
 end
 
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -335,9 +335,11 @@ const _all_defaults = KW[
     _axis_defaults_byletter
 ]
 
-# to be able to reset things to initial values
-const _all_initial_defaults = deepcopy(_all_defaults)
-const _axis_initial_defaults = deepcopy(_axis_defaults)
+# to be able to reset font sizes to initial values
+const _initial_fontsizes = Dict(:titlefont  => deepcopy(_subplot_defaults[:titlefont]),
+                                :legendfont => deepcopy(_subplot_defaults[:legendfont]),
+                                :tickfont   => deepcopy(_axis_defaults[:tickfont]),
+                                :guidefont  => deepcopy(_axis_defaults[:guidefont]))
 
 const _all_args = sort(collect(union(map(keys, _all_defaults)...)))
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -335,6 +335,10 @@ const _all_defaults = KW[
     _axis_defaults_byletter
 ]
 
+# to be able to reset things to initial values
+const _all_initial_defaults = deepcopy(_all_defaults)
+const _axis_initial_defaults = deepcopy(_axis_defaults)
+
 const _all_args = sort(collect(union(map(keys, _all_defaults)...)))
 
 RecipesBase.is_key_supported(k::Symbol) = is_attr_supported(k)
@@ -519,6 +523,24 @@ function default(d::KW, k::Symbol)
     get(d, k, default(k))
 end
 
+# reset the defaults globally to values at startup
+
+"""
+`initial(key)` returns the intial value for that key
+"""
+
+function initial(k::Symbol)
+    k = get(_keyAliases, k, k)
+    for defaults in _all_initial_defaults
+        if haskey(defaults, k)
+            return defaults[k]
+        end
+    end
+    if haskey(_axis_initial_defaults, k)
+        return _axis_initial_defaults[k]
+    end
+    k in _suppress_warnings || error("Unknown key: ", k)
+end
 
 
 # -----------------------------------------------------------------------------

--- a/src/components.jl
+++ b/src/components.jl
@@ -303,6 +303,18 @@ function scalefontsizes(factor::Number)
     end
 end
 
+function resetfontsize(k::Symbol)
+    f = default(k)
+    default(k,f)
+end
+
+"Reset all fonts to default size"
+function resetfontsizes()
+    for k in (:titlefont, :guidefont, :tickfont, :legendfont)
+        resetfontsize(k, factor)
+    end
+end
+
 "Wrap a string with font info"
 immutable PlotText
   str::AbstractString

--- a/src/components.jl
+++ b/src/components.jl
@@ -303,21 +303,15 @@ function scalefontsizes(factor::Number)
     end
 end
 
-function resetfontsize(k::Symbol)
-    i = initial(k)
-    f = default(k)
-    # some fonts don't have an initial value!
-    if i != false
-      f.pointsize = i.pointsize
-      default(k, i)
-    end
-end
-
-"Reset all fonts to initial size"
-function resetfontsizes()
-    for k in (:titlefont, :guidefont, :tickfont, :legendfont)
-        resetfontsize(k)
-    end
+"Resets font sizes to initial default values"
+function scalefontsizes()
+  for k in (:titlefont, :guidefont, :tickfont, :legendfont)
+      f = default(k)
+      if haskey(_initial_fontsizes,k)
+        factor = f.pointsize / _initial_fontsizes[k].pointsize
+        scalefontsize(k, 1.0/factor)
+      end
+  end
 end
 
 "Wrap a string with font info"

--- a/src/components.jl
+++ b/src/components.jl
@@ -311,7 +311,7 @@ end
 "Reset all fonts to default size"
 function resetfontsizes()
     for k in (:titlefont, :guidefont, :tickfont, :legendfont)
-        resetfontsize(k, factor)
+        resetfontsize(k)
     end
 end
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -307,7 +307,7 @@ end
 function scalefontsizes()
   for k in (:titlefont, :guidefont, :tickfont, :legendfont)
       f = default(k)
-      for k in keys(_initial_fontsizes)
+      if k in keys(_initial_fontsizes)
         factor = f.pointsize / _initial_fontsizes[k]
         scalefontsize(k, 1.0/factor)
       end

--- a/src/components.jl
+++ b/src/components.jl
@@ -307,8 +307,8 @@ end
 function scalefontsizes()
   for k in (:titlefont, :guidefont, :tickfont, :legendfont)
       f = default(k)
-      if haskey(_initial_fontsizes,k)
-        factor = f.pointsize / _initial_fontsizes[k].pointsize
+      for k in keys(_initial_fontsizes)
+        factor = f.pointsize / _initial_fontsizes[k]
         scalefontsize(k, 1.0/factor)
       end
   end

--- a/src/components.jl
+++ b/src/components.jl
@@ -297,13 +297,23 @@ function scalefontsize(k::Symbol, factor::Number)
     f.pointsize = round(Int, factor * f.pointsize)
     default(k, f)
 end
+
+"""
+    scalefontsizes(factor::Number)
+
+Scales all **current** font sizes by `factor`. For example `scalefontsizes(1.1)` increases all current font sizes by 10%. To reset to initial sizes, use `scalefontsizes()`
+"""
 function scalefontsizes(factor::Number)
     for k in (:titlefont, :guidefont, :tickfont, :legendfont)
         scalefontsize(k, factor)
     end
 end
 
-"Resets font sizes to initial default values"
+"""
+    scalefontsizes()
+
+Resets font sizes to initial default values.
+"""
 function scalefontsizes()
   for k in (:titlefont, :guidefont, :tickfont, :legendfont)
       f = default(k)

--- a/src/components.jl
+++ b/src/components.jl
@@ -304,11 +304,16 @@ function scalefontsizes(factor::Number)
 end
 
 function resetfontsize(k::Symbol)
+    i = initial(k)
     f = default(k)
-    default(k,f)
+    # some fonts don't have an initial value!
+    if i != false
+      f.pointsize = i.pointsize
+      default(k, i)
+    end
 end
 
-"Reset all fonts to default size"
+"Reset all fonts to initial size"
 function resetfontsizes()
     for k in (:titlefont, :guidefont, :tickfont, :legendfont)
         resetfontsize(k)


### PR DESCRIPTION
added const copies of _all_defaults and _axis_defaults to be able to reset fonts to initial values with new  `resetfontsizes` method. 

## Example

```julia
Plots.plot(rand(10))
Plots.scalefontsizes(2)
Plots.plot(rand(10))
Plots.resetfontsizes()
Plots.plot(rand(10))
```