### PR TITLE
don't use pywrap

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -70,18 +70,18 @@ function _initialize_backend(::PyPlotBackend)
         append!(Base.Multimedia.displays, otherdisplays)
 
         export PyPlot
-        const pycolors = PyPlot.pywrap(PyPlot.pyimport("matplotlib.colors"))
-        const pypath = PyPlot.pywrap(PyPlot.pyimport("matplotlib.path"))
-        const mplot3d = PyPlot.pywrap(PyPlot.pyimport("mpl_toolkits.mplot3d"))
-        const pypatches = PyPlot.pywrap(PyPlot.pyimport("matplotlib.patches"))
-        const pyfont = PyPlot.pywrap(PyPlot.pyimport("matplotlib.font_manager"))
-        const pyticker = PyPlot.pywrap(PyPlot.pyimport("matplotlib.ticker"))
-        const pycmap = PyPlot.pywrap(PyPlot.pyimport("matplotlib.cm"))
-        const pynp = PyPlot.pywrap(PyPlot.pyimport("numpy"))
-        pynp.seterr(invalid="ignore")
-        const pytransforms = PyPlot.pywrap(PyPlot.pyimport("matplotlib.transforms"))
-        const pycollections = PyPlot.pywrap(PyPlot.pyimport("matplotlib.collections"))
-        const pyart3d = PyPlot.pywrap(PyPlot.pyimport("mpl_toolkits.mplot3d.art3d"))
+        const pycolors = PyPlot.pyimport("matplotlib.colors")
+        const pypath = PyPlot.pyimport("matplotlib.path")
+        const mplot3d = PyPlot.pyimport("mpl_toolkits.mplot3d")
+        const pypatches = PyPlot.pyimport("matplotlib.patches")
+        const pyfont = PyPlot.pyimport("matplotlib.font_manager")
+        const pyticker = PyPlot.pyimport("matplotlib.ticker")
+        const pycmap = PyPlot.pyimport("matplotlib.cm")
+        const pynp = PyPlot.pyimport("numpy")
+        pynp["seterr"](invalid="ignore")
+        const pytransforms = PyPlot.pyimport("matplotlib.transforms")
+        const pycollections = PyPlot.pyimport("matplotlib.collections")
+        const pyart3d = PyPlot.pyimport("mpl_toolkits.mplot3d.art3d")
 
         # we don't want every command to update the figure
         PyPlot.ioff()
@@ -118,7 +118,7 @@ py_color(grad::ColorGradient) = py_color(grad.colors)
 
 function py_colormap(grad::ColorGradient)
     pyvals = [(z, py_color(grad[z])) for z in grad.values]
-    cm = pycolors.LinearSegmentedColormap[:from_list]("tmp", pyvals)
+    cm = pycolors["LinearSegmentedColormap"][:from_list]("tmp", pyvals)
     cm[:set_bad](color=(0,0,0,0.0), alpha=0.0)
     cm
 end
@@ -256,7 +256,7 @@ function labelfunc(scale::Symbol, backend::PyPlotBackend)
 end
 
 function py_mask_nans(z)
-    # PyPlot.pywrap(pynp.ma[:masked_invalid](PyPlot.pywrap(z)))
+    # pynp.ma[:masked_invalid](z)))
     PyCall.pycall(pynp.ma[:masked_invalid], Any, z)
     # pynp.ma[:masked_where](pynp.isnan(z),z)
 end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -101,7 +101,7 @@ end
 
 # function py_colormap(c::ColorGradient, α=nothing)
 #     pyvals = [(v, py_color(getColorZ(c, v), α)) for v in c.values]
-#     pycolors.pymember("LinearSegmentedColormap")[:from_list]("tmp", pyvals)
+#     pycolors["LinearSegmentedColormap"][:from_list]("tmp", pyvals)
 # end
 
 # # convert vectors and ColorVectors to standard ColorGradients
@@ -127,7 +127,7 @@ py_colormap(c) = py_colormap(cgrad())
 
 function py_shading(c, z)
     cmap = py_colormap(c)
-    ls = pycolors.pymember("LightSource")(270,45)
+    ls = pycolors["LightSource"](270,45)
     ls[:shade](z, cmap, vert_exag=0.1, blend_mode="soft")
 end
 
@@ -151,7 +151,7 @@ function py_marker(marker::Shape)
         mat[i,2] = y[i]
     end
     mat[n+1,:] = mat[1,:]
-    pypath.pymember("Path")(mat)
+    pypath["Path"](mat)
 end
 
 const _path_MOVETO = UInt8(1)
@@ -177,7 +177,7 @@ const _path_CLOSEPOLY = UInt8(79)
 #         lastnan = nan
 #     end
 #     codes[n+1] = _path_CLOSEPOLY
-#     pypath.pymember("Path")(mat, codes)
+#     pypath["Path"](mat, codes)
 # end
 
 # get the marker shape
@@ -227,14 +227,14 @@ end
 
 # # untested... return a FontProperties object from a Plots.Font
 # function py_font(font::Font)
-#     pyfont.pymember("FontProperties")(
+#     pyfont["FontProperties"](
 #         family = font.family,
 #         size = font.size
 #     )
 # end
 
 function get_locator_and_formatter(vals::AVec)
-    pyticker.pymember("FixedLocator")(1:length(vals)), pyticker.pymember("FixedFormatter")(vals)
+    pyticker["FixedLocator"](1:length(vals)), pyticker["FixedFormatter"](vals)
 end
 
 function add_pyfixedformatter(cbar, vals::AVec)
@@ -256,9 +256,9 @@ function labelfunc(scale::Symbol, backend::PyPlotBackend)
 end
 
 function py_mask_nans(z)
-    # pynp.ma[:masked_invalid](z)))
-    PyCall.pycall(pynp.ma[:masked_invalid], Any, z)
-    # pynp.ma[:masked_where](pynp.isnan(z),z)
+    # pynp["ma"][:masked_invalid](z)))
+    PyCall.pycall(pynp["ma"][:masked_invalid], Any, z)
+    # pynp["ma"][:masked_where](pynp["isnan"](z),z)
 end
 
 # ---------------------------------------------------------------------------
@@ -489,7 +489,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     extrakw = KW()
                     isfinite(clims[1]) && (extrakw[:vmin] = clims[1])
                     isfinite(clims[2]) && (extrakw[:vmax] = clims[2])
-                    kw[:norm] = pycolors.Normalize(; extrakw...)
+                    kw[:norm] = pycolors["Normalize"](; extrakw...)
                 end
                 lz = collect(series[:line_z])
                 handle = if is3d(st)
@@ -500,7 +500,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     # for i=1:n
                     #     segments[i] = [(_cycle(x,i), _cycle(y,i), _cycle(z,i)), (_cycle(x,i+1), _cycle(y,i+1), _cycle(z,i+1))]
                     # end
-                    lc = pyart3d.Line3DCollection(segments; kw...)
+                    lc = pyart3d["Line3DCollection"](segments; kw...)
                     lc[:set_array](lz)
                     ax[:add_collection3d](lc, zs=z) #, zdir='y')
                     lc
@@ -512,7 +512,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     # for i=1:n
                     #     segments[i] = [(_cycle(x,i), _cycle(y,i)), (_cycle(x,i+1), _cycle(y,i+1))]
                     # end
-                    lc = pycollections.LineCollection(segments; kw...)
+                    lc = pycollections["LineCollection"](segments; kw...)
                     lc[:set_array](lz)
                     ax[:add_collection](lc)
                     lc
@@ -797,8 +797,8 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         handle = []
         for (i,rng) in enumerate(iter_segments(x, y))
             if length(rng) > 1
-                path = pypath.pymember("Path")(hcat(x[rng], y[rng]))
-                patches = pypatches.pymember("PathPatch")(
+                path = pypath["Path"](hcat(x[rng], y[rng]))
+                patches = pypatches["PathPatch"](
                     path;
                     label = series[:label],
                     zorder = series[:series_plotindex],


### PR DESCRIPTION
As explained in #983, this eliminates the `pywrap` calls from the PyPlot backend initialization.  On my machine, this cuts the time for `Plots.pyplot()` down from 12 seconds to 6.5 seconds.