### PR TITLE
Avoid non-positive heatmap edges for log axis on GR and PyPlot

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -585,7 +585,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         end
         if st == :heatmap
             outside_ticks = true
-            x, y = heatmap_edges(series[:x]), heatmap_edges(series[:y])
+            x, y = heatmap_edges(series[:x], sp[:xaxis][:scale]), heatmap_edges(series[:y], sp[:yaxis][:scale])
             expand_extrema!(sp[:xaxis], x)
             expand_extrema!(sp[:yaxis], y)
             data_lims = gr_xy_axislims(sp)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -768,7 +768,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     end
 
     if st == :heatmap
-        x, y, z = heatmap_edges(x), heatmap_edges(y), transpose_z(series, z.surf)
+        x, y, z = heatmap_edges(x, sp[:xaxis][:scale]), heatmap_edges(y, sp[:yaxis][:scale]), transpose_z(series, z.surf)
 
         expand_extrema!(sp[:xaxis], x)
         expand_extrema!(sp[:yaxis], y)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -332,11 +332,24 @@ Base.first(x::Symbol) = x
 
 sortedkeys(d::Dict) = sort(collect(keys(d)))
 
+
+const _scale_base = Dict{Symbol, Real}(
+    :log10 => 10,
+    :log2 => 2,
+    :ln => e,
+)
+
 "create an (n+1) list of the outsides of heatmap rectangles"
-function heatmap_edges(v::AVec)
+function heatmap_edges(v::AVec, scale::Symbol = :identity)
   vmin, vmax = ignorenan_extrema(v)
-  extra = 0.5 * (vmax-vmin) / (length(v)-1)
-  vcat(vmin-extra, 0.5 * (v[1:end-1] + v[2:end]), vmax+extra)
+  extra_min = extra_max = 0.5 * (vmax-vmin) / (length(v)-1)
+  if scale in _logScales
+      vmin > 0 || error("The axis values must be positive for a $scale scale")
+      while vmin - extra_min <= 0
+          extra_min /= _scale_base[scale]
+      end
+  end
+  vcat(vmin-extra_min, 0.5 * (v[1:end-1] + v[2:end]), vmax+extra_max)
 end
 
 


### PR DESCRIPTION
```julia
using Plots
x = y = 1:3:30
heatmap(x, y, x * y', xscale = :log10, yscale = :log10)
```
used to return a `log10` `DomainError`, although all input data is positve. That is because the first calculated heatmap edge is `-0.5` (cf. #920).

PlotlyJS solves this by removing the first values of `x` and `y` as well as the first row and column of the data matrix:
![heatmap_log10_plotlyjs](https://user-images.githubusercontent.com/16589944/27262346-185d7500-5455-11e7-9e86-a165d63ee9b8.png)

PyPlot and GR now increase the first heatmap edge values to a positive value to avoid `DomainError`s and keep all matrix data.
PyPlot:
![heatmap_log10_pyplot_new](https://user-images.githubusercontent.com/16589944/27262265-59e6e74c-5453-11e7-9440-a8ea82d21e2c.png)
GR still has some issues:
![heatmap_log10_gr_new](https://user-images.githubusercontent.com/16589944/27262274-77a22224-5453-11e7-925e-18576f7bfc29.png)
On GR heatmaps are drawn as images with the uniformly sized rectangles, so the log scale does not affect the heatmap edge positions. Instead the colorbar ticks are affected. (cc: @jheinen )
