### PR TITLE
Change default backends

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -148,7 +148,7 @@ function pickDefaultBackend()
     # the ordering/inclusion of this package list is my semi-arbitrary guess at
     # which one someone will want to use if they have the package installed...accounting for
     # features, speed, and robustness
-    for pkgstr in ("PyPlot", "GR", "PlotlyJS", "Immerse", "Gadfly", "UnicodePlots")
+    for pkgstr in ("GR", "PyPlot", "PlotlyJS", "PGFPlots", "UnicodePlots", "InspectDR", "GLVIsualize")
         if Pkg.installed(pkgstr) != nothing
             return backend(Symbol(lowercase(pkgstr)))
         end


### PR DESCRIPTION
The backend order is out of date. PyPlot and PlotlyJS will error on 0.6