### PR TITLE
Make tests pass on 0.6

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -119,14 +119,15 @@ PlotExample("Line styles",
         styles = reshape(styles, 1, length(styles)) # Julia 0.6 unfortunately gives an error when transposing symbol vectors
         n = length(styles)
         y = cumsum(randn(20,n),1)
-        plot(y, line = (5, styles), label = map(string,styles))
+        plot(y, line = (5, styles), label = map(string,styles), legendtitle = "linestyle")
     end)]
 ),
 
 PlotExample("Marker types",
     "",
     [:(begin
-        markers = filter(m -> m in Plots.supported_markers(), Plots._shape_keys)'
+        markers = filter(m -> m in Plots.supported_markers(), Plots._shape_keys)
+        markers = reshape(markers, 1, length(markers))
         n = length(markers)
         x = linspace(0,10,n+2)[2:end-1]
         y = repmat(reverse(x)', n, 1)

--- a/test/imgcomp.jl
+++ b/test/imgcomp.jl
@@ -99,7 +99,7 @@ function image_comparison_facts(pkg::Symbol;
   for i in 1:length(Plots._examples)
     i in skip && continue
     if only == nothing || i in only
-      @fact image_comparison_tests(pkg, i, debug=debug, sigma=sigma, eps=eps) |> success --> true
+      @fact @eval(image_comparison_tests(Symbol(String(Symbol($pkg))[7:end]), $i, debug=$debug, sigma=$sigma, eps=$eps)) |> success --> true
     end
   end
 end


### PR DESCRIPTION
This works on my local machine and the new PyPlot testimages from https://github.com/JuliaPlots/PlotReferenceImages.jl/pull/5. I have no idea if it will work on travis, but it's worth a shot.