### PR TITLE
fix passing ticks tuple on 0.6

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -229,7 +229,7 @@ function get_ticks(axis::Axis)
     elseif typeof(ticks) <: AVec
         # override ticks, but get the labels
         optimal_ticks_and_labels(axis, ticks)
-    elseif typeof(ticks) <: NTuple{2}
+    elseif typeof(ticks) <: NTuple{2, Any}
         # assuming we're passed (ticks, labels)
         ticks
     else


### PR DESCRIPTION
@kescobo reported in the gitter channel that passing a tuple to the ticks attribute like `scatter(1:3, xticks = (1:3, ["a","b","c"]))` is not working. This happens only on 0.6 and the reason for this is that
```julia
(1:3, ["a","b","c"]))::NTuple{2}
```
gives an error on 0.6, while it does not on 0.5.
This PR should resolve this issue.