### PR TITLE
RFC: Ignore NaNs on 0.6 (like on 0.5): fixes #796

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -9,3 +9,4 @@ Measures
 Showoff
 StatsBase 0.14.0
 JSON
+NaNMath

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -10,6 +10,7 @@ using Base.Meta
 @reexport using PlotThemes
 import Showoff
 import StatsBase
+import NaNMath # define functions that ignores NaNs. To overcome the destructive effects of https://github.com/JuliaLang/julia/pull/12563
 
 export
     grid,
@@ -103,15 +104,6 @@ export
     BezierCurve,
 
     plotattr
-
-# ---------------------------------------------------------
-
-import NaNMath
-# define functions (e.g. `_extrema`, that ignores NaNs, when the type is applicable. To overcome the destructive effects of https://github.com/JuliaLang/julia/pull/12563
-for fun in (:extrema, :minimum, :maximum)
-       @eval $(Symbol(string("_",fun))){F<:AbstractFloat}(x::AbstractArray{F}) = NaNMath.$(fun)(x)
-       @eval $(Symbol(string("_",fun)))(x) = Base.$(fun)(x)
-end
 
 # ---------------------------------------------------------
 

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -106,9 +106,10 @@ export
 
 # ---------------------------------------------------------
 
+import NaNMath
 # define functions (e.g. `_extrema`, that ignores NaNs, when the type is applicable. To overcome the destructive effects of https://github.com/JuliaLang/julia/pull/12563
 for fun in (:extrema, :minimum, :maximum)
-       @eval $(Symbol(string("_",fun))){F<:AbstractFloat}(x::AbstractArray{F}) = Base.$(fun)(filter(!isnan,x))
+       @eval $(Symbol(string("_",fun))){F<:AbstractFloat}(x::AbstractArray{F}) = NaNMath.$(fun)(x)
        @eval $(Symbol(string("_",fun)))(x) = Base.$(fun)(x)
 end
 

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -106,8 +106,8 @@ export
 
 # ---------------------------------------------------------
 
-# define functions (e.g. `_extrema`, that uses the NaNMath version (which ignores NaNs)) when the type is applicable
-for fun in (:extrema, :minimum, :maximum, :mean)
+# define functions (e.g. `_extrema`, that ignores NaNs, when the type is applicable. To overcome the destructive effects of https://github.com/JuliaLang/julia/pull/12563
+for fun in (:extrema, :minimum, :maximum)
        @eval $(Symbol(string("_",fun))){F<:AbstractFloat}(x::AbstractArray{F}) = Base.$(fun)(filter(!isnan,x))
        @eval $(Symbol(string("_",fun)))(x) = Base.$(fun)(x)
 end

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -10,7 +10,7 @@ using Base.Meta
 @reexport using PlotThemes
 import Showoff
 import StatsBase
-import NaNMath: extrema
+import NaNMath: extrema, maximum, minimum
 
 export
     grid,

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -106,11 +106,10 @@ export
 
 # ---------------------------------------------------------
 
-import NaNMath
 # define functions (e.g. `_extrema`, that uses the NaNMath version (which ignores NaNs)) when the type is applicable
 for fun in (:extrema, :minimum, :maximum, :mean)
-       @eval $(Symbol(string("_",fun)))(x...) = Base.$(fun)(x...)
-       @eval $(Symbol(string("_",fun))){F <: AbstractFloat}(x::AbstractVector{F}) = NaNMath.$(fun)(x)
+       @eval $(Symbol(string("_",fun))){F<:AbstractFloat, N<:Integer}(x::AbstractArray{F, N}) = Base.$(fun)(filter(!isnan(x)))
+       @eval $(Symbol(string("_",fun)))(x) = Base.$(fun)(x)
 end
 
 # ---------------------------------------------------------

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -108,7 +108,7 @@ export
 
 # define functions (e.g. `_extrema`, that uses the NaNMath version (which ignores NaNs)) when the type is applicable
 for fun in (:extrema, :minimum, :maximum, :mean)
-       @eval $(Symbol(string("_",fun))){F<:AbstractFloat, N<:Integer}(x::AbstractArray{F, N}) = Base.$(fun)(filter(!isnan(x)))
+       @eval $(Symbol(string("_",fun))){F<:AbstractFloat}(x::AbstractArray{F}) = Base.$(fun)(filter(!isnan,x))
        @eval $(Symbol(string("_",fun)))(x) = Base.$(fun)(x)
 end
 

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -10,6 +10,7 @@ using Base.Meta
 @reexport using PlotThemes
 import Showoff
 import StatsBase
+import NaNMath: extrema
 
 export
     grid,

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -109,7 +109,7 @@ export
 import NaNMath
 # define functions (e.g. `_extrema`, that uses the NaNMath version (which ignores NaNs)) when the type is applicable
 for fun in (:extrema, :minimum, :maximum, :mean)
-       @eval $(Symbol(string("_",fun)))(x) = Base.$(fun)(x)
+       @eval $(Symbol(string("_",fun)))(x...) = Base.$(fun)(x...)
        @eval $(Symbol(string("_",fun))){F <: AbstractFloat}(x::AbstractVector{F}) = NaNMath.$(fun)(x)
 end
 

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -10,7 +10,6 @@ using Base.Meta
 @reexport using PlotThemes
 import Showoff
 import StatsBase
-import NaNMath: extrema, maximum, minimum
 
 export
     grid,
@@ -104,6 +103,15 @@ export
     BezierCurve,
 
     plotattr
+
+# ---------------------------------------------------------
+
+import NaNMath
+# define functions (e.g. `_extrema`, that uses the NaNMath version (which ignores NaNs)) when the type is applicable
+for fun in (:extrema, :minimum, :maximum, :mean)
+       @eval $(Symbol(string("_",fun)))(x) = Base.$(fun)(x)
+       @eval $(Symbol(string("_",fun))){F <: AbstractFloat}(x::AbstractVector{F}) = NaNMath.$(fun)(x)
+end
 
 # ---------------------------------------------------------
 

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -118,7 +118,7 @@ Base.show(io::IO, axis::Axis) = dumpdict(axis.d, "Axis", true)
 # Base.getindex(axis::Axis, k::Symbol) = getindex(axis.d, k)
 Base.setindex!(axis::Axis, v, ks::Symbol...) = setindex!(axis.d, v, ks...)
 Base.haskey(axis::Axis, k::Symbol) = haskey(axis.d, k)
-Base.extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax))
+extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax)) #This is the NaNMath version, not the Base version
 
 
 const _scale_funcs = Dict{Symbol,Function}(

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -260,8 +260,8 @@ end
 
 
 function expand_extrema!(ex::Extrema, v::Number)
-    ex.emin = min(v, ex.emin)
-    ex.emax = max(v, ex.emax)
+    ex.emin = _min(v, ex.emin)
+    ex.emax = _max(v, ex.emax)
     ex
 end
 
@@ -276,8 +276,8 @@ expand_extrema!(axis::Axis, ::Bool) = axis[:extrema]
 
 function expand_extrema!{MIN<:Number,MAX<:Number}(axis::Axis, v::Tuple{MIN,MAX})
     ex = axis[:extrema]
-    ex.emin = min(v[1], ex.emin)
-    ex.emax = max(v[2], ex.emax)
+    ex.emin = _min(v[1], ex.emin)
+    ex.emax = _max(v[2], ex.emax)
     ex
 end
 function expand_extrema!{N<:Number}(axis::Axis, v::AVec{N})
@@ -368,8 +368,8 @@ end
 # push the limits out slightly
 function widen(lmin, lmax)
     span = lmax - lmin
-    # eps = max(1e-16, min(1e-2span, 1e-10))
-    eps = max(1e-16, 0.03span)
+    # eps = _max(1e-16, min(1e-2span, 1e-10))
+    eps = _max(1e-16, 0.03span)
     lmin-eps, lmax+eps
 end
 
@@ -425,7 +425,7 @@ function discrete_value!(axis::Axis, dv)
     # @show axis[:discrete_map], axis[:discrete_values], dv
     if cv_idx == -1
         ex = axis[:extrema]
-        cv = max(0.5, ex.emax + 1.0)
+        cv = _max(0.5, ex.emax + 1.0)
         expand_extrema!(axis, cv)
         push!(axis[:discrete_values], dv)
         push!(axis[:continuous_values], cv)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -118,7 +118,7 @@ Base.show(io::IO, axis::Axis) = dumpdict(axis.d, "Axis", true)
 # Base.getindex(axis::Axis, k::Symbol) = getindex(axis.d, k)
 Base.setindex!(axis::Axis, v, ks::Symbol...) = setindex!(axis.d, v, ks...)
 Base.haskey(axis::Axis, k::Symbol) = haskey(axis.d, k)
-extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax)) #This is the NaNMath version, not the Base version
+_extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax))
 
 
 const _scale_funcs = Dict{Symbol,Function}(
@@ -349,11 +349,11 @@ function expand_extrema!(sp::Subplot, d::KW)
 
         bw = d[:bar_width]
         if bw == nothing
-            bw = d[:bar_width] = mean(diff(data))
+            bw = d[:bar_width] = _mean(diff(data))
         end
         axis = sp.attr[Symbol(dsym, :axis)]
-        expand_extrema!(axis, maximum(data) + 0.5maximum(bw))
-        expand_extrema!(axis, minimum(data) - 0.5minimum(bw))
+        expand_extrema!(axis, _maximum(data) + 0.5_maximum(bw))
+        expand_extrema!(axis, _minimum(data) - 0.5_minimum(bw))
     end
 
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -118,7 +118,7 @@ Base.show(io::IO, axis::Axis) = dumpdict(axis.d, "Axis", true)
 # Base.getindex(axis::Axis, k::Symbol) = getindex(axis.d, k)
 Base.setindex!(axis::Axis, v, ks::Symbol...) = setindex!(axis.d, v, ks...)
 Base.haskey(axis::Axis, k::Symbol) = haskey(axis.d, k)
-_extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax))
+NaNMath.extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax))
 
 
 const _scale_funcs = Dict{Symbol,Function}(
@@ -349,11 +349,11 @@ function expand_extrema!(sp::Subplot, d::KW)
 
         bw = d[:bar_width]
         if bw == nothing
-            bw = d[:bar_width] = _mean(diff(data))
+            bw = d[:bar_width] = NaNMath.mean(diff(data))
         end
         axis = sp.attr[Symbol(dsym, :axis)]
-        expand_extrema!(axis, _maximum(data) + 0.5_maximum(bw))
-        expand_extrema!(axis, _minimum(data) - 0.5_minimum(bw))
+        expand_extrema!(axis, NaNMath.maximum(data) + 0.5maximum(bw))
+        expand_extrema!(axis, NaNMath.minimum(data) - 0.5minimum(bw))
     end
 
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -260,8 +260,8 @@ end
 
 
 function expand_extrema!(ex::Extrema, v::Number)
-    ex.emin = _min(v, ex.emin)
-    ex.emax = _max(v, ex.emax)
+    ex.emin = NaNMath.min(v, ex.emin)
+    ex.emax = NaNMath.max(v, ex.emax)
     ex
 end
 
@@ -276,8 +276,8 @@ expand_extrema!(axis::Axis, ::Bool) = axis[:extrema]
 
 function expand_extrema!{MIN<:Number,MAX<:Number}(axis::Axis, v::Tuple{MIN,MAX})
     ex = axis[:extrema]
-    ex.emin = _min(v[1], ex.emin)
-    ex.emax = _max(v[2], ex.emax)
+    ex.emin = NaNMath.min(v[1], ex.emin)
+    ex.emax = NaNMath.max(v[2], ex.emax)
     ex
 end
 function expand_extrema!{N<:Number}(axis::Axis, v::AVec{N})
@@ -368,8 +368,8 @@ end
 # push the limits out slightly
 function widen(lmin, lmax)
     span = lmax - lmin
-    # eps = _max(1e-16, min(1e-2span, 1e-10))
-    eps = _max(1e-16, 0.03span)
+    # eps = NaNMath.max(1e-16, min(1e-2span, 1e-10))
+    eps = NaNMath.max(1e-16, 0.03span)
     lmin-eps, lmax+eps
 end
 
@@ -425,7 +425,7 @@ function discrete_value!(axis::Axis, dv)
     # @show axis[:discrete_map], axis[:discrete_values], dv
     if cv_idx == -1
         ex = axis[:extrema]
-        cv = _max(0.5, ex.emax + 1.0)
+        cv = NaNMath.max(0.5, ex.emax + 1.0)
         expand_extrema!(axis, cv)
         push!(axis[:discrete_values], dv)
         push!(axis[:continuous_values], cv)

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -75,7 +75,7 @@ function tick_padding(axis::Axis)
         vals, labs = ticks
         isempty(labs) && return 0mm
         # ptsz = axis[:tickfont].pointsize * pt
-        longest_label = _maximum(length(lab) for lab in labs)
+        longest_label = maximum(length(lab) for lab in labs)
 
         # generalize by "rotating" y labels
         rot = axis[:rotation] + (axis[:letter] == :y ? 90 : 0)

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -75,7 +75,7 @@ function tick_padding(axis::Axis)
         vals, labs = ticks
         isempty(labs) && return 0mm
         # ptsz = axis[:tickfont].pointsize * pt
-        longest_label = maximum(length(lab) for lab in labs)
+        longest_label = _maximum(length(lab) for lab in labs)
 
         # generalize by "rotating" y labels
         rot = axis[:rotation] + (axis[:letter] == :y ? 90 : 0)

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -367,14 +367,14 @@ end
 
 
 dist(a, b) = abs(a-b)
-mindist(x, a, b) = min(dist(a, x), dist(b, x))
+mindist(x, a, b) = _min(dist(a, x), dist(b, x))
 
 function gappy(x, ps)
     n = length(ps)
     x <= first(ps) && return first(ps) - x
     for j=1:(n-1)
         p0 = ps[j]
-        p1 = ps[min(j+1, n)]
+        p1 = ps[_min(j+1, n)]
         if p0 <= x && p1 >= x
             return mindist(x, p0, p1) * (isodd(j) ? 1 : -1)
         end

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -175,7 +175,7 @@ end
 function gl_marker(shape::Shape)
     points = Point2f0[Vec{2,Float32}(p) for p in zip(shape.x, shape.y)]
     bb = GeometryTypes.AABB(points)
-    mini, maxi = _minimum(bb), _maximum(bb)
+    mini, maxi = minimum(bb), maximum(bb)
     w3 = maxi-mini
     origin, width = Point2f0(mini[1], mini[2]), Point2f0(w3[1], w3[2])
     map!(p -> ((p - origin) ./ width) - 0.5f0, points) # normalize and center
@@ -304,7 +304,7 @@ function extract_any_color(d, kw_args)
                     kw_args[:color_norm] = Vec2f0(clims)
                 end
             elseif clims == :auto
-                kw_args[:color_norm] = Vec2f0(_extrema(d[:y]))
+                kw_args[:color_norm] = Vec2f0(NaNMath.extrema(d[:y]))
             end
         end
     else
@@ -315,7 +315,7 @@ function extract_any_color(d, kw_args)
                 kw_args[:color_norm] = Vec2f0(clims)
             end
         elseif clims == :auto
-            kw_args[:color_norm] = Vec2f0(_extrema(d[:y]))
+            kw_args[:color_norm] = Vec2f0(NaNMath.extrema(d[:y]))
         else
             error("Unsupported limits: $clims")
         end
@@ -470,7 +470,7 @@ function hover(to_hover, to_display, window)
                 end
                 GLVisualize._view(robj, popup, camera = cam)
                 bb = GLAbstraction.boundingbox(robj).value
-                mini = _minimum(bb)
+                mini = minimum(bb)
                 w = GeometryTypes.widths(bb)
                 wborder = w * 0.08f0 #8 percent border
                 bb = GeometryTypes.AABB{Float32}(mini - wborder, w + 2 * wborder)
@@ -482,7 +482,7 @@ function hover(to_hover, to_display, window)
 end
 
 function extract_extrema(d, kw_args)
-    xmin, xmax = _extrema(d[:x]); ymin, ymax = _extrema(d[:y])
+    xmin, xmax = NaNMath.extrema(d[:x]); ymin, ymax = NaNMath.extrema(d[:y])
     kw_args[:primitive] = GeometryTypes.SimpleRectangle{Float32}(xmin, ymin, xmax-xmin, ymax-ymin)
     nothing
 end
@@ -509,7 +509,7 @@ function extract_colornorm(d, kw_args)
         else
             d[:y]
         end
-        kw_args[:color_norm] = Vec2f0(_extrema(z))
+        kw_args[:color_norm] = Vec2f0(NaNMath.extrema(z))
         kw_args[:intensity] = map(Float32, collect(z))
     end
 end
@@ -781,7 +781,7 @@ function gl_bar(d, kw_args)
     # compute half-width of bars
     bw = nothing
     hw = if bw == nothing
-        _mean(diff(x))
+        NaNMath.mean(diff(x))
     else
         Float64[cycle(bw,i)*0.5 for i=1:length(x)]
     end
@@ -864,7 +864,7 @@ function gl_boxplot(d, kw_args)
             end
             # change q1 and q5 to show outliers
             # using maximum and minimum values inside the limits
-            q1, q5 = _extrema(inside)
+            q1, q5 = NaNMath.extrema(inside)
         end
         # Box
         if notch
@@ -1318,7 +1318,7 @@ function gl_contour(x, y, z, kw_args)
         T = eltype(z)
         levels = Contour.contours(map(T, x), map(T, y), z, h)
         result = Point2f0[]
-        zmin, zmax = get(kw_args, :limits, Vec2f0(_extrema(z)))
+        zmin, zmax = get(kw_args, :limits, Vec2f0(NaNMath.extrema(z)))
         cmap = get(kw_args, :color_map, get(kw_args, :color, RGBA{Float32}(0,0,0,1)))
         colors = RGBA{Float32}[]
         for c in levels.contours
@@ -1339,7 +1339,7 @@ end
 
 
 function gl_heatmap(x,y,z, kw_args)
-    get!(kw_args, :color_norm, Vec2f0(_extrema(z)))
+    get!(kw_args, :color_norm, Vec2f0(NaNMath.extrema(z)))
     get!(kw_args, :color_map, Plots.make_gradient(cgrad()))
     delete!(kw_args, :intensity)
     I = GLVisualize.Intensity{1, Float32}
@@ -1382,7 +1382,7 @@ function label_scatter(d, w, ho)
         if isapprox(bbw[3], 0)
             bbw = Vec3f0(bbw[1], bbw[2], 1)
         end
-        mini = _minimum(bb)
+        mini = NaNMath.minimum(bb)
         m = GLAbstraction.translationmatrix(-mini)
         m *= GLAbstraction.scalematrix(1 ./ bbw)
         kw[:primitive] = m * p

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -367,14 +367,14 @@ end
 
 
 dist(a, b) = abs(a-b)
-mindist(x, a, b) = _min(dist(a, x), dist(b, x))
+mindist(x, a, b) = NaNMath.min(dist(a, x), dist(b, x))
 
 function gappy(x, ps)
     n = length(ps)
     x <= first(ps) && return first(ps) - x
     for j=1:(n-1)
         p0 = ps[j]
-        p1 = ps[_min(j+1, n)]
+        p1 = ps[NaNMath.min(j+1, n)]
         if p0 <= x && p1 >= x
             return mindist(x, p0, p1) * (isodd(j) ? 1 : -1)
         end

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -482,7 +482,7 @@ function hover(to_hover, to_display, window)
 end
 
 function extract_extrema(d, kw_args)
-    xmin, xmax = extrema(d[:x]); ymin, ymax = _extrema(d[:y])
+    xmin, xmax = _extrema(d[:x]); ymin, ymax = _extrema(d[:y])
     kw_args[:primitive] = GeometryTypes.SimpleRectangle{Float32}(xmin, ymin, xmax-xmin, ymax-ymin)
     nothing
 end

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -1382,7 +1382,7 @@ function label_scatter(d, w, ho)
         if isapprox(bbw[3], 0)
             bbw = Vec3f0(bbw[1], bbw[2], 1)
         end
-        mini = NaNMath.minimum(bb)
+        mini = minimum(bb)
         m = GLAbstraction.translationmatrix(-mini)
         m *= GLAbstraction.scalematrix(1 ./ bbw)
         kw[:primitive] = m * p

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -175,7 +175,7 @@ end
 function gl_marker(shape::Shape)
     points = Point2f0[Vec{2,Float32}(p) for p in zip(shape.x, shape.y)]
     bb = GeometryTypes.AABB(points)
-    mini, maxi = minimum(bb), maximum(bb)
+    mini, maxi = _minimum(bb), _maximum(bb)
     w3 = maxi-mini
     origin, width = Point2f0(mini[1], mini[2]), Point2f0(w3[1], w3[2])
     map!(p -> ((p - origin) ./ width) - 0.5f0, points) # normalize and center
@@ -304,7 +304,7 @@ function extract_any_color(d, kw_args)
                     kw_args[:color_norm] = Vec2f0(clims)
                 end
             elseif clims == :auto
-                kw_args[:color_norm] = Vec2f0(extrema(d[:y]))
+                kw_args[:color_norm] = Vec2f0(_extrema(d[:y]))
             end
         end
     else
@@ -315,7 +315,7 @@ function extract_any_color(d, kw_args)
                 kw_args[:color_norm] = Vec2f0(clims)
             end
         elseif clims == :auto
-            kw_args[:color_norm] = Vec2f0(extrema(d[:y]))
+            kw_args[:color_norm] = Vec2f0(_extrema(d[:y]))
         else
             error("Unsupported limits: $clims")
         end
@@ -470,7 +470,7 @@ function hover(to_hover, to_display, window)
                 end
                 GLVisualize._view(robj, popup, camera = cam)
                 bb = GLAbstraction.boundingbox(robj).value
-                mini = minimum(bb)
+                mini = _minimum(bb)
                 w = GeometryTypes.widths(bb)
                 wborder = w * 0.08f0 #8 percent border
                 bb = GeometryTypes.AABB{Float32}(mini - wborder, w + 2 * wborder)
@@ -482,7 +482,7 @@ function hover(to_hover, to_display, window)
 end
 
 function extract_extrema(d, kw_args)
-    xmin, xmax = extrema(d[:x]); ymin, ymax = extrema(d[:y])
+    xmin, xmax = extrema(d[:x]); ymin, ymax = _extrema(d[:y])
     kw_args[:primitive] = GeometryTypes.SimpleRectangle{Float32}(xmin, ymin, xmax-xmin, ymax-ymin)
     nothing
 end
@@ -509,7 +509,7 @@ function extract_colornorm(d, kw_args)
         else
             d[:y]
         end
-        kw_args[:color_norm] = Vec2f0(extrema(z))
+        kw_args[:color_norm] = Vec2f0(_extrema(z))
         kw_args[:intensity] = map(Float32, collect(z))
     end
 end
@@ -781,7 +781,7 @@ function gl_bar(d, kw_args)
     # compute half-width of bars
     bw = nothing
     hw = if bw == nothing
-        mean(diff(x))
+        _mean(diff(x))
     else
         Float64[cycle(bw,i)*0.5 for i=1:length(x)]
     end
@@ -864,7 +864,7 @@ function gl_boxplot(d, kw_args)
             end
             # change q1 and q5 to show outliers
             # using maximum and minimum values inside the limits
-            q1, q5 = extrema(inside)
+            q1, q5 = _extrema(inside)
         end
         # Box
         if notch
@@ -1318,7 +1318,7 @@ function gl_contour(x, y, z, kw_args)
         T = eltype(z)
         levels = Contour.contours(map(T, x), map(T, y), z, h)
         result = Point2f0[]
-        zmin, zmax = get(kw_args, :limits, Vec2f0(extrema(z)))
+        zmin, zmax = get(kw_args, :limits, Vec2f0(_extrema(z)))
         cmap = get(kw_args, :color_map, get(kw_args, :color, RGBA{Float32}(0,0,0,1)))
         colors = RGBA{Float32}[]
         for c in levels.contours
@@ -1339,7 +1339,7 @@ end
 
 
 function gl_heatmap(x,y,z, kw_args)
-    get!(kw_args, :color_norm, Vec2f0(extrema(z)))
+    get!(kw_args, :color_norm, Vec2f0(_extrema(z)))
     get!(kw_args, :color_map, Plots.make_gradient(cgrad()))
     delete!(kw_args, :intensity)
     I = GLVisualize.Intensity{1, Float32}
@@ -1382,7 +1382,7 @@ function label_scatter(d, w, ho)
         if isapprox(bbw[3], 0)
             bbw = Vec3f0(bbw[1], bbw[2], 1)
         end
-        mini = minimum(bb)
+        mini = _minimum(bb)
         m = GLAbstraction.translationmatrix(-mini)
         m *= GLAbstraction.scalematrix(1 ./ bbw)
         kw[:primitive] = m * p

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -341,7 +341,7 @@ end
 function gr_set_line(lw, style, c) #, a)
     GR.setlinetype(gr_linetype[style])
     w, h = gr_plot_size
-    GR.setlinewidth(max(0, lw / ((w + h) * 0.001)))
+    GR.setlinewidth(_max(0, lw / ((w + h) * 0.001)))
     gr_set_linecolor(c) #, a)
 end
 
@@ -394,7 +394,7 @@ function gr_viewport_from_bbox(sp::Subplot{GRBackend}, bb::BoundingBox, w, h, vi
     viewport[4] = viewport_canvas[4] * (1.0 - top(bb) / h)
     if is3d(sp)
         vp = viewport[:]
-        extent = min(vp[2] - vp[1], vp[4] - vp[3])
+        extent = _min(vp[2] - vp[1], vp[4] - vp[3])
         viewport[1] = 0.5 * (vp[1] + vp[2] - extent)
         viewport[2] = 0.5 * (vp[1] + vp[2] + extent)
         viewport[3] = 0.5 * (vp[3] + vp[4] - extent)
@@ -428,7 +428,7 @@ function gr_set_viewport_polar()
     ymax -= 0.05 * (xmax - xmin)
     xcenter = 0.5 * (xmin + xmax)
     ycenter = 0.5 * (ymin + ymax)
-    r = 0.5 * min(xmax - xmin, ymax - ymin)
+    r = 0.5 * _min(xmax - xmin, ymax - ymin)
     GR.setviewport(xcenter -r, xcenter + r, ycenter - r, ycenter + r)
     GR.setwindow(-1, 1, -1, 1)
     r

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -341,7 +341,7 @@ end
 function gr_set_line(lw, style, c) #, a)
     GR.setlinetype(gr_linetype[style])
     w, h = gr_plot_size
-    GR.setlinewidth(NaNMath.max(0, lw / ((w + h) * 0.001)))
+    GR.setlinewidth(max(0, lw / ((w + h) * 0.001)))
     gr_set_linecolor(c) #, a)
 end
 
@@ -394,7 +394,7 @@ function gr_viewport_from_bbox(sp::Subplot{GRBackend}, bb::BoundingBox, w, h, vi
     viewport[4] = viewport_canvas[4] * (1.0 - top(bb) / h)
     if is3d(sp)
         vp = viewport[:]
-        extent = NaNMath.min(vp[2] - vp[1], vp[4] - vp[3])
+        extent = min(vp[2] - vp[1], vp[4] - vp[3])
         viewport[1] = 0.5 * (vp[1] + vp[2] - extent)
         viewport[2] = 0.5 * (vp[1] + vp[2] + extent)
         viewport[3] = 0.5 * (vp[3] + vp[4] - extent)
@@ -824,7 +824,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             # create the colorbar of contour levels
             if sp[:colorbar] != :none
                 gr_set_viewport_cmap(sp)
-                l = round(Int32, 1000 + (h - NaNMath.minimum(h)) / (NaNMath.maximum(h) - NaNMath.minimum(h)) * 255) #much in doubt whether to use the NaNMath minimum here
+                l = round(Int32, 1000 + (h - NaNMath.minimum(h)) / (NaNMath.maximum(h) - NaNMath.minimum(h)) * 255)
                 GR.setwindow(xmin, xmax, zmin, zmax)
                 GR.cellarray(xmin, xmax, zmax, zmin, 1, length(l), l)
                 ztick = 0.5 * GR.tick(zmin, zmax)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -639,7 +639,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
     elseif ispolar(sp)
         r = gr_set_viewport_polar()
-        rmin, rmax = GR.adjustrange(minimum(r), maximum(r))
+        rmin, rmax = GR.adjustrange(NaNMath.minimum(r), NaNMath.maximum(r))
         # rmin, rmax = axis_limits(sp[:yaxis])
         gr_polaraxes(rmin, rmax)
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -264,7 +264,7 @@ end
 
 normalize_zvals(zv::Void) = zv
 function normalize_zvals(zv::AVec)
-    vmin, vmax = extrema(zv)
+    vmin, vmax = _extrema(zv)
     if vmin == vmax
         zeros(length(zv))
     else
@@ -639,7 +639,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
     elseif ispolar(sp)
         r = gr_set_viewport_polar()
-        rmin, rmax = GR.adjustrange(minimum(r), maximum(r))
+        rmin, rmax = GR.adjustrange(_minimum(r), _maximum(r))
         # rmin, rmax = axis_limits(sp[:yaxis])
         gr_polaraxes(rmin, rmax)
 
@@ -824,7 +824,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             # create the colorbar of contour levels
             if sp[:colorbar] != :none
                 gr_set_viewport_cmap(sp)
-                l = round(Int32, 1000 + (h - minimum(h)) / (maximum(h) - minimum(h)) * 255)
+                l = round(Int32, 1000 + (h - _minimum(h)) / (_maximum(h) - _minimum(h)) * 255)
                 GR.setwindow(xmin, xmax, zmin, zmax)
                 GR.cellarray(xmin, xmax, zmax, zmin, 1, length(l), l)
                 ztick = 0.5 * GR.tick(zmin, zmax)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -341,7 +341,7 @@ end
 function gr_set_line(lw, style, c) #, a)
     GR.setlinetype(gr_linetype[style])
     w, h = gr_plot_size
-    GR.setlinewidth(_max(0, lw / ((w + h) * 0.001)))
+    GR.setlinewidth(NaNMath.max(0, lw / ((w + h) * 0.001)))
     gr_set_linecolor(c) #, a)
 end
 
@@ -394,7 +394,7 @@ function gr_viewport_from_bbox(sp::Subplot{GRBackend}, bb::BoundingBox, w, h, vi
     viewport[4] = viewport_canvas[4] * (1.0 - top(bb) / h)
     if is3d(sp)
         vp = viewport[:]
-        extent = _min(vp[2] - vp[1], vp[4] - vp[3])
+        extent = NaNMath.min(vp[2] - vp[1], vp[4] - vp[3])
         viewport[1] = 0.5 * (vp[1] + vp[2] - extent)
         viewport[2] = 0.5 * (vp[1] + vp[2] + extent)
         viewport[3] = 0.5 * (vp[3] + vp[4] - extent)
@@ -428,7 +428,7 @@ function gr_set_viewport_polar()
     ymax -= 0.05 * (xmax - xmin)
     xcenter = 0.5 * (xmin + xmax)
     ycenter = 0.5 * (ymin + ymax)
-    r = 0.5 * _min(xmax - xmin, ymax - ymin)
+    r = 0.5 * NaNMath.min(xmax - xmin, ymax - ymin)
     GR.setviewport(xcenter -r, xcenter + r, ycenter - r, ycenter + r)
     GR.setwindow(-1, 1, -1, 1)
     r

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -264,7 +264,7 @@ end
 
 normalize_zvals(zv::Void) = zv
 function normalize_zvals(zv::AVec)
-    vmin, vmax = _extrema(zv)
+    vmin, vmax = NaNMath.extrema(zv)
     if vmin == vmax
         zeros(length(zv))
     else
@@ -639,7 +639,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
     elseif ispolar(sp)
         r = gr_set_viewport_polar()
-        rmin, rmax = GR.adjustrange(_minimum(r), _maximum(r))
+        rmin, rmax = GR.adjustrange(minimum(r), maximum(r))
         # rmin, rmax = axis_limits(sp[:yaxis])
         gr_polaraxes(rmin, rmax)
 
@@ -824,7 +824,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             # create the colorbar of contour levels
             if sp[:colorbar] != :none
                 gr_set_viewport_cmap(sp)
-                l = round(Int32, 1000 + (h - _minimum(h)) / (_maximum(h) - _minimum(h)) * 255)
+                l = round(Int32, 1000 + (h - NaNMath.minimum(h)) / (NaNMath.maximum(h) - NaNMath.minimum(h)) * 255) #much in doubt whether to use the NaNMath minimum here
                 GR.setwindow(xmin, xmax, zmin, zmax)
                 GR.cellarray(xmin, xmax, zmax, zmin, 1, length(l), l)
                 ztick = 0.5 * GR.tick(zmin, zmax)

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -349,7 +349,7 @@ function _inspectdr_setupsubplot(sp::Subplot{InspectDRBackend})
         ymin, ymax  = axis_limits(yaxis)
         if ispolar(sp)
             #Plots.jl appears to give (xmin,xmax) ≜ (Θmin,Θmax) & (ymin,ymax) ≜ (rmin,rmax)
-            rmax = _max(abs(ymin), abs(ymax))
+            rmax = NaNMath.max(abs(ymin), abs(ymax))
             xmin, xmax = -rmax, rmax
             ymin, ymax = -rmax, rmax
         end

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -349,7 +349,7 @@ function _inspectdr_setupsubplot(sp::Subplot{InspectDRBackend})
         ymin, ymax  = axis_limits(yaxis)
         if ispolar(sp)
             #Plots.jl appears to give (xmin,xmax) ≜ (Θmin,Θmax) & (ymin,ymax) ≜ (rmin,rmax)
-            rmax = max(abs(ymin), abs(ymax))
+            rmax = _max(abs(ymin), abs(ymax))
             xmin, xmax = -rmax, rmax
             ymin, ymax = -rmax, rmax
         end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -546,7 +546,7 @@ function plotly_series(plt::Plot, series::Series)
         else
             # grad = ColorGradient(series[:markercolor], alpha=series[:markeralpha])
             grad = as_gradient(series[:markercolor], series[:markeralpha])
-            zmin, zmax = extrema(series[:marker_z])
+            zmin, zmax = _extrema(series[:marker_z])
             zrange = zmax == zmin ? 1 : zmax - zmin # if all marker_z values are the same, plot all markers same color (avoids division by zero in next line)
             [rgba_string(grad[(zi - zmin) / zrange]) for zi in series[:marker_z]]
         end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -546,7 +546,7 @@ function plotly_series(plt::Plot, series::Series)
         else
             # grad = ColorGradient(series[:markercolor], alpha=series[:markeralpha])
             grad = as_gradient(series[:markercolor], series[:markeralpha])
-            zmin, zmax = _extrema(series[:marker_z])
+            zmin, zmax = NaNMath.extrema(series[:marker_z])
             zrange = zmax == zmin ? 1 : zmax - zmin # if all marker_z values are the same, plot all markers same color (avoids division by zero in next line)
             [rgba_string(grad[(zi - zmin) / zrange]) for zi in series[:marker_z]]
         end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -926,14 +926,14 @@ function py_compute_axis_minval(axis::Axis)
         for series in series_list(sp)
             v = series.d[axis[:letter]]
             if !isempty(v)
-                minval = min(minval, _minimum(abs(v)))
+                minval = _min(minval, _minimum(abs(v)))
             end
         end
     end
 
     # now if the axis limits go to a smaller abs value, use that instead
     vmin, vmax = axis_limits(axis)
-    minval = min(minval, abs(vmin), abs(vmax))
+    minval = _min(minval, abs(vmin), abs(vmax))
 
     minval
 end
@@ -954,7 +954,7 @@ function py_set_scale(ax, axis::Axis)
         elseif scale == :log10
             10
         end
-        kw[Symbol(:linthresh,letter)] = max(1e-16, py_compute_axis_minval(axis))
+        kw[Symbol(:linthresh,letter)] = _max(1e-16, py_compute_axis_minval(axis))
         "symlog"
     end
     func(arg; kw...)
@@ -1096,10 +1096,10 @@ function _update_min_padding!(sp::Subplot{PyPlotBackend})
     bottompad = 0mm
     for bb in (py_bbox_axis(ax, "x"), py_bbox_axis(ax, "y"), py_bbox_title(ax))
         if ispositive(width(bb)) && ispositive(height(bb))
-            leftpad   = max(leftpad,   left(plotbb) - left(bb))
-            toppad    = max(toppad,    top(plotbb)  - top(bb))
-            rightpad  = max(rightpad,  right(bb)    - right(plotbb))
-            bottompad = max(bottompad, bottom(bb)   - bottom(plotbb))
+            leftpad   = _max(leftpad,   left(plotbb) - left(bb))
+            toppad    = _max(toppad,    top(plotbb)  - top(bb))
+            rightpad  = _max(rightpad,  right(bb)    - right(plotbb))
+            bottompad = _max(bottompad, bottom(bb)   - bottom(plotbb))
         end
     end
 

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -705,11 +705,11 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             # contours on the axis planes
             if series[:contours]
                 for (zdir,mat) in (("x",x), ("y",y), ("z",z))
-                    offset = (zdir == "y" ? _maximum : _minimum)(mat)
+                    offset = (zdir == "y" ? NaNMath.maximum : NaNMath.minimum)(mat)
                     handle = ax[:contourf](x, y, z, levelargs...;
                         zdir = zdir,
                         cmap = py_fillcolormap(series),
-                        offset = (zdir == "y" ? _maximum : _minimum)(mat)  # where to draw the contour plane
+                        offset = (zdir == "y" ? NaNMath.maximum : NaNMath.minimum)(mat)  # where to draw the contour plane
                     )
                     push!(handles, handle)
                     needs_colorbar = true
@@ -1096,10 +1096,10 @@ function _update_min_padding!(sp::Subplot{PyPlotBackend})
     bottompad = 0mm
     for bb in (py_bbox_axis(ax, "x"), py_bbox_axis(ax, "y"), py_bbox_title(ax))
         if ispositive(width(bb)) && ispositive(height(bb))
-            leftpad   = NaNMath.max(leftpad,   left(plotbb) - left(bb))
-            toppad    = NaNMath.max(toppad,    top(plotbb)  - top(bb))
-            rightpad  = NaNMath.max(rightpad,  right(bb)    - right(plotbb))
-            bottompad = NaNMath.max(bottompad, bottom(bb)   - bottom(plotbb))
+            leftpad   = max(leftpad,   left(plotbb) - left(bb))
+            toppad    = max(toppad,    top(plotbb)  - top(bb))
+            rightpad  = max(rightpad,  right(bb)    - right(plotbb))
+            bottompad = max(bottompad, bottom(bb)   - bottom(plotbb))
         end
     end
 

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -926,14 +926,14 @@ function py_compute_axis_minval(axis::Axis)
         for series in series_list(sp)
             v = series.d[axis[:letter]]
             if !isempty(v)
-                minval = _min(minval, _minimum(abs(v)))
+                minval = NaNMath.min(minval, _minimum(abs(v)))
             end
         end
     end
 
     # now if the axis limits go to a smaller abs value, use that instead
     vmin, vmax = axis_limits(axis)
-    minval = _min(minval, abs(vmin), abs(vmax))
+    minval = NaNMath.min(minval, abs(vmin), abs(vmax))
 
     minval
 end
@@ -954,7 +954,7 @@ function py_set_scale(ax, axis::Axis)
         elseif scale == :log10
             10
         end
-        kw[Symbol(:linthresh,letter)] = _max(1e-16, py_compute_axis_minval(axis))
+        kw[Symbol(:linthresh,letter)] = NaNMath.max(1e-16, py_compute_axis_minval(axis))
         "symlog"
     end
     func(arg; kw...)
@@ -1096,10 +1096,10 @@ function _update_min_padding!(sp::Subplot{PyPlotBackend})
     bottompad = 0mm
     for bb in (py_bbox_axis(ax, "x"), py_bbox_axis(ax, "y"), py_bbox_title(ax))
         if ispositive(width(bb)) && ispositive(height(bb))
-            leftpad   = _max(leftpad,   left(plotbb) - left(bb))
-            toppad    = _max(toppad,    top(plotbb)  - top(bb))
-            rightpad  = _max(rightpad,  right(bb)    - right(plotbb))
-            bottompad = _max(bottompad, bottom(bb)   - bottom(plotbb))
+            leftpad   = NaNMath.max(leftpad,   left(plotbb) - left(bb))
+            toppad    = NaNMath.max(toppad,    top(plotbb)  - top(bb))
+            rightpad  = NaNMath.max(rightpad,  right(bb)    - right(plotbb))
+            bottompad = NaNMath.max(bottompad, bottom(bb)   - bottom(plotbb))
         end
     end
 

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -705,11 +705,11 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             # contours on the axis planes
             if series[:contours]
                 for (zdir,mat) in (("x",x), ("y",y), ("z",z))
-                    offset = (zdir == "y" ? maximum : minimum)(mat)
+                    offset = (zdir == "y" ? _maximum : _minimum)(mat)
                     handle = ax[:contourf](x, y, z, levelargs...;
                         zdir = zdir,
                         cmap = py_fillcolormap(series),
-                        offset = (zdir == "y" ? maximum : minimum)(mat)  # where to draw the contour plane
+                        offset = (zdir == "y" ? _maximum : _minimum)(mat)  # where to draw the contour plane
                     )
                     push!(handles, handle)
                     needs_colorbar = true
@@ -778,7 +778,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         end
 
         clims = sp[:clims]
-        zmin, zmax = extrema(z)
+        zmin, zmax = _extrema(z)
         extrakw[:vmin] = (is_2tuple(clims) && isfinite(clims[1])) ? clims[1] : zmin
         extrakw[:vmax] = (is_2tuple(clims) && isfinite(clims[2])) ? clims[2] : zmax
 
@@ -926,7 +926,7 @@ function py_compute_axis_minval(axis::Axis)
         for series in series_list(sp)
             v = series.d[axis[:letter]]
             if !isempty(v)
-                minval = min(minval, minimum(abs(v)))
+                minval = min(minval, _minimum(abs(v)))
             end
         end
     end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -778,7 +778,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         end
 
         clims = sp[:clims]
-        zmin, zmax = _extrema(z)
+        zmin, zmax = NaNMath.extrema(z)
         extrakw[:vmin] = (is_2tuple(clims) && isfinite(clims[1])) ? clims[1] : zmin
         extrakw[:vmax] = (is_2tuple(clims) && isfinite(clims[2])) ? clims[2] : zmax
 
@@ -926,7 +926,7 @@ function py_compute_axis_minval(axis::Axis)
         for series in series_list(sp)
             v = series.d[axis[:letter]]
             if !isempty(v)
-                minval = NaNMath.min(minval, _minimum(abs(v)))
+                minval = NaNMath.min(minval, NaNMath.minimum(abs(v)))
             end
         end
     end

--- a/src/components.jl
+++ b/src/components.jl
@@ -646,7 +646,7 @@ function (bc::BezierCurve)(t::Real)
 end
 
 # mean(x::Real, y::Real) = 0.5*(x+y) #commented out as I cannot see this used anywhere and it overwrites a Base method with different functionality
-NaNMath.mean{N,T<:Real}(ps::FixedSizeArrays.Vec{N,T}...) = NaNMath.sum(ps) / length(ps)
+# mean{N,T<:Real}(ps::FixedSizeArrays.Vec{N,T}...) = sum(ps) / length(ps) # I also could not see this used anywhere, and it's type piracy - implementing a NaNMath version for this would just involve converting to a standard array
 
 @deprecate curve_points coords
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -501,7 +501,7 @@ immutable ZValues
   zrange::Tuple{Float64,Float64}
 end
 
-function zvalues{T<:Real}(values::AVec{T}, zrange::Tuple{T,T} = (_minimum(values), _maximum(values)))
+function zvalues{T<:Real}(values::AVec{T}, zrange::Tuple{T,T} = (NaNMath.minimum(values), NaNMath.maximum(values)))
   ZValues(collect(float(values)), map(Float64, zrange))
 end
 
@@ -645,8 +645,8 @@ function (bc::BezierCurve)(t::Real)
     p
 end
 
-_mean(x::Real, y::Real) = 0.5*(x+y)
-_mean{N,T<:Real}(ps::FixedSizeArrays.Vec{N,T}...) = sum(ps) / length(ps)
+# mean(x::Real, y::Real) = 0.5*(x+y) #commented out as I cannot see this used anywhere and it overwrites a Base method with different functionality
+NaNMath.mean{N,T<:Real}(ps::FixedSizeArrays.Vec{N,T}...) = NaNMath.sum(ps) / length(ps)
 
 @deprecate curve_points coords
 
@@ -659,7 +659,7 @@ function directed_curve(args...; kw...)
 end
 
 function extrema_plus_buffer(v, buffmult = 0.2)
-    vmin,vmax = _extrema(v)
+    vmin,vmax = NaNMath.extrema(v)
     vdiff = vmax-vmin
     buffer = vdiff * buffmult
     vmin - buffer, vmax + buffer

--- a/src/components.jl
+++ b/src/components.jl
@@ -501,7 +501,7 @@ immutable ZValues
   zrange::Tuple{Float64,Float64}
 end
 
-function zvalues{T<:Real}(values::AVec{T}, zrange::Tuple{T,T} = (minimum(values), maximum(values)))
+function zvalues{T<:Real}(values::AVec{T}, zrange::Tuple{T,T} = (_minimum(values), _maximum(values)))
   ZValues(collect(float(values)), map(Float64, zrange))
 end
 
@@ -645,8 +645,8 @@ function (bc::BezierCurve)(t::Real)
     p
 end
 
-Base.mean(x::Real, y::Real) = 0.5*(x+y)
-Base.mean{N,T<:Real}(ps::FixedSizeArrays.Vec{N,T}...) = sum(ps) / length(ps)
+_mean(x::Real, y::Real) = 0.5*(x+y)
+_mean{N,T<:Real}(ps::FixedSizeArrays.Vec{N,T}...) = sum(ps) / length(ps)
 
 @deprecate curve_points coords
 
@@ -659,7 +659,7 @@ function directed_curve(args...; kw...)
 end
 
 function extrema_plus_buffer(v, buffmult = 0.2)
-    vmin,vmax = extrema(v)
+    vmin,vmax = _extrema(v)
     vdiff = vmax-vmin
     buffer = vdiff * buffmult
     vmin - buffer, vmax + buffer

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -301,10 +301,10 @@ bottompad(layout::GridLayout) = layout.minpad[4]
 function _update_min_padding!(layout::GridLayout)
     map(_update_min_padding!, layout.grid)
     layout.minpad = (
-        maximum(map(leftpad,   layout.grid[:,1])),
-        maximum(map(toppad,    layout.grid[1,:])),
-        maximum(map(rightpad,  layout.grid[:,end])),
-        maximum(map(bottompad, layout.grid[end,:]))
+        _maximum(map(leftpad,   layout.grid[:,1])),
+        _maximum(map(toppad,    layout.grid[1,:])),
+        _maximum(map(rightpad,  layout.grid[:,end])),
+        _maximum(map(bottompad, layout.grid[end,:]))
     )
 end
 
@@ -349,10 +349,10 @@ function update_child_bboxes!(layout::GridLayout, minimum_perimeter = [0mm,0mm,0
     # get the max horizontal (left and right) padding over columns,
     # and max vertical (bottom and top) padding over rows
     # TODO: add extra padding here
-    pad_left   = maximum(minpad_left,   1)
-    pad_top    = maximum(minpad_top,    2)
-    pad_right  = maximum(minpad_right,  1)
-    pad_bottom = maximum(minpad_bottom, 2)
+    pad_left   = _maximum(minpad_left,   1)
+    pad_top    = _maximum(minpad_top,    2)
+    pad_right  = _maximum(minpad_right,  1)
+    pad_bottom = _maximum(minpad_bottom, 2)
 
     # make sure the perimeter match the parent
     pad_left[1]     = max(pad_left[1], minimum_perimeter[1])
@@ -642,7 +642,7 @@ end
 
 function create_grid_vcat(expr::Expr)
     rowsizes = map(rowsize, expr.args)
-    rmin, rmax = extrema(rowsizes)
+    rmin, rmax = _extrema(rowsizes)
     if rmin > 0 && rmin == rmax
         # we have a grid... build the whole thing
         # note: rmin is the number of columns

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -301,10 +301,10 @@ bottompad(layout::GridLayout) = layout.minpad[4]
 function _update_min_padding!(layout::GridLayout)
     map(_update_min_padding!, layout.grid)
     layout.minpad = (
-        _maximum(map(leftpad,   layout.grid[:,1])),
-        _maximum(map(toppad,    layout.grid[1,:])),
-        _maximum(map(rightpad,  layout.grid[:,end])),
-        _maximum(map(bottompad, layout.grid[end,:]))
+        maximum(map(leftpad,   layout.grid[:,1])),
+        maximum(map(toppad,    layout.grid[1,:])),
+        maximum(map(rightpad,  layout.grid[:,end])),
+        maximum(map(bottompad, layout.grid[end,:]))
     )
 end
 
@@ -349,10 +349,10 @@ function update_child_bboxes!(layout::GridLayout, minimum_perimeter = [0mm,0mm,0
     # get the max horizontal (left and right) padding over columns,
     # and max vertical (bottom and top) padding over rows
     # TODO: add extra padding here
-    pad_left   = _maximum(minpad_left,   1)
-    pad_top    = _maximum(minpad_top,    2)
-    pad_right  = _maximum(minpad_right,  1)
-    pad_bottom = _maximum(minpad_bottom, 2)
+    pad_left   = maximum(minpad_left,   1)
+    pad_top    = maximum(minpad_top,    2)
+    pad_right  = maximum(minpad_right,  1)
+    pad_bottom = maximum(minpad_bottom, 2)
 
     # make sure the perimeter match the parent
     pad_left[1]     = max(pad_left[1], minimum_perimeter[1])

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -642,7 +642,7 @@ end
 
 function create_grid_vcat(expr::Expr)
     rowsizes = map(rowsize, expr.args)
-    rmin, rmax = _extrema(rowsizes)
+    rmin, rmax = extrema(rowsizes)
     if rmin > 0 && rmin == rmax
         # we have a grid... build the whole thing
         # note: rmin is the number of columns
@@ -704,7 +704,7 @@ function link_axes!(axes::Axis...)
     a1 = axes[1]
     for i=2:length(axes)
         a2 = axes[i]
-        expand_extrema!(a1, _extrema(a2))
+        expand_extrema!(a1, NaNMath.extrema(a2))
         for k in (:extrema, :discrete_values, :continuous_values, :discrete_map)
             a2[k] = a1[k]
         end

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -55,10 +55,10 @@ function Base.:+(bb1::BoundingBox, bb2::BoundingBox)
     ispositive(width(bb2))  || return bb1
     ispositive(height(bb2)) || return bb1
 
-    l = NaNMath.min(left(bb1), left(bb2))
-    t = NaNMath.min(top(bb1), top(bb2))
-    r = NaNMath.max(right(bb1), right(bb2))
-    b = NaNMath.max(bottom(bb1), bottom(bb2))
+    l = min(left(bb1), left(bb2))
+    t = min(top(bb1), top(bb2))
+    r = max(right(bb1), right(bb2))
+    b = max(bottom(bb1), bottom(bb2))
     BoundingBox(l, t, r-l, b-t)
 end
 

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -704,7 +704,7 @@ function link_axes!(axes::Axis...)
     a1 = axes[1]
     for i=2:length(axes)
         a2 = axes[i]
-        expand_extrema!(a1, extrema(a2))
+        expand_extrema!(a1, _extrema(a2))
         for k in (:extrema, :discrete_values, :continuous_values, :discrete_map)
             a2[k] = a1[k]
         end

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -55,10 +55,10 @@ function Base.:+(bb1::BoundingBox, bb2::BoundingBox)
     ispositive(width(bb2))  || return bb1
     ispositive(height(bb2)) || return bb1
 
-    l = min(left(bb1), left(bb2))
-    t = min(top(bb1), top(bb2))
-    r = max(right(bb1), right(bb2))
-    b = max(bottom(bb1), bottom(bb2))
+    l = _min(left(bb1), left(bb2))
+    t = _min(top(bb1), top(bb2))
+    r = _max(right(bb1), right(bb2))
+    b = _max(bottom(bb1), bottom(bb2))
     BoundingBox(l, t, r-l, b-t)
 end
 

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -55,10 +55,10 @@ function Base.:+(bb1::BoundingBox, bb2::BoundingBox)
     ispositive(width(bb2))  || return bb1
     ispositive(height(bb2)) || return bb1
 
-    l = _min(left(bb1), left(bb2))
-    t = _min(top(bb1), top(bb2))
-    r = _max(right(bb1), right(bb2))
-    b = _max(bottom(bb1), bottom(bb2))
+    l = NaNMath.min(left(bb1), left(bb2))
+    t = NaNMath.min(top(bb1), top(bb2))
+    r = NaNMath.max(right(bb1), right(bb2))
+    b = NaNMath.max(bottom(bb1), bottom(bb2))
     BoundingBox(l, t, r-l, b-t)
 end
 

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -153,7 +153,7 @@ function _add_smooth_kw(kw_list::Vector{KW}, kw::KW)
     if get(kw, :smooth, false)
         x, y = kw[:x], kw[:y]
         β, α = convert(Matrix{Float64}, [x ones(length(x))]) \ convert(Vector{Float64}, y)
-        sx = [minimum(x), maximum(x)]
+        sx = [_minimum(x), _maximum(x)]
         sy = β * sx + α
         push!(kw_list, merge(copy(kw), KW(
             :seriestype => :path,

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -153,7 +153,7 @@ function _add_smooth_kw(kw_list::Vector{KW}, kw::KW)
     if get(kw, :smooth, false)
         x, y = kw[:x], kw[:y]
         β, α = convert(Matrix{Float64}, [x ones(length(x))]) \ convert(Vector{Float64}, y)
-        sx = [_minimum(x), _maximum(x)]
+        sx = [NaNMath.minimum(x), NaNMath.maximum(x)]
         sy = β * sx + α
         push!(kw_list, merge(copy(kw), KW(
             :seriestype => :path,

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -225,7 +225,7 @@ end
         fr = if yaxis[:scale] == :identity
             0.0
         else
-            _min(axis_limits(yaxis)[1], _minimum(y))
+            NaNMath.min(axis_limits(yaxis)[1], _minimum(y))
         end
     end
     newx, newy = zeros(3n), zeros(3n)
@@ -548,7 +548,7 @@ Plots.@deps stepbins path
 
 
 function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode::Symbol = :auto)
-    _cl(x) = _max(ceil(Int, x), 1)
+    _cl(x) = NaNMath.max(ceil(Int, x), 1)
     _iqr(v) = quantile(v, 0.75) - quantile(v, 0.25)
     _span(v) = _maximum(v) - _minimum(v)
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -225,7 +225,7 @@ end
         fr = if yaxis[:scale] == :identity
             0.0
         else
-            min(axis_limits(yaxis)[1], minimum(y))
+            min(axis_limits(yaxis)[1], _minimum(y))
         end
     end
     newx, newy = zeros(3n), zeros(3n)
@@ -338,7 +338,7 @@ end
     # compute half-width of bars
     bw = d[:bar_width]
     hw = if bw == nothing
-        0.5mean(diff(procx))
+        0.5_mean(diff(procx))
     else
         Float64[0.5cycle(bw,i) for i=1:length(procx)]
     end
@@ -414,8 +414,8 @@ end
 
 function _preprocess_binbarlike_weights{T<:AbstractFloat}(::Type{T}, w, wscale::Symbol)
     w_adj = _scale_adjusted_values(T, w, wscale)
-    w_min = minimum(w_adj)
-    w_max = maximum(w_adj)
+    w_min = _minimum(w_adj)
+    w_max = _maximum(w_adj)
     baseline = _binbarlike_baseline(w_min, wscale)
     w_adj, baseline
 end
@@ -550,7 +550,7 @@ Plots.@deps stepbins path
 function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode::Symbol = :auto)
     _cl(x) = max(ceil(Int, x), 1)
     _iqr(v) = quantile(v, 0.75) - quantile(v, 0.25)
-    _span(v) = maximum(v) - minimum(v)
+    _span(v) = _maximum(v) - _minimum(v)
 
     n_samples = length(linearindices(first(vs)))
     # Estimator for number of samples in one row/column of bins along each axis:
@@ -919,7 +919,7 @@ end
 
 # get the joined vector
 function get_xy(v::AVec{OHLC}, x = 1:length(v))
-    xdiff = 0.3mean(abs(diff(x)))
+    xdiff = 0.3_mean(abs(diff(x)))
     x_out, y_out = zeros(0), zeros(0)
     for (i,ohlc) in enumerate(v)
         ox,oy = get_xy(ohlc, x[i], xdiff)
@@ -984,8 +984,8 @@ end
     yflip := true
     aspect_ratio := 1
     rs, cs, zs = findnz(z.surf)
-    xlim := extrema(cs)
-    ylim := extrema(rs)
+    xlim := _extrema(cs)
+    ylim := _extrema(rs)
     if d[:markershape] == :none
         markershape := :circle
     end
@@ -1006,7 +1006,7 @@ end
 
 "Adds a+bx... straight line over the current plot"
 function abline!(plt::Plot, a, b; kw...)
-    plot!(plt, [extrema(plt)...], x -> b + a*x; kw...)
+    plot!(plt, [_extrema(plt)...], x -> b + a*x; kw...)
 end
 
 abline!(args...; kw...) = abline!(current(), args...; kw...)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -225,7 +225,7 @@ end
         fr = if yaxis[:scale] == :identity
             0.0
         else
-            min(axis_limits(yaxis)[1], _minimum(y))
+            _min(axis_limits(yaxis)[1], _minimum(y))
         end
     end
     newx, newy = zeros(3n), zeros(3n)
@@ -548,7 +548,7 @@ Plots.@deps stepbins path
 
 
 function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode::Symbol = :auto)
-    _cl(x) = max(ceil(Int, x), 1)
+    _cl(x) = _max(ceil(Int, x), 1)
     _iqr(v) = quantile(v, 0.75) - quantile(v, 0.25)
     _span(v) = _maximum(v) - _minimum(v)
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -366,7 +366,7 @@ end
     end
 
     # widen limits out a bit
-    expand_extrema!(axis, widen(extrema(xseg.pts)...))
+    expand_extrema!(axis, widen(_extrema(xseg.pts)...))
 
     # switch back
     if !isvertical(d)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -548,7 +548,7 @@ Plots.@deps stepbins path
 
 
 function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode::Symbol = :auto)
-    _cl(x) = max(ceil(Int, x), 1)
+    _cl(x) = ceil(Int, NaNMath.max(x, one(x)))
     _iqr(v) = quantile(v, 0.75) - quantile(v, 0.25)
     _span(v) = NaNMath.maximum(v) - NaNMath.minimum(v)
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -225,7 +225,7 @@ end
         fr = if yaxis[:scale] == :identity
             0.0
         else
-            NaNMath.min(axis_limits(yaxis)[1], _minimum(y))
+            NaNMath.min(axis_limits(yaxis)[1], NaNMath.minimum(y))
         end
     end
     newx, newy = zeros(3n), zeros(3n)
@@ -338,7 +338,7 @@ end
     # compute half-width of bars
     bw = d[:bar_width]
     hw = if bw == nothing
-        0.5_mean(diff(procx))
+        0.5NaNMath.mean(diff(procx))
     else
         Float64[0.5cycle(bw,i) for i=1:length(procx)]
     end
@@ -366,7 +366,7 @@ end
     end
 
     # widen limits out a bit
-    expand_extrema!(axis, widen(_extrema(xseg.pts)...))
+    expand_extrema!(axis, widen(NaNMath.extrema(xseg.pts)...))
 
     # switch back
     if !isvertical(d)
@@ -414,8 +414,8 @@ end
 
 function _preprocess_binbarlike_weights{T<:AbstractFloat}(::Type{T}, w, wscale::Symbol)
     w_adj = _scale_adjusted_values(T, w, wscale)
-    w_min = _minimum(w_adj)
-    w_max = _maximum(w_adj)
+    w_min = NaNMath.minimum(w_adj)
+    w_max = NaNMath.maximum(w_adj)
     baseline = _binbarlike_baseline(w_min, wscale)
     w_adj, baseline
 end
@@ -550,7 +550,7 @@ Plots.@deps stepbins path
 function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode::Symbol = :auto)
     _cl(x) = NaNMath.max(ceil(Int, x), 1)
     _iqr(v) = quantile(v, 0.75) - quantile(v, 0.25)
-    _span(v) = _maximum(v) - _minimum(v)
+    _span(v) = NaNMath.maximum(v) - NaNMath.minimum(v)
 
     n_samples = length(linearindices(first(vs)))
     # Estimator for number of samples in one row/column of bins along each axis:
@@ -919,7 +919,7 @@ end
 
 # get the joined vector
 function get_xy(v::AVec{OHLC}, x = 1:length(v))
-    xdiff = 0.3_mean(abs(diff(x)))
+    xdiff = 0.3NaNMath.mean(abs(diff(x)))
     x_out, y_out = zeros(0), zeros(0)
     for (i,ohlc) in enumerate(v)
         ox,oy = get_xy(ohlc, x[i], xdiff)
@@ -984,8 +984,8 @@ end
     yflip := true
     aspect_ratio := 1
     rs, cs, zs = findnz(z.surf)
-    xlim := _extrema(cs)
-    ylim := _extrema(rs)
+    xlim := NaNMath.extrema(cs)
+    ylim := NaNMath.extrema(rs)
     if d[:markershape] == :none
         markershape := :circle
     end
@@ -1006,7 +1006,7 @@ end
 
 "Adds a+bx... straight line over the current plot"
 function abline!(plt::Plot, a, b; kw...)
-    plot!(plt, [_extrema(plt)...], x -> b + a*x; kw...)
+    plot!(plt, [NaNMath.extrema(plt)...], x -> b + a*x; kw...)
 end
 
 abline!(args...; kw...) = abline!(current(), args...; kw...)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -548,7 +548,7 @@ Plots.@deps stepbins path
 
 
 function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode::Symbol = :auto)
-    _cl(x) = NaNMath.max(ceil(Int, x), 1)
+    _cl(x) = max(ceil(Int, x), 1)
     _iqr(v) = quantile(v, 0.75) - quantile(v, 0.25)
     _span(v) = NaNMath.maximum(v) - NaNMath.minimum(v)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,7 @@ calcMidpoints(edges::AbstractVector) = Float64[0.5 * (edges[i] + edges[i+1]) for
 
 "Make histogram-like bins of data"
 function binData(data, nbins)
-  lo, hi = extrema(data)
+  lo, hi = _extrema(data)
   edges = collect(linspace(lo, hi, nbins+1))
   midpoints = calcMidpoints(edges)
   buckets = Int[max(2, min(searchsortedfirst(edges, x), length(edges)))-1 for x in data]
@@ -109,7 +109,7 @@ function regressionXY(x, y)
   β, α = convert(Matrix{Float64}, [x ones(length(x))]) \ convert(Vector{Float64}, y)
 
   # make a line segment
-  regx = [minimum(x), maximum(x)]
+  regx = [_minimum(x), _maximum(x)]
   regy = β * regx + α
   regx, regy
 end
@@ -187,7 +187,7 @@ type SegmentsIterator
 end
 function iter_segments(args...)
     tup = Plots.wraptuple(args)
-    n = maximum(map(length, tup))
+    n = _maximum(map(length, tup))
     SegmentsIterator(tup, n)
 end
 
@@ -283,7 +283,7 @@ unzip{T}(xyuv::FixedSizeArrays.Vec{4,T})       = T[xyuv[1]], T[xyuv[2]], T[xyuv[
 # given 2-element lims and a vector of data x, widen lims to account for the extrema of x
 function _expand_limits(lims, x)
   try
-    e1, e2 = extrema(x)
+    e1, e2 = _extrema(x)
     lims[1] = min(lims[1], e1)
     lims[2] = max(lims[2], e2)
   # catch err
@@ -334,17 +334,17 @@ sortedkeys(d::Dict) = sort(collect(keys(d)))
 
 "create an (n+1) list of the outsides of heatmap rectangles"
 function heatmap_edges(v::AVec)
-  vmin, vmax = extrema(v)
+  vmin, vmax = _extrema(v)
   extra = 0.5 * (vmax-vmin) / (length(v)-1)
   vcat(vmin-extra, 0.5 * (v[1:end-1] + v[2:end]), vmax+extra)
 end
 
 
 function calc_r_extrema(x, y)
-    xmin, xmax = extrema(x)
-    ymin, ymax = extrema(y)
+    xmin, xmax = _extrema(x)
+    ymin, ymax = _extrema(y)
     r = 0.5 * min(xmax - xmin, ymax - ymin)
-    extrema(r)
+    _extrema(r)
 end
 
 function convert_to_polar(x, y, r_extrema = calc_r_extrema(x, y))
@@ -644,8 +644,8 @@ end
 # ---------------------------------------------------------------
 # used in updating an existing series
 
-extendSeriesByOne(v::UnitRange{Int}, n::Int = 1) = isempty(v) ? (1:n) : (minimum(v):maximum(v)+n)
-extendSeriesByOne(v::AVec, n::Integer = 1)       = isempty(v) ? (1:n) : vcat(v, (1:n) + maximum(v))
+extendSeriesByOne(v::UnitRange{Int}, n::Int = 1) = isempty(v) ? (1:n) : (_minimum(v):_maximum(v)+n)
+extendSeriesByOne(v::AVec, n::Integer = 1)       = isempty(v) ? (1:n) : vcat(v, (1:n) + _maximum(v))
 extendSeriesData{T}(v::Range{T}, z::Real)        = extendSeriesData(float(collect(v)), z)
 extendSeriesData{T}(v::Range{T}, z::AVec)        = extendSeriesData(float(collect(v)), z)
 extendSeriesData{T}(v::AVec{T}, z::Real)         = (push!(v, convert(T, z)); v)
@@ -871,9 +871,9 @@ mm2px(mm::Real)         = float(px / MM_PER_PX)
 
 
 "Smallest x in plot"
-xmin(plt::Plot) = minimum([minimum(series.d[:x]) for series in plt.series_list])
+xmin(plt::Plot) = _minimum([_minimum(series.d[:x]) for series in plt.series_list])
 "Largest x in plot"
-xmax(plt::Plot) = maximum([maximum(series.d[:x]) for series in plt.series_list])
+xmax(plt::Plot) = _maximum([_maximum(series.d[:x]) for series in plt.series_list])
 
 "Extrema of x-values in plot"
-Base.extrema(plt::Plot) = (xmin(plt), xmax(plt))
+_extrema(plt::Plot) = (xmin(plt), xmax(plt))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ function binData(data, nbins)
   lo, hi = _extrema(data)
   edges = collect(linspace(lo, hi, nbins+1))
   midpoints = calcMidpoints(edges)
-  buckets = Int[_max(2, _min(searchsortedfirst(edges, x), length(edges)))-1 for x in data]
+  buckets = Int[NaNMath.max(2, NaNMath.min(searchsortedfirst(edges, x), length(edges)))-1 for x in data]
   counts = zeros(Int, length(midpoints))
   for b in buckets
     counts[b] += 1
@@ -284,8 +284,8 @@ unzip{T}(xyuv::FixedSizeArrays.Vec{4,T})       = T[xyuv[1]], T[xyuv[2]], T[xyuv[
 function _expand_limits(lims, x)
   try
     e1, e2 = _extrema(x)
-    lims[1] = _min(lims[1], e1)
-    lims[2] = _max(lims[2], e2)
+    lims[1] = NaNMath.min(lims[1], e1)
+    lims[2] = NaNMath.max(lims[2], e2)
   # catch err
   #   warn(err)
   end
@@ -343,7 +343,7 @@ end
 function calc_r_extrema(x, y)
     xmin, xmax = _extrema(x)
     ymin, ymax = _extrema(y)
-    r = 0.5 * _min(xmax - xmin, ymax - ymin)
+    r = 0.5 * NaNMath.min(xmax - xmin, ymax - ymin)
     _extrema(r)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ function binData(data, nbins)
   lo, hi = NaNMath.extrema(data)
   edges = collect(linspace(lo, hi, nbins+1))
   midpoints = calcMidpoints(edges)
-  buckets = Int[NaNMath.max(2, NaNMath.min(searchsortedfirst(edges, x), length(edges)))-1 for x in data]
+  buckets = Int[max(2, min(searchsortedfirst(edges, x), length(edges)))-1 for x in data]
   counts = zeros(Int, length(midpoints))
   for b in buckets
     counts[b] += 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ function binData(data, nbins)
   lo, hi = _extrema(data)
   edges = collect(linspace(lo, hi, nbins+1))
   midpoints = calcMidpoints(edges)
-  buckets = Int[max(2, min(searchsortedfirst(edges, x), length(edges)))-1 for x in data]
+  buckets = Int[_max(2, _min(searchsortedfirst(edges, x), length(edges)))-1 for x in data]
   counts = zeros(Int, length(midpoints))
   for b in buckets
     counts[b] += 1
@@ -284,8 +284,8 @@ unzip{T}(xyuv::FixedSizeArrays.Vec{4,T})       = T[xyuv[1]], T[xyuv[2]], T[xyuv[
 function _expand_limits(lims, x)
   try
     e1, e2 = _extrema(x)
-    lims[1] = min(lims[1], e1)
-    lims[2] = max(lims[2], e2)
+    lims[1] = _min(lims[1], e1)
+    lims[2] = _max(lims[2], e2)
   # catch err
   #   warn(err)
   end
@@ -343,7 +343,7 @@ end
 function calc_r_extrema(x, y)
     xmin, xmax = _extrema(x)
     ymin, ymax = _extrema(y)
-    r = 0.5 * min(xmax - xmin, ymax - ymin)
+    r = 0.5 * _min(xmax - xmin, ymax - ymin)
     _extrema(r)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,7 @@ calcMidpoints(edges::AbstractVector) = Float64[0.5 * (edges[i] + edges[i+1]) for
 
 "Make histogram-like bins of data"
 function binData(data, nbins)
-  lo, hi = _extrema(data)
+  lo, hi = NaNMath.extrema(data)
   edges = collect(linspace(lo, hi, nbins+1))
   midpoints = calcMidpoints(edges)
   buckets = Int[NaNMath.max(2, NaNMath.min(searchsortedfirst(edges, x), length(edges)))-1 for x in data]
@@ -109,7 +109,7 @@ function regressionXY(x, y)
   β, α = convert(Matrix{Float64}, [x ones(length(x))]) \ convert(Vector{Float64}, y)
 
   # make a line segment
-  regx = [_minimum(x), _maximum(x)]
+  regx = [NaNMath.minimum(x), NaNMath.maximum(x)]
   regy = β * regx + α
   regx, regy
 end
@@ -187,7 +187,7 @@ type SegmentsIterator
 end
 function iter_segments(args...)
     tup = Plots.wraptuple(args)
-    n = _maximum(map(length, tup))
+    n = maximum(map(length, tup))
     SegmentsIterator(tup, n)
 end
 
@@ -283,7 +283,7 @@ unzip{T}(xyuv::FixedSizeArrays.Vec{4,T})       = T[xyuv[1]], T[xyuv[2]], T[xyuv[
 # given 2-element lims and a vector of data x, widen lims to account for the extrema of x
 function _expand_limits(lims, x)
   try
-    e1, e2 = _extrema(x)
+    e1, e2 = NaNMath.extrema(x)
     lims[1] = NaNMath.min(lims[1], e1)
     lims[2] = NaNMath.max(lims[2], e2)
   # catch err
@@ -334,17 +334,17 @@ sortedkeys(d::Dict) = sort(collect(keys(d)))
 
 "create an (n+1) list of the outsides of heatmap rectangles"
 function heatmap_edges(v::AVec)
-  vmin, vmax = _extrema(v)
+  vmin, vmax = NaNMath.extrema(v)
   extra = 0.5 * (vmax-vmin) / (length(v)-1)
   vcat(vmin-extra, 0.5 * (v[1:end-1] + v[2:end]), vmax+extra)
 end
 
 
 function calc_r_extrema(x, y)
-    xmin, xmax = _extrema(x)
-    ymin, ymax = _extrema(y)
+    xmin, xmax = NaNMath.extrema(x)
+    ymin, ymax = NaNMath.extrema(y)
     r = 0.5 * NaNMath.min(xmax - xmin, ymax - ymin)
-    _extrema(r)
+    NaNMath.extrema(r)
 end
 
 function convert_to_polar(x, y, r_extrema = calc_r_extrema(x, y))
@@ -644,8 +644,8 @@ end
 # ---------------------------------------------------------------
 # used in updating an existing series
 
-extendSeriesByOne(v::UnitRange{Int}, n::Int = 1) = isempty(v) ? (1:n) : (_minimum(v):_maximum(v)+n)
-extendSeriesByOne(v::AVec, n::Integer = 1)       = isempty(v) ? (1:n) : vcat(v, (1:n) + _maximum(v))
+extendSeriesByOne(v::UnitRange{Int}, n::Int = 1) = isempty(v) ? (1:n) : (minimum(v):maximum(v)+n)
+extendSeriesByOne(v::AVec, n::Integer = 1)       = isempty(v) ? (1:n) : vcat(v, (1:n) + NaNMath.maximum(v))
 extendSeriesData{T}(v::Range{T}, z::Real)        = extendSeriesData(float(collect(v)), z)
 extendSeriesData{T}(v::Range{T}, z::AVec)        = extendSeriesData(float(collect(v)), z)
 extendSeriesData{T}(v::AVec{T}, z::Real)         = (push!(v, convert(T, z)); v)
@@ -871,9 +871,9 @@ mm2px(mm::Real)         = float(px / MM_PER_PX)
 
 
 "Smallest x in plot"
-xmin(plt::Plot) = _minimum([_minimum(series.d[:x]) for series in plt.series_list])
+xmin(plt::Plot) = NaNMath.minimum([NaNMath.minimum(series.d[:x]) for series in plt.series_list])
 "Largest x in plot"
-xmax(plt::Plot) = _maximum([_maximum(series.d[:x]) for series in plt.series_list])
+xmax(plt::Plot) = NaNMath.maximum([NaNMath.maximum(series.d[:x]) for series in plt.series_list])
 
 "Extrema of x-values in plot"
-_extrema(plt::Plot) = (xmin(plt), xmax(plt))
+NaNMath.extrema(plt::Plot) = (xmin(plt), xmax(plt))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,7 +83,7 @@ facts("Axes") do
 
     Plots.discrete_value!(axis, ["x$i" for i=1:5])
     Plots.discrete_value!(axis, ["x$i" for i=0:2])
-    @fact Plots.extrema(axis) --> (0.5, 7.5)
+    @fact Plots._extrema(axis) --> (0.5, 7.5)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,12 +78,12 @@ facts("Axes") do
     @fact typeof(axis) --> Plots.Axis
     @fact Plots.discrete_value!(axis, "HI") --> (0.5, 1)
     @fact Plots.discrete_value!(axis, :yo) --> (1.5, 2)
-    @fact extrema(axis) --> (0.5,1.5)
+    @fact Plots._extrema(axis) --> (0.5,1.5)
     @fact axis[:discrete_map] --> Dict{Any,Any}(:yo  => 2, "HI" => 1)
 
     Plots.discrete_value!(axis, ["x$i" for i=1:5])
     Plots.discrete_value!(axis, ["x$i" for i=0:2])
-    @fact extrema(axis) --> (0.5, 7.5)
+    @fact Plots.extrema(axis) --> (0.5, 7.5)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,12 +78,12 @@ facts("Axes") do
     @fact typeof(axis) --> Plots.Axis
     @fact Plots.discrete_value!(axis, "HI") --> (0.5, 1)
     @fact Plots.discrete_value!(axis, :yo) --> (1.5, 2)
-    @fact Plots._extrema(axis) --> (0.5,1.5)
+    @fact Plots.NaNMath.extrema(axis) --> (0.5,1.5)
     @fact axis[:discrete_map] --> Dict{Any,Any}(:yo  => 2, "HI" => 1)
 
     Plots.discrete_value!(axis, ["x$i" for i=1:5])
     Plots.discrete_value!(axis, ["x$i" for i=0:2])
-    @fact Plots._extrema(axis) --> (0.5, 7.5)
+    @fact Plots.NaNMath.extrema(axis) --> (0.5, 7.5)
 end
 
 


### PR DESCRIPTION
Bases summary functions on NaNMath:
min, max, extrema, minimum, maximum