### PR TITLE
fixing deprecation warning

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -703,7 +703,7 @@ end
 
 function error_coords(xorig, yorig, ebar)
     # init empty x/y, and zip errors if passed Tuple{Vector,Vector}
-    x, y = Array(float_extended_type(xorig), 0), Array(Float64, 0)
+    x, y = Array{float_extended_type(xorig)}(0), Array{Float64}(0)
     # for each point, create a line segment from the bottom to the top of the errorbar
     for i = 1:max(length(xorig), length(yorig))
         xi = _cycle(xorig, i)


### PR DESCRIPTION
```
WARNING: Array{T}(::Type{T}, m::Int) is deprecated, use Array{T}(m) instead.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at .\deprecated.jl:70
 [2] Array(::Type{Float64}, ::Int64) at .\deprecated.jl:57
 [3] error_coords(::Array{Int64,1}, ::Array{Float64,1}, ::Array{Float64,1}) at C:\Users\chris\.julia\v0.6\Plots\src\recipes.jl:706
 [4] macro expansion at C:\Users\chris\.julia\v0.6\Plots\src\recipes.jl:730 [inlined]
 [5] apply_recipe(::Dict{Symbol,Any}, ::Type{Val{:yerror}}, ::Array{Int64,1}, ::Array{Float64,1}, ::Void) at C:\Users\chris\.julia\v0.6\RecipesBase\src\RecipesBase.jl:259
 [6] _process_seriesrecipe(::Plots.Plot{Plots.PlotlyJSBackend}, ::Dict{Symbol,Any}) at C:\Users\chris\.julia\v0.6\Plots\src\pipeline.jl:404
 [7] _plot!(::Plots.Plot{Plots.PlotlyJSBackend}, ::Dict{Symbol,Any}, ::Tuple{Array{Int64,1},Array{Float64,2}}) at C:\Users\chris\.julia\v0.6\Plots\src\plot.jl:227
 [8] #plot!#141(::Array{Any,1}, ::Function, ::Plots.Plot{Plots.PlotlyJSBackend}, ::Array{Int64,1}, ::Vararg{Any,N} where N) at C:\Users\chris\.julia\v0.6\Plots\src\plot.jl:151
 [9] (::Plots.#kw##plot!)(::Array{Any,1}, ::Plots.#plot!, ::Plots.Plot{Plots.PlotlyJSBackend}, ::Array{Int64,1}, ::Vararg{Any,N} where N) at .\<missing>:0
 [10] #plot!#140(::Array{Any,1}, ::Function, ::Array{Int64,1}, ::Vararg{Any,N} where N) at C:\Users\chris\.julia\v0.6\Plots\src\plot.jl:143
 [11] (::Plots.#kw##plot!)(::Array{Any,1}, ::Plots.#plot!, ::Array{Int64,1}, ::Array{Float64,2}, ::Vararg{Array{Float64,2},N} where N) at .\<missing>:0
 [12] include_string(::String, ::String) at .\loading.jl:515
 [13] execute_request(::ZMQ.Socket, ::IJulia.Msg) at C:\Users\chris\.julia\v0.6\IJulia\src\execute_request.jl:160
 [14] eventloop(::ZMQ.Socket) at C:\Users\chris\.julia\v0.6\IJulia\src\eventloop.jl:8
 [15] (::IJulia.##11#14)() at .\task.jl:335

```while loading In[38], in expression starting on line 3