### PR TITLE
fix-example12-transpose

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -115,7 +115,8 @@ PlotExample("Line types",
 PlotExample("Line styles",
     "",
     [:(begin
-        styles = filter(s -> s in Plots.supported_styles(), [:solid, :dash, :dot, :dashdot, :dashdotdot])'
+        styles = filter(s -> s in Plots.supported_styles(), [:solid, :dash, :dot, :dashdot, :dashdotdot])
+        styles = reshape(styles, 1, length(styles)) # Julia 0.6 unfortunately gives an error when transposing symbol vectors
         n = length(styles)
         y = cumsum(randn(20,n),1)
         plot(y, line = (5, styles), label = map(string,styles))


### PR DESCRIPTION
Julia 0.6 gives an error on using `'` to transpose a vector