### PR TITLE
Reduced colorbar size on PyPlot for big z values (fix #925)

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1221,7 +1221,7 @@ function _update_plot_object(plt::Plot{PyPlotBackend})
             cbw = sp.attr[:cbar_width]
             # this is the bounding box of just the colors of the colorbar (not labels)
             has_toplabel = sp[:zaxis][:extrema].emax >= 1e7
-            cb_bbox = BoundingBox(right(sp.bbox)-cbw+1mm, top(sp.bbox) +  (has_toplabel ? 4mm : 2mm), _cbar_width-1mm, height(sp.bbox) - (has_toplabel ? 8mm : 4mm))
+            cb_bbox = BoundingBox(right(sp.bbox)-cbw+1mm, top(sp.bbox) +  (has_toplabel ? 4mm : 2mm), _cbar_width-1mm, height(sp.bbox) - (has_toplabel ? 6mm : 4mm))
             pcts = bbox_to_pcts(cb_bbox, figw, figh)
             sp.attr[:cbar_ax][:set_position](pcts)
         end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1220,7 +1220,8 @@ function _update_plot_object(plt::Plot{PyPlotBackend})
         if haskey(sp.attr, :cbar_ax)
             cbw = sp.attr[:cbar_width]
             # this is the bounding box of just the colors of the colorbar (not labels)
-            cb_bbox = BoundingBox(right(sp.bbox)-cbw+1mm, top(sp.bbox)+2mm, _cbar_width-1mm, height(sp.bbox)-4mm)
+            has_toplabel = sp[:zaxis][:extrema].emax >= 1e7
+            cb_bbox = BoundingBox(right(sp.bbox)-cbw+1mm, top(sp.bbox) +  (has_toplabel ? 4mm : 2mm), _cbar_width-1mm, height(sp.bbox) - (has_toplabel ? 8mm : 4mm))
             pcts = bbox_to_pcts(cb_bbox, figw, figh)
             sp.attr[:cbar_ax][:set_position](pcts)
         end


### PR DESCRIPTION
```julia
using Plots; pyplot()
x = y = 1:10
z = 1e5 * x * y'
heatmap(x, y, z, aspectratio = true)
```
used to produce this:
![pyplot_colorbar_big_old](https://user-images.githubusercontent.com/16589944/27050092-a0211d46-4fb1-11e7-8443-20d90342b5c6.png)

Now it looks like this:
![pyplot_colorbar_big](https://user-images.githubusercontent.com/16589944/27050129-b59d09d2-4fb1-11e7-89e9-c3e59444ac59.png)

The colorbar axes limits remain the same for smaller `z` values like, e.g. `z = 1e4 * x * y'`:
![pyplot_colorbar_normal](https://user-images.githubusercontent.com/16589944/27050181-ed9de450-4fb1-11e7-9572-b52fdeed7e9f.png)
