### PR TITLE
Add fillrange for Plotly backend

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -585,6 +585,7 @@ function plotly_series(plt::Plot, series::Series)
         # series, one for series being filled to) instead of one
         d_out_fillrange = copy(d_out)
         d_out_fillrange[:y] = series[:fillrange]
+        d_out_fillrange[:showlegend] = false
         delete!(d_out_fillrange, :fill)
         delete!(d_out_fillrange, :fillcolor)
 


### PR DESCRIPTION
These two commits resolve plotly/Plotly.jl#34, allowing the user to fill between two lines using `fillrange`. Previously, using `fillrange` gave the following warning:

```julia
julia> using Plots

julia> Plots.plotly();

julia> x = linspace(-6, 6, 100);

julia> y = sin.(x);

julia> p = plot(x, y .+ 1, fillrange = y .- 1, label = "Hello")
WARNING: fillrange ignored... plotly only supports filling to zero. fillrange: [-0.720585,-0.606535,-0.49826,-0.397347,-0.305278,-0.223403,-0.152925,-0.0948765,-0.0501105,-0.0192835,-0.002848,-0.00104508,-0.0139012,-0.0412278,-0.0826237,-0.137482,-0.204996,-0.284178,-0.373863,-0.472736,-0.579347,-0.692131,-0.809432,-0.92953,-1.05066,-1.17105,-1.28893,-1.40257,-1.5103,-1.61054,-1.70183,-1.78281,-1.85231,-1.9093,-1.95294,-1.98261,-1.99785,-1.99845,-1.9844,-1.95591,-1.91338,-1.85745,-1.78895,-1.70886,-1.61837,-1.51881,-1.41163,-1.29841,-1.18082,-1.06057,-0.939431,-0.819182,-0.701586,-0.58837,-0.481193,-0.38163,-0.291141,-0.211055,-0.142545,-0.0866182,-0.0440947,-0.0155985,-0.00154777,-0.00214877,-0.0173926,-0.0470557,-0.0907026,-0.147693,-0.21719,-0.298175,-0.389458,-0.489701,-0.597433,-0.711071,-0.82895,-0.949338,-1.07047,-1.19057,-1.30787,-1.42065,-1.52726,-1.62614,-1.71582,-1.795,-1.86252,-1.91738,-1.95877,-1.9861,-1.99895,-1.99715,-1.980
```

and produced this plot:

![capture2](https://user-images.githubusercontent.com/6033297/28140229-7b8e15b6-6725-11e7-89bf-aef9f8fb273d.PNG)

With these commits, the warning is no longer thrown and the result is:

![capture](https://user-images.githubusercontent.com/6033297/28139986-8106667a-6724-11e7-92eb-fe9de10c706d.PNG)
