### PR TITLE
Line legend marker for ribbons in GR (fix #896)

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1049,7 +1049,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
                 gr_set_line(series[:linewidth], series[:linestyle], series[:linecolor]) #, series[:linealpha])
-                if st == :path && series[:fillrange] == nothing
+                if st == :path && (series[:fillrange] == nothing || has_ribbon(series))
                     GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
                 elseif st == :shape || series[:fillrange] != nothing
                     gr_set_fill(series[:fillcolor]) #, series[:fillalpha])

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1049,7 +1049,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
                 gr_set_line(series[:linewidth], series[:linestyle], series[:linecolor]) #, series[:linealpha])
-                if st == :path && (series[:fillrange] == nothing || has_ribbon(series))
+                if st == :path && (series[:fillrange] == nothing || series[:ribbon] != nothing)
                     GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
                 elseif st == :shape || series[:fillrange] != nothing
                     gr_set_fill(series[:fillcolor]) #, series[:fillalpha])

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1057,11 +1057,15 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     x = [l, r, r, l, l]
                     y = [b, b, t, t, b]
                     gr_polyline(x, y, GR.fillarea)
-                    series[:ribbon] != nothing || gr_polyline(x, y)
+                    st == :shape && gr_polyline(x, y)
                 end
 
-                if st == :path && (series[:fillrange] == nothing || series[:ribbon] != nothing)
-                    GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
+                if st == :path
+                    if series[:fillrange] == nothing || series[:ribbon] != nothing
+                        GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
+                    else
+                        GR.polyline([xpos - 0.07, xpos - 0.01], [ypos+0.4dy, ypos+0.4dy])
+                    end
                 end
 
                 if series[:markershape] != :none

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1049,16 +1049,19 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
                 gr_set_line(series[:linewidth], series[:linestyle], series[:linecolor]) #, series[:linealpha])
-                if st == :path && (series[:fillrange] == nothing || series[:ribbon] != nothing)
-                    GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
-                elseif st == :shape || series[:fillrange] != nothing
+
+                if st == :shape || series[:fillrange] != nothing
                     gr_set_fill(series[:fillcolor]) #, series[:fillalpha])
                     l, r = xpos-0.07, xpos-0.01
                     b, t = ypos-0.4dy, ypos+0.4dy
                     x = [l, r, r, l, l]
                     y = [b, b, t, t, b]
                     gr_polyline(x, y, GR.fillarea)
-                    gr_polyline(x, y)
+                    series[:ribbon] != nothing || gr_polyline(x, y)
+                end
+
+                if st == :path && (series[:fillrange] == nothing || series[:ribbon] != nothing)
+                    GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
                 end
 
                 if series[:markershape] != :none

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -272,6 +272,10 @@ function normalize_zvals(zv::AVec)
     end
 end
 
+
+gr_alpha(α::Void) = 1
+gr_alpha(α::Real) = α
+
 # ---------------------------------------------------------
 
 # draw ONE Shape
@@ -1042,6 +1046,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             if sp[:legendtitle] != nothing
                 GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_HALF)
                 gr_set_textcolor(sp[:foreground_color_legend])
+                GR.settransparency(1)
                 gr_text(xpos - 0.03 + 0.5*w, ypos, string(sp[:legendtitle]))
                 ypos -= dy
             end
@@ -1056,11 +1061,14 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     b, t = ypos-0.4dy, ypos+0.4dy
                     x = [l, r, r, l, l]
                     y = [b, b, t, t, b]
+                    GR.settransparency(gr_alpha(series[:fillalpha]))
                     gr_polyline(x, y, GR.fillarea)
+                    GR.settransparency(gr_alpha(series[:linealpha]))
                     st == :shape && gr_polyline(x, y)
                 end
 
                 if st == :path
+                    GR.settransparency(gr_alpha(series[:linealpha]))
                     if series[:fillrange] == nothing || series[:ribbon] != nothing
                         GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
                     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -493,8 +493,14 @@ function make_fillrange_from_ribbon(kw::KW)
     y, rib = kw[:y], kw[:ribbon]
     rib = wraptuple(rib)
     rib1, rib2 = -first(rib), last(rib)
-    kw[:ribbon] = nothing
+    # kw[:ribbon] = nothing
     kw[:fillrange] = make_fillrange_side(y, rib1), make_fillrange_side(y, rib2)
+end
+
+# check if series has a ribbon
+function has_ribbon(series::Series)
+    series[:ribbon] == nothing && return false
+    return series[:ribbon] > 0
 end
 
 function get_sp_lims(sp::Subplot, letter::Symbol)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -497,12 +497,6 @@ function make_fillrange_from_ribbon(kw::KW)
     kw[:fillrange] = make_fillrange_side(y, rib1), make_fillrange_side(y, rib2)
 end
 
-# check if series has a ribbon
-function has_ribbon(series::Series)
-    series[:ribbon] == nothing && return false
-    return series[:ribbon] > 0
-end
-
 function get_sp_lims(sp::Subplot, letter::Symbol)
     axis_limits(sp[Symbol(letter, :axis)])
 end


### PR DESCRIPTION
Resets the GR legend marker for plots with ribbons to the behaviour before #885.
```julia
using Plots; gr()
rib1, rib2, rib3, rib4 = 0.1, (0.1, 0.2), 0.1 * rand(10), (0.1 * rand(10), 0.2 * rand(10))
plot([plot(rand(10), ribbon = rib, fillalpha = 0.5) for rib in (rib1, rib2, rib3, rib4)]...)
```
produced these legend markers:
![ribbon_old](https://user-images.githubusercontent.com/16589944/28441198-ded83b44-6da9-11e7-835d-568f10101a64.png)

Now only lines are drawn again:
![ribbon_new](https://user-images.githubusercontent.com/16589944/28441212-f1163a0e-6da9-11e7-8763-b313ef8a356b.png)
