### PR TITLE
Switch from FixedSizeArrays to StaticArrays.FixedSizeArrays

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ RecipesBase 0.2.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-FixedSizeArrays
+StaticArrays 0.5
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -3,7 +3,7 @@ __precompile__(true)
 module Plots
 
 using Reexport
-using FixedSizeArrays
+using StaticArrays.FixedSizeArrays
 @reexport using RecipesBase
 import RecipesBase: plot, animate
 using Base.Meta


### PR DESCRIPTION
FixedSizeArrays.jl [has been deprecated](https://github.com/SimonDanisch/FixedSizeArrays.jl#this-package-doesnt-support-03-and-its-not-planned-to-update-it-to-06-use-staticarrays-instead) in favor of `StaticArrays.FixedSizeArrays` which has better v0.6 support and is actively maintained.

I've successfully run the unit tests using the scripts referenced in `.travis.yml`, and I've sanity-checked that basic plotting from Jupyter works, but I'm not sure of what other tests I need to run to be sure that this is OK. Any advice? 

