### PR TITLE
RFC: fix markershape in recipes

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -706,6 +706,9 @@ function preprocessArgs!(d::KW)
     delete!(d, :marker)
     if haskey(d, :markershape)
         d[:markershape] = _replace_markershape(d[:markershape])
+        if d[:markershape] == :none && d[:seriestype] in (:scatter, :scatterbins, :scatterhist, :scatter3d) #the default should be :auto, not :none, so that :none can be set explicitly and would be respected
+            d[:markershape] = :circle
+        end
     elseif anymarker
         d[:markershape_to_add] = :circle  # add it after _apply_recipe
     end


### PR DESCRIPTION
This fixes a bug in recipes, where if a series recipe defines `seriestype := scatter`, the markers will not be shown. This is because the default value of `markershape` is `:none`, which is changed to `:circle` in `add_defaults` if the seriestype is a `:scatter` type, but `add_defaults` is called before series recipes are processed. This behaviour requires the recipe to define markershape manually, as e.g. here: [https://github.com/JuliaPlots/StatPlots.jl/blob/master/src/boxplot.jl#L94-L96](https://github.com/JuliaPlots/StatPlots.jl/blob/master/src/boxplot.jl#L94-L96) , which is really confusing and shouldn't be necessary.
A problem with the suggested solution (which also exists now, but at least isn't fixed by this solution) is that you can't define `scatter` then turn off markers (which could perhaps sometimes be smart to do, e.g. for fixing the coordinates of `series_annotations`.