### PR TITLE
remove all 0.5-compliant uses of the transpose operator

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -1,4 +1,4 @@
-__precompile__(true)
+__precompile__(false)
 
 module Plots
 
@@ -120,8 +120,11 @@ ignorenan_extrema(x) = Base.extrema(x)
 # This makes it impossible to create row vectors of String and Symbol with the transpose operator.
 # This solves this issue, internally in Plots at least.
 
-Base.transpose(x::Symbol) = x
-Base.transpose(x::String) = x
+
+# commented out on the insistence of the METADATA maintainers
+
+#Base.transpose(x::Symbol) = x
+#Base.transpose(x::String) = x
 
 # ---------------------------------------------------------
 

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -130,7 +130,7 @@ PlotExample("Marker types",
         markers = reshape(markers, 1, length(markers))
         n = length(markers)
         x = linspace(0,10,n+2)[2:end-1]
-        y = repmat(reverse(x)', n, 1)
+        y = repmat(reshape(reverse(x),1,:), n, 1)
         scatter(x, y, m=(8,:auto), lab=map(string,markers), bg=:linen, xlim=(0,10), ylim=(0,10))
     end)]
 ),
@@ -216,7 +216,7 @@ PlotExample("Contours",
         x = 1:0.5:20
         y = 1:0.5:10
         f(x,y) = (3x+y^2)*abs(sin(x)+cos(y))
-        X = repmat(x', length(y), 1)
+        X = repmat(reshape(x,1,:), length(y), 1)
         Y = repmat(y, 1, length(x))
         Z = map(f, X, Y)
         p1 = contour(x, y, f, fill=true)
@@ -280,7 +280,7 @@ PlotExample("Heatmap, categorical axes, and aspect_ratio",
     [:(begin
         xs = [string("x",i) for i=1:10]
         ys = [string("y",i) for i=1:4]
-        z = float((1:4)*(1:10)')
+        z = float((1:4)*reshape(1:10,1,:))
         heatmap(xs, ys, z, aspect_ratio=1)
     end)]
 ),

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -870,7 +870,7 @@ end
 
 # get the joined vector
 function get_xy(v::AVec{OHLC}, x = 1:length(v))
-    xdiff = 0.3ignorenan_mean(abs(diff(x)))
+    xdiff = 0.3ignorenan_mean(abs.(diff(x)))
     x_out, y_out = zeros(0), zeros(0)
     for (i,ohlc) in enumerate(v)
         ox,oy = get_xy(ohlc, x[i], xdiff)
@@ -911,7 +911,7 @@ end
 
 # "Sparsity plot... heatmap of non-zero values of a matrix"
 # function spy{T<:Real}(z::AMat{T}; kw...)
-#     mat = map(zi->float(zi!=0), z)'
+#     mat = reshape(map(zi->float(zi!=0), z),1,:)
 #     xn, yn = size(mat)
 #     heatmap(mat; leg=false, yflip=true, aspect_ratio=:equal,
 #         xlim=(0.5, xn+0.5), ylim=(0.5, yn+0.5),
@@ -1005,7 +1005,7 @@ end
     end
 
     library = PlotUtils.color_libraries[cl.args[1]]
-    z = sqrt.((1:15)*(1:20)')
+    z = sqrt.((1:15)*reshape(1:20,1,:))
 
     seriestype := :heatmap
     ticks := nothing
@@ -1029,7 +1029,7 @@ end
     if !(length(grad.args) == 1 && isa(grad.args[1], Symbol))
         error("showgradient takes the name of a color gradient as a Symbol")
     end
-    z = sqrt.((1:15)*(1:20)')
+    z = sqrt.((1:15)*reshape(1:20,1,:))
     seriestype := :heatmap
     ticks := nothing
     legend := false

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -324,7 +324,7 @@ function replaceAliases!(d::KW, aliases::Dict{Symbol,Symbol})
   end
 end
 
-createSegments(z) = collect(repmat(z',2,1))[2:end]
+createSegments(z) = collect(repmat(reshape(z,1,:),2,1))[2:end]
 
 Base.first(c::Colorant) = c
 Base.first(x::Symbol) = x


### PR DESCRIPTION
required by Julia METADATA maintainers