### PR TITLE
Fixed a deprecation warning on the pyplot backend

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -926,7 +926,7 @@ function py_compute_axis_minval(axis::Axis)
         for series in series_list(sp)
             v = series.d[axis[:letter]]
             if !isempty(v)
-                minval = NaNMath.min(minval, ignorenan_minimum(abs(v)))
+                minval = NaNMath.min(minval, ignorenan_minimum(abs.(v)))
             end
         end
     end


### PR DESCRIPTION
The follwing code created a deprecation warning:
```julia
using Plots; pyplot()
plot([1,2,3,4], [2,3,4,5], yscale=:log10)
```

WARNING: abs{T <: Number}(x::AbstractArray{T}) is deprecated, use abs.(x) instead.

Stacktrace:

 [1] 
depwarn(::String, ::Symbol) at ./deprecated.jl:70
 [2] abs(::Array{Int64,1}) at ./deprecated.jl:57
 [3] py_compute_axis_minval(::Plots.Axis) at /home/devja964/.julia/v0.6/Plots/src/backends/pyplot.jl:929
 [4] py_set_scale(::PyCall.PyObject, ::Plots.Axis) at /home/devja964/.julia/v0.6/Plots/src/backends/pyplot.jl:957
 [5] _before_layout_calcs(::Plots.Plot{Plots.PyPlotBackend}) at /home/devja964/.julia/v0.6/Plots/src/backends/pyplot.jl:1045
 [6] prepare_output(::Plots.Plot{Plots.PyPlotBackend}) at /home/devja964/.julia/v0.6/Plots/src/plot.jl:247
 [7] show(::Base64EncodePipe, ::MIME{Symbol("image/png")}, ::Plots.Plot{Plots.PyPlotBackend}) at /home/devja964/.julia/v0.6/Plots/src/output.jl:196
 [8] base64encode(::Function, ::MIME{Symbol("image/png")}, ::Vararg{Any,N} where N) at ./base64.jl:197
 [9] show(::IOContext{Base.AbstractIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("text/html")}, ::Plots.Plot{Plots.PyPlotBackend}) at /home/devja964/.julia/v0.6/Plots/src/output.jl:174
 [10] verbose_show(::Base.AbstractIOBuffer{Array{UInt8,1}}, ::MIME{Symbol("text/html")}, ::Plots.Plot{Plots.PyPlotBackend}) at ./multimedia.jl:42
 [11] #sprint#228(::Void, ::Function, ::Int64, ::Function, ::MIME{Symbol("text/html")}, ::Vararg{Any,N} where N) at ./strings/io.jl:66
 [12] reprmime(::MIME{Symbol("text/html")}, ::Plots.Plot{Plots.PyPlotBackend}) at ./multimedia.jl:61
 [13] stringmime at ./multimedia.jl:83 [inlined]
 [14] render(::Juno.PlotPane, ::Plots.Plot{Plots.PyPlotBackend}) at /home/devja964/.julia/v0.6/Plots/src/output.jl:302
 [15] render′(::Juno.PlotPane, ::Plots.Plot{Plots.PyPlotBackend}) at /home/devja964/.julia/v0.6/Atom/src/display/errors.jl:89
 [16] (::Atom.##61#64)() at /home/devja964/.julia/v0.6/Atom/src/eval.jl:104
 [17] withpath(::Atom.##61#64, ::Void) at /home/devja964/.julia/v0.6/CodeTools/src/utils.jl:30
 [18] withpath(::Function, ::Void) at /home/devja964/.julia/v0.6/Atom/src/eval.jl:38
 [19] macro expansion at /home/devja964/.julia/v0.6/Atom/src/eval.jl:101 [inlined]
 [20] (::Atom.##60#63{Dict{String,Any}})() at ./task.jl:80
while loading /home/devja964/.atom/packages/julia-client/script/boot.jl, in expression starting on line 303