### PR TITLE
Changed GR legend markers for plots with fillrange

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1007,9 +1007,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
                 gr_set_line(series[:linewidth], series[:linestyle], series[:linecolor]) #, series[:linealpha])
-                if st == :path
+                if st == :path && series[:fillrange] == nothing
                     GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
-                elseif st == :shape
+                elseif st == :shape || series[:fillrange] != nothing
                     gr_set_fill(series[:fillcolor]) #, series[:fillalpha])
                     l, r = xpos-0.07, xpos-0.01
                     b, t = ypos-0.4dy, ypos+0.4dy


### PR DESCRIPTION
Before this PR
```julia
using Plots
gr()

y = [0 0 0;
     2 4 6]
f = [0 0 0;
     1 3 5]

plot(
    plot(y),
    plot(y, fillrange = f, linewidth = 0),
    plot(y, fillrange = f, fillcolor = [4 5 6], linewidth = 3),
    layout = (1, 3)
    )
```
used to produce this:
![gr_legend_old](https://cloud.githubusercontent.com/assets/16589944/26734051/08c2dd96-47bd-11e7-8692-2af62955f6fe.png)
Now the legend markers look like this:
![gr_legend_new](https://cloud.githubusercontent.com/assets/16589944/26734068/130cc1f4-47bd-11e7-986a-adb660677ff7.png)



