### PR TITLE
allow setting surface alpha in plotly(js) (fix #957)

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -508,6 +508,7 @@ function plotly_series(plt::Plot, series::Series)
             d_out[:showscale] = false
         else
             d_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
+            d_out[:opacity] = series[:fillalpha]
             if series[:fill_z] != nothing
                 d_out[:surfacecolor] = plotly_surface_data(series, series[:fill_z])
             end


### PR DESCRIPTION
```julia
using Plots; plotlyjs()
surface(rand(10, 10), alpha = 0.5)
```

![plotly_surf_alpha](https://user-images.githubusercontent.com/16589944/28442760-48d47a96-6db2-11e7-94b7-41337f4f4b77.png)
