### PR TITLE
grid should be axis attribute (fix #675)

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -215,8 +215,8 @@ xflip!(flip::Bool = true; kw...)                          = plot!(; xflip = flip
 yflip!(flip::Bool = true; kw...)                          = plot!(; yflip = flip, kw...)
 xaxis!(args...; kw...)                                    = plot!(; xaxis = args, kw...)
 yaxis!(args...; kw...)                                    = plot!(; yaxis = args, kw...)
-xgrid!(grid::Bool = true; kw...)                          = plot!(; xgrid = grid, kw...)
-ygrid!(grid::Bool = true; kw...)                          = plot!(; ygrid = grid, kw...)
+xgrid!(args...; kw...)                                    = plot!(; xgrid = args, kw...)
+ygrid!(args...; kw...)                                    = plot!(; ygrid = args, kw...)
 
 let PlotOrSubplot = Union{Plot, Subplot}
     title!(plt::PlotOrSubplot, s::AbstractString; kw...)                  = plot!(plt; title = s, kw...)

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -234,8 +234,8 @@ let PlotOrSubplot = Union{Plot, Subplot}
                               ticks::AVec{T}, labels::AVec{S}; kw...)     = plot!(plt; xticks = (ticks,labels), kw...)
     yticks!{T<:Real,S<:AbstractString}(plt::PlotOrSubplot,
                               ticks::AVec{T}, labels::AVec{S}; kw...)     = plot!(plt; yticks = (ticks,labels), kw...)
-    xgrid!(plt::PlotOrSubplot, grid::Bool = true; kw...)                  = plot!(plt; xgrid = grid, kw...)
-    ygrid!(plt::PlotOrSubplot, grid::Bool = true; kw...)                  = plot!(plt; ygrid = grid, kw...)
+    xgrid!(plt::PlotOrSubplot, args...; kw...)                  = plot!(plt; xgrid = args, kw...)
+    ygrid!(plt::PlotOrSubplot, args...; kw...)                  = plot!(plt; ygrid = args, kw...)
     annotate!(plt::PlotOrSubplot, anns...; kw...)                         = plot!(plt; annotation = anns, kw...)
     annotate!{T<:Tuple}(plt::PlotOrSubplot, anns::AVec{T}; kw...)         = plot!(plt; annotation = anns, kw...)
     xflip!(plt::PlotOrSubplot, flip::Bool = true; kw...)                  = plot!(plt; xflip = flip, kw...)

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -52,6 +52,8 @@ export
     yflip!,
     xaxis!,
     yaxis!,
+    xgrid!,
+    ygrid!,
 
     xlims,
     ylims,
@@ -213,6 +215,8 @@ xflip!(flip::Bool = true; kw...)                          = plot!(; xflip = flip
 yflip!(flip::Bool = true; kw...)                          = plot!(; yflip = flip, kw...)
 xaxis!(args...; kw...)                                    = plot!(; xaxis = args, kw...)
 yaxis!(args...; kw...)                                    = plot!(; yaxis = args, kw...)
+xgrid!(grid::Bool = true; kw...)                          = plot!(; xgrid = grid, kw...)
+ygrid!(grid::Bool = true; kw...)                          = plot!(; ygrid = grid, kw...)
 
 let PlotOrSubplot = Union{Plot, Subplot}
     title!(plt::PlotOrSubplot, s::AbstractString; kw...)                  = plot!(plt; title = s, kw...)
@@ -230,6 +234,8 @@ let PlotOrSubplot = Union{Plot, Subplot}
                               ticks::AVec{T}, labels::AVec{S}; kw...)     = plot!(plt; xticks = (ticks,labels), kw...)
     yticks!{T<:Real,S<:AbstractString}(plt::PlotOrSubplot,
                               ticks::AVec{T}, labels::AVec{S}; kw...)     = plot!(plt; yticks = (ticks,labels), kw...)
+    xgrid!(plt::PlotOrSubplot, grid::Bool = true; kw...)                  = plot!(plt; xgrid = grid, kw...)
+    ygrid!(plt::PlotOrSubplot, grid::Bool = true; kw...)                  = plot!(plt; ygrid = grid, kw...)
     annotate!(plt::PlotOrSubplot, anns...; kw...)                         = plot!(plt; annotation = anns, kw...)
     annotate!{T<:Tuple}(plt::PlotOrSubplot, anns::AVec{T}; kw...)         = plot!(plt; annotation = anns, kw...)
     xflip!(plt::PlotOrSubplot, flip::Bool = true; kw...)                  = plot!(plt; xflip = flip, kw...)

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -84,7 +84,6 @@ const _arg_desc = KW(
 :colorbar                 => "Bool (show the colorbar?) or Symbol (colorbar position).  Symbol values: `:none`, `:best`, `:right`, `:left`, `:top`, `:bottom`, `:legend` (matches legend value) (note: only some may be supported in each backend)",
 :clims 					  => "`:auto` or NTuple{2,Number}.  Fixes the limits of the colorbar.",
 :legendfont               => "Font. Font of legend items.",
-:grid                     => "Bool. Show the grid lines?",
 :annotations              => "(x,y,text) tuple(s).  Can be a single tuple or a list of them.  Text can be String or PlotText (created with `text(args...)`)  Add one-off text annotations at the x,y coordinates.",
 :projection               => "Symbol or String.  '3d' or 'polar'",
 :aspect_ratio             => "Symbol (:equal) or Number. Plot area is resized so that 1 y-unit is the same size as `apect_ratio` x-units.",
@@ -111,5 +110,6 @@ const _arg_desc = KW(
 :foreground_color_text    => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of tick labels.",
 :foreground_color_guide   => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of axis guides (axis labels).",
 :mirror                   => "Bool.  Switch the side of the tick labels (right or top).",
+:grid                     => "Bool. Show the grid lines?",
 
 )

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -76,7 +76,6 @@ const _arg_desc = KW(
 :background_color_inside  => "Color Type or `:match` (matches `:background_color_subplot`).  Background color inside the plot area (under the grid).",
 :foreground_color_subplot => "Color Type or `:match` (matches `:foreground_color`).  Base foreground color of the subplot.",
 :foreground_color_legend  => "Color Type or `:match` (matches `:foreground_color_subplot`).  Foreground color of the legend.",
-:foreground_color_grid    => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of grid lines.",
 :foreground_color_title   => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of subplot title.",
 :color_palette            => "Vector of colors (cycle through) or color gradient (generate list from gradient) or `:auto` (generate a color list using `Colors.distiguishable_colors` and custom seed colors chosen to contrast with the background).  The color palette is a color list from which series colors are automatically chosen.",
 :legend                   => "Bool (show the legend?) or Symbol (legend position).  Symbol values: `:none`, `:best`, `:right`, `:left`, `:top`, `:bottom`, `:inside`, `:legend`, `:topright`, `:topleft`, `:bottomleft`, `:bottomright` (note: only some may be supported in each backend)",
@@ -110,6 +109,9 @@ const _arg_desc = KW(
 :foreground_color_text    => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of tick labels.",
 :foreground_color_guide   => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of axis guides (axis labels).",
 :mirror                   => "Bool.  Switch the side of the tick labels (right or top).",
-:grid                     => "Bool. Show the grid lines?",
-
+:grid                     => "Bool, Symbol, String or `nothing`. Show the grid lines? `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:none`, `:off`",
+:foreground_color_grid    => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of grid lines.",
+:gridalpha                => "Number in [0,1]. The alpha/opacity override for the grid lines.",
+:gridstyle                => "Symbol. Style of the grid lines. Choose from $(_allStyles)",
+:gridlinewidth            => "Number. Width of the grid lines (in pixels)",
 )

--- a/src/args.jl
+++ b/src/args.jl
@@ -943,7 +943,6 @@ const _match_map = KW(
     :background_color_legend  => :background_color_subplot,
     :background_color_inside  => :background_color_subplot,
     :foreground_color_legend  => :foreground_color_subplot,
-    :foreground_color_grid    => :foreground_color_subplot,
     :foreground_color_title   => :foreground_color_subplot,
     :left_margin   => :margin,
     :top_margin    => :margin,
@@ -957,6 +956,7 @@ const _match_map2 = KW(
     :foreground_color_subplot => :foreground_color,
     :foreground_color_axis    => :foreground_color_subplot,
     :foreground_color_border  => :foreground_color_subplot,
+    :foreground_color_grid    => :foreground_color_subplot,
     :foreground_color_guide   => :foreground_color_subplot,
     :foreground_color_text    => :foreground_color_subplot,
 )
@@ -1091,7 +1091,6 @@ function _update_subplot_colors(sp::Subplot)
     # foreground colors
     color_or_nothing!(sp.attr, :foreground_color_subplot)
     color_or_nothing!(sp.attr, :foreground_color_legend)
-    color_or_nothing!(sp.attr, :foreground_color_grid)
     color_or_nothing!(sp.attr, :foreground_color_title)
     return
 end
@@ -1143,6 +1142,7 @@ function _update_axis_colors(axis::Axis)
     color_or_nothing!(axis.d, :foreground_color_border)
     color_or_nothing!(axis.d, :foreground_color_guide)
     color_or_nothing!(axis.d, :foreground_color_text)
+    color_or_nothing!(axis.d, :foreground_color_grid)
     return
 end
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -247,7 +247,6 @@ const _subplot_defaults = KW(
     :background_color_inside  => :match,            # background inside grid
     :foreground_color_subplot => :match,            # default for other fg colors... match takes plot default
     :foreground_color_legend  => :match,            # foreground of legend
-    :foreground_color_grid    => :match,            # grid color
     :foreground_color_title   => :match,            # title color
     :color_palette            => :auto,
     :legend                   => :best,
@@ -255,7 +254,6 @@ const _subplot_defaults = KW(
     :colorbar                 => :legend,
     :clims                    => :auto,
     :legendfont               => font(8),
-    :grid                     => true,
     :annotations              => [],                # annotation tuples... list of (x,y,annotation)
     :projection               => :none,             # can also be :polar or :3d
     :aspect_ratio             => :none,             # choose from :none or :equal
@@ -285,6 +283,8 @@ const _axis_defaults = KW(
     :discrete_values => [],
     :formatter => :auto,
     :mirror => false,
+    :grid                     => true,
+    :foreground_color_grid    => :match,            # grid color
 )
 
 const _suppress_warnings = Set{Symbol}([

--- a/src/args.jl
+++ b/src/args.jl
@@ -168,7 +168,7 @@ const _allGridSyms = [:x, :y, :z,
                     :xyz, :xzy, :yxz, :yzx, :zxy, :zyx,
                     :all, :both, :on,
                     :none, :off,]
-const _allGridArgs = [_allGridSyms; string.(_allGridSyms); nothing; false; true]
+const _allGridArgs = [_allGridSyms; string.(_allGridSyms); nothing]
 hasgrid(arg::Void, letter) = false
 hasgrid(arg::Bool, letter) = arg
 function hasgrid(arg::Symbol, letter)
@@ -671,7 +671,7 @@ end
 
 
 function processGridArg!(d::KW, arg, letter)
-    if arg in _allGridArgs
+    if arg in _allGridArgs || isa(arg, Bool)
         d[Symbol(letter, :grid)] = hasgrid(arg, letter)
 
     elseif allStyles(arg)

--- a/src/args.jl
+++ b/src/args.jl
@@ -175,7 +175,7 @@ function hasgrid(arg::Symbol, letter)
     if arg in _allGridSyms
         arg in (:all, :both, :on) || contains(string(arg), string(letter))
     else
-        warn("Unknown grid argument $arg; $letter\grid was set to `true` instead")
+        warn("Unknown grid argument $arg; $letter\grid was set to `true` instead.")
         true
     end
 end
@@ -303,9 +303,9 @@ const _axis_defaults = KW(
     :mirror => false,
     :grid                     => true,
     :foreground_color_grid    => :match,            # grid color
-    :gridalpha                => 0.3,
-    :gridstyle                => :dot,
-    :gridlinewidth                => 1,
+    :gridalpha                => 0.1,
+    :gridstyle                => :solid,
+    :gridlinewidth            => 0.5,
 )
 
 const _suppress_warnings = Set{Symbol}([

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -490,38 +490,50 @@ function axis_drawing_info(sp::Subplot)
     ymin, ymax = axis_limits(yaxis)
     xticks = get_ticks(xaxis)
     yticks = get_ticks(yaxis)
-    spine_segs = Segments(2)
-    grid_segs = Segments(2)
+    xspine_segs = Segments(2)
+    yspine_segs = Segments(2)
+    xgrid_segs = Segments(2)
+    ygrid_segs = Segments(2)
+
+    f = scalefunc(yaxis[:scale])
+    invf = invscalefunc(yaxis[:scale])
+    t1 = invf(f(ymin) + 0.015*(f(ymax)-f(ymin)))
+    t2 = invf(f(ymax) - 0.015*(f(ymax)-f(ymin)))
 
     if !(xaxis[:ticks] in (nothing, false))
-        f = scalefunc(yaxis[:scale])
-        invf = invscalefunc(yaxis[:scale])
-        t1 = invf(f(ymin) + 0.015*(f(ymax)-f(ymin)))
-        t2 = invf(f(ymax) - 0.015*(f(ymax)-f(ymin)))
-
-        push!(spine_segs, (xmin,ymin), (xmax,ymin)) # bottom spine
-        # push!(spine_segs, (xmin,ymax), (xmax,ymax)) # top spine
+        push!(xspine_segs, (xmin,ymin), (xmax,ymin)) # bottom spine
+        # push!(xspine_segs, (xmin,ymax), (xmax,ymax)) # top spine
         for xtick in xticks[1]
-            push!(spine_segs, (xtick, ymin), (xtick, t1)) # bottom tick
-            push!(grid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
-            # push!(spine_segs, (xtick, ymax), (xtick, t2)) # top tick
+            push!(xspine_segs, (xtick, ymin), (xtick, t1)) # bottom tick
+            # push!(xspine_segs, (xtick, ymax), (xtick, t2)) # top tick
         end
     end
+
+    if !(xaxis[:grid] in (nothing, false))
+        for xtick in xticks[1]
+            push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
+        end
+    end
+
+    f = scalefunc(xaxis[:scale])
+    invf = invscalefunc(xaxis[:scale])
+    t1 = invf(f(xmin) + 0.015*(f(xmax)-f(xmin)))
+    t2 = invf(f(xmax) - 0.015*(f(xmax)-f(xmin)))
 
     if !(yaxis[:ticks] in (nothing, false))
-        f = scalefunc(xaxis[:scale])
-        invf = invscalefunc(xaxis[:scale])
-        t1 = invf(f(xmin) + 0.015*(f(xmax)-f(xmin)))
-        t2 = invf(f(xmax) - 0.015*(f(xmax)-f(xmin)))
-
-        push!(spine_segs, (xmin,ymin), (xmin,ymax)) # left spine
-        # push!(spine_segs, (xmax,ymin), (xmax,ymax)) # right spine
+        push!(yspine_segs, (xmin,ymin), (xmin,ymax)) # left spine
+        # push!(yspine_segs, (xmax,ymin), (xmax,ymax)) # right spine
         for ytick in yticks[1]
-            push!(spine_segs, (xmin, ytick), (t1, ytick)) # left tick
-            push!(grid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
-            # push!(spine_segs, (xmax, ytick), (t2, ytick)) # right tick
+            push!(yspine_segs, (xmin, ytick), (t1, ytick)) # left tick
+            # push!(yspine_segs, (xmax, ytick), (t2, ytick)) # right tick
         end
     end
 
-    xticks, yticks, spine_segs, grid_segs
+    if !(yaxis[:grid] in (nothing, false))
+        for ytick in yticks[1]
+            push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
+        end
+    end
+
+    xticks, yticks, xspine_segs, yspine_segs, xgrid_segs, ygrid_segs
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -495,43 +495,33 @@ function axis_drawing_info(sp::Subplot)
     xgrid_segs = Segments(2)
     ygrid_segs = Segments(2)
 
-    f = scalefunc(yaxis[:scale])
-    invf = invscalefunc(yaxis[:scale])
-    t1 = invf(f(ymin) + 0.015*(f(ymax)-f(ymin)))
-    t2 = invf(f(ymax) - 0.015*(f(ymax)-f(ymin)))
-
     if !(xaxis[:ticks] in (nothing, false))
+        f = scalefunc(yaxis[:scale])
+        invf = invscalefunc(yaxis[:scale])
+        t1 = invf(f(ymin) + 0.015*(f(ymax)-f(ymin)))
+        t2 = invf(f(ymax) - 0.015*(f(ymax)-f(ymin)))
+
         push!(xspine_segs, (xmin,ymin), (xmax,ymin)) # bottom spine
         # push!(xspine_segs, (xmin,ymax), (xmax,ymax)) # top spine
         for xtick in xticks[1]
             push!(xspine_segs, (xtick, ymin), (xtick, t1)) # bottom tick
             # push!(xspine_segs, (xtick, ymax), (xtick, t2)) # top tick
+            !(xaxis[:grid] in (nothing, false)) && push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
         end
     end
-
-    if !(xaxis[:grid] in (nothing, false))
-        for xtick in xticks[1]
-            push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
-        end
-    end
-
-    f = scalefunc(xaxis[:scale])
-    invf = invscalefunc(xaxis[:scale])
-    t1 = invf(f(xmin) + 0.015*(f(xmax)-f(xmin)))
-    t2 = invf(f(xmax) - 0.015*(f(xmax)-f(xmin)))
 
     if !(yaxis[:ticks] in (nothing, false))
+        f = scalefunc(xaxis[:scale])
+        invf = invscalefunc(xaxis[:scale])
+        t1 = invf(f(xmin) + 0.015*(f(xmax)-f(xmin)))
+        t2 = invf(f(xmax) - 0.015*(f(xmax)-f(xmin)))
+
         push!(yspine_segs, (xmin,ymin), (xmin,ymax)) # left spine
         # push!(yspine_segs, (xmax,ymin), (xmax,ymax)) # right spine
         for ytick in yticks[1]
             push!(yspine_segs, (xmin, ytick), (t1, ytick)) # left tick
             # push!(yspine_segs, (xmax, ytick), (t2, ytick)) # right tick
-        end
-    end
-
-    if !(yaxis[:grid] in (nothing, false))
-        for ytick in yticks[1]
-            push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
+            !(yaxis[:grid] in (nothing, false)) && push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
         end
     end
 

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -506,7 +506,7 @@ function axis_drawing_info(sp::Subplot)
         for xtick in xticks[1]
             push!(xspine_segs, (xtick, ymin), (xtick, t1)) # bottom tick
             # push!(xspine_segs, (xtick, ymax), (xtick, t2)) # top tick
-            !(xaxis[:grid] in (nothing, false)) && push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
+            xaxis[:grid] && push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
         end
     end
 
@@ -521,7 +521,7 @@ function axis_drawing_info(sp::Subplot)
         for ytick in yticks[1]
             push!(yspine_segs, (xmin, ytick), (t1, ytick)) # left tick
             # push!(yspine_segs, (xmax, ytick), (t2, ytick)) # right tick
-            !(yaxis[:grid] in (nothing, false)) && push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
+            yaxis[:grid] && push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
         end
     end
 

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -24,7 +24,8 @@ const _glvisualize_attr = merge_with_base_supported([
     :window_title,
     :guide, :lims, :ticks, :scale, :flip, :rotation,
     :tickfont, :guidefont, :legendfont,
-    :grid, :legend, :colorbar,
+    :grid, :gridalpha, :gridstyle, :gridlinewidth,
+    :legend, :colorbar,
     :marker_z,
     :line_z,
     :levels,
@@ -682,12 +683,12 @@ function gl_draw_axes_2d(sp::Plots.Subplot{Plots.GLVisualizeBackend}, model, are
     xgc = Colors.color(Plots.gl_color(xaxis[:foreground_color_grid]))
     ygc = Colors.color(Plots.gl_color(yaxis[:foreground_color_grid]))
     axis_vis = []
-    if !(xaxis[:grid] in (nothing, false))
-        grid = draw_grid_lines(sp, xgrid_segs, 1f0, :dot, model, RGBA(xgc, 0.3f0))
+    if xaxis[:grid]
+        grid = draw_grid_lines(sp, xgrid_segs, xaxis[:gridlinewidth], xaxis[:gridstyle], model, RGBA(xgc, xaxis[:gridalpha]))
         push!(axis_vis, grid)
     end
-    if !(yaxis[:grid] in (nothing, false))
-        grid = draw_grid_lines(sp, ygrid_segs, 1f0, :dot, model, RGBA(ygc, 0.3f0))
+    if yaxis[:grid]
+        grid = draw_grid_lines(sp, ygrid_segs, yaxis[:gridlinewidth], yaxis[:gridstyle], model, RGBA(ygc, yaxis[:gridalpha]))
         push!(axis_vis, grid)
     end
 

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -676,17 +676,29 @@ function text_model(font, pivot)
     end
 end
 function gl_draw_axes_2d(sp::Plots.Subplot{Plots.GLVisualizeBackend}, model, area)
-    xticks, yticks, spine_segs, grid_segs = Plots.axis_drawing_info(sp)
+    xticks, yticks, xspine_segs, yspine_segs, xgrid_segs, ygrid_segs = Plots.axis_drawing_info(sp)
     xaxis = sp[:xaxis]; yaxis = sp[:yaxis]
 
-    c = Colors.color(Plots.gl_color(sp[:foreground_color_grid]))
+    xgc = Colors.color(Plots.gl_color(xaxis[:foreground_color_grid]))
+    ygc = Colors.color(Plots.gl_color(yaxis[:foreground_color_grid]))
     axis_vis = []
-    if sp[:grid]
-        grid = draw_grid_lines(sp, grid_segs, 1f0, :dot, model, RGBA(c, 0.3f0))
+    if !(xaxis[:grid] in (nothing, false))
+        grid = draw_grid_lines(sp, xgrid_segs, 1f0, :dot, model, RGBA(xgc, 0.3f0))
         push!(axis_vis, grid)
     end
-    if alpha(xaxis[:foreground_color_border]) > 0
-        spine = draw_grid_lines(sp, spine_segs, 1f0, :solid, model, RGBA(c, 1.0f0))
+    if !(yaxis[:grid] in (nothing, false))
+        grid = draw_grid_lines(sp, ygrid_segs, 1f0, :dot, model, RGBA(ygc, 0.3f0))
+        push!(axis_vis, grid)
+    end
+
+    xac = Colors.color(Plots.gl_color(xaxis[:foreground_color_axis]))
+    yac = Colors.color(Plots.gl_color(yaxis[:foreground_color_axis]))
+    if alpha(xaxis[:foreground_color_axis]) > 0
+        spine = draw_grid_lines(sp, xspine_segs, 1f0, :solid, model, RGBA(xac, 1.0f0))
+        push!(axis_vis, spine)
+    end
+    if alpha(yaxis[:foreground_color_axis]) > 0
+        spine = draw_grid_lines(sp, yspine_segs, 1f0, :solid, model, RGBA(yac, 1.0f0))
         push!(axis_vis, spine)
     end
     fcolor = Plots.gl_color(xaxis[:foreground_color_axis])

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -691,10 +691,10 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         ticksize = 0.01 * (viewport_plotarea[2] - viewport_plotarea[1])
 
         # GR.setlinetype(GR.LINETYPE_DOTTED)
-        if sp[:grid]
-            GR.grid3d(xtick, 0, ztick, xmin, ymax, zmin, 2, 0, 2)
-            GR.grid3d(0, ytick, 0, xmin, ymax, zmin, 0, 2, 0)
-        end
+        # if sp[:grid]
+        GR.grid3d(xtick, 0, ztick, xmin, ymax, zmin, 2, 0, 2)
+        GR.grid3d(0, ytick, 0, xmin, ymax, zmin, 0, 2, 0)
+        # end
         GR.axes3d(xtick, 0, ztick, xmin, ymin, zmin, 2, 0, 2, -ticksize)
         GR.axes3d(0, ytick, 0, xmax, ymin, zmin, 0, 2, 0, ticksize)
 
@@ -709,23 +709,31 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             GR.setwindow(xmin, xmax, ymin, ymax)
         end
 
-        xticks, yticks, spine_segs, grid_segs = axis_drawing_info(sp)
+        xticks, yticks, xspine_segs, yspine_segs, xgrid_segs, ygrid_segs = axis_drawing_info(sp)
         # @show xticks yticks #spine_segs grid_segs
 
         # draw the grid lines
-        if sp[:grid]
+        if !(xaxis[:grid] in (nothing, false))
             # gr_set_linecolor(sp[:foreground_color_grid])
             # GR.grid(xtick, ytick, 0, 0, majorx, majory)
-            gr_set_line(1, :dot, sp[:foreground_color_grid])
+            gr_set_line(1, :dot, xaxis[:foreground_color_grid])
             GR.settransparency(0.5)
-            gr_polyline(coords(grid_segs)...)
+            gr_polyline(coords(xgrid_segs)...)
+        end
+        if !(yaxis[:grid] in (nothing, false))
+            gr_set_line(1, :dot, yaxis[:foreground_color_grid])
+            GR.settransparency(0.5)
+            gr_polyline(coords(ygrid_segs)...)
         end
         GR.settransparency(1.0)
 
         # spine (border) and tick marks
-        gr_set_line(1, :solid, sp[:xaxis][:foreground_color_axis])
+        gr_set_line(1, :solid, xaxis[:foreground_color_axis])
         GR.setclip(0)
-        gr_polyline(coords(spine_segs)...)
+        gr_polyline(coords(xspine_segs)...)
+        gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+        GR.setclip(0)
+        gr_polyline(coords(yspine_segs)...)
         GR.setclip(1)
 
         if !(xticks in (nothing, false))

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -691,10 +691,15 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         ticksize = 0.01 * (viewport_plotarea[2] - viewport_plotarea[1])
 
         # GR.setlinetype(GR.LINETYPE_DOTTED)
-        # if sp[:grid]
-        GR.grid3d(xtick, 0, ztick, xmin, ymax, zmin, 2, 0, 2)
-        GR.grid3d(0, ytick, 0, xmin, ymax, zmin, 0, 2, 0)
-        # end
+        if !(xaxis[:grid] in (nothing, false))
+            GR.grid3d(xtick, 0, 0, xmin, ymax, zmin, 2, 0, 0)
+        end
+        if !(yaxis[:grid] in (nothing, false))
+            GR.grid3d(0, ytick, 0, xmin, ymax, zmin, 0, 2, 0)
+        end
+        if !(zaxis[:grid] in (nothing, false))
+            GR.grid3d(0, 0, ztick, xmin, ymax, zmin, 0, 0, 2)
+        end
         GR.axes3d(xtick, 0, ztick, xmin, ymin, zmin, 2, 0, 2, -ticksize)
         GR.axes3d(0, ytick, 0, xmax, ymin, zmin, 0, 2, 0, ticksize)
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -20,7 +20,8 @@ const _gr_attr = merge_with_base_supported([
     :title, :window_title,
     :guide, :lims, :ticks, :scale, :flip,
     :tickfont, :guidefont, :legendfont,
-    :grid, :legend, :legendtitle, :colorbar,
+    :grid, :gridalpha, :gridstyle, :gridlinewidth,
+    :legend, :legendtitle, :colorbar,
     :marker_z, :levels,
     :ribbon, :quiver,
     :orientation,
@@ -691,15 +692,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         ticksize = 0.01 * (viewport_plotarea[2] - viewport_plotarea[1])
 
         # GR.setlinetype(GR.LINETYPE_DOTTED)
-        if !(xaxis[:grid] in (nothing, false))
-            GR.grid3d(xtick, 0, 0, xmin, ymax, zmin, 2, 0, 0)
-        end
-        if !(yaxis[:grid] in (nothing, false))
-            GR.grid3d(0, ytick, 0, xmin, ymax, zmin, 0, 2, 0)
-        end
-        if !(zaxis[:grid] in (nothing, false))
-            GR.grid3d(0, 0, ztick, xmin, ymax, zmin, 0, 0, 2)
-        end
+        xaxis[:grid] && GR.grid3d(xtick, 0, 0, xmin, ymax, zmin, 2, 0, 0)
+        yaxis[:grid] && GR.grid3d(0, ytick, 0, xmin, ymax, zmin, 0, 2, 0)
+        zaxis[:grid] && GR.grid3d(0, 0, ztick, xmin, ymax, zmin, 0, 0, 2)
         GR.axes3d(xtick, 0, ztick, xmin, ymin, zmin, 2, 0, 2, -ticksize)
         GR.axes3d(0, ytick, 0, xmax, ymin, zmin, 0, 2, 0, ticksize)
 
@@ -718,16 +713,16 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         # @show xticks yticks #spine_segs grid_segs
 
         # draw the grid lines
-        if !(xaxis[:grid] in (nothing, false))
+        if xaxis[:grid]
             # gr_set_linecolor(sp[:foreground_color_grid])
             # GR.grid(xtick, ytick, 0, 0, majorx, majory)
-            gr_set_line(1, :dot, xaxis[:foreground_color_grid])
-            GR.settransparency(0.5)
+            gr_set_line(xaxis[:gridlinewidth], xaxis[:gridstyle], xaxis[:foreground_color_grid])
+            GR.settransparency(xaxis[:gridalpha])
             gr_polyline(coords(xgrid_segs)...)
         end
-        if !(yaxis[:grid] in (nothing, false))
-            gr_set_line(1, :dot, yaxis[:foreground_color_grid])
-            GR.settransparency(0.5)
+        if yaxis[:grid]
+            gr_set_line(yaxis[:gridlinewidth], yaxis[:gridstyle], yaxis[:foreground_color_grid])
+            GR.settransparency(yaxis[:gridalpha])
             gr_polyline(coords(ygrid_segs)...)
         end
         GR.settransparency(1.0)

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -18,7 +18,8 @@ Add in functionality to Plots.jl:
 const _inspectdr_attr = merge_with_base_supported([
     :annotations,
     :background_color_legend, :background_color_inside, :background_color_outside,
-    :foreground_color_grid, :foreground_color_legend, :foreground_color_title,
+    # :foreground_color_grid,
+    :foreground_color_legend, :foreground_color_title,
     :foreground_color_axis, :foreground_color_border, :foreground_color_guide, :foreground_color_text,
     :label,
     :linecolor, :linestyle, :linewidth, :linealpha,
@@ -334,15 +335,18 @@ end
 # ---------------------------------------------------------------------------
 
 function _inspectdr_setupsubplot(sp::Subplot{InspectDRBackend})
-    const gridon = InspectDR.GridRect(vmajor=true, hmajor=true)
-    const gridoff = InspectDR.GridRect()
     const plot = sp.o
     const strip = plot.strips[1] #Only 1 strip supported with Plots.jl
 
-	#No independent control of grid???
-	strip.grid = sp[:grid]? gridon: gridoff
-
     xaxis = sp[:xaxis]; yaxis = sp[:yaxis]
+    xgrid_show = !(xaxis[:grid] in (nothing, false))
+    ygrid_show = !(yaxis[:grid] in (nothing, false))
+
+    strip.grid = InspectDR.GridRect(
+    	vmajor=xgrid_show, # vminor=xgrid_show,
+    	hmajor=ygrid_show, # hminor=ygrid_show,
+    )
+
         plot.xscale = _inspectdr_getscale(xaxis[:scale], false)
         strip.yscale = _inspectdr_getscale(yaxis[:scale], true)
         xmin, xmax  = axis_limits(xaxis)

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -339,8 +339,8 @@ function _inspectdr_setupsubplot(sp::Subplot{InspectDRBackend})
     const strip = plot.strips[1] #Only 1 strip supported with Plots.jl
 
     xaxis = sp[:xaxis]; yaxis = sp[:yaxis]
-    xgrid_show = !(xaxis[:grid] in (nothing, false))
-    ygrid_show = !(yaxis[:grid] in (nothing, false))
+    xgrid_show = xaxis[:grid]
+    ygrid_show = yaxis[:grid]
 
     strip.grid = InspectDR.GridRect(
     	vmajor=xgrid_show, # vminor=xgrid_show,

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -98,7 +98,7 @@ const _pgf_series_extrastyle = KW(
     :xsticks => "xcomb",
 )
 
-# PGFPlots uses the anchors to define orientations for example to align left 
+# PGFPlots uses the anchors to define orientations for example to align left
 # one needs to use the right edge as anchor
 const _pgf_annotation_halign = KW(
     :center => "",
@@ -121,7 +121,7 @@ function pgf_color(grad::ColorGradient)
 end
 
 # Generates a colormap for pgfplots based on a ColorGradient
-function pgf_colormap(grad::ColorGradient) 
+function pgf_colormap(grad::ColorGradient)
     join(map(grad.colors) do c
         @sprintf("rgb=(%.8f,%.8f,%.8f)", red(c), green(c),blue(c))
     end,", ")
@@ -266,6 +266,11 @@ function pgf_axis(sp::Subplot, letter)
         push!(style, "$(letter)majorticks=false")
     end
 
+    # grid on or off
+    if !(axis[:grid] in (nothing, false))
+        push!(style, "$(letter)majorgrids = true")
+    end
+
     # limits
     # TODO: support zlims
     if letter != :z
@@ -324,7 +329,6 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
             kw[:title] = "$(sp[:title])"
         end
 
-        sp[:grid] && push!(style, "grid = major")
         if sp[:aspect_ratio] in (1, :equal)
             kw[:axisEqual] = "true"
         end
@@ -360,7 +364,7 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
                         kw[:colorbar] = "true"
                     end
                     # goto is needed to break out of col and series for
-                    @goto colorbar_end 
+                    @goto colorbar_end
                 end
             end
         end

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -267,7 +267,7 @@ function pgf_axis(sp::Subplot, letter)
     end
 
     # grid on or off
-    if !(axis[:grid] in (nothing, false))
+    if axis[:grid]
         push!(style, "$(letter)majorgrids = true")
     end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -5,7 +5,8 @@ const _plotly_attr = merge_with_base_supported([
     :annotations,
     :background_color_legend, :background_color_inside, :background_color_outside,
     :foreground_color_legend, :foreground_color_guide,
-    # :foreground_color_grid, :foreground_color_axis,
+    :foreground_color_grid,
+    # :foreground_color_axis,
     :foreground_color_text, :foreground_color_border,
     :foreground_color_title,
     :label,
@@ -213,7 +214,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
     letter = axis[:letter]
     ax = KW(
         :title      => axis[:guide],
-        :showgrid   => sp[:grid],
+        :showgrid   => !(axis[:grid] in (nothing, false)),
         :zeroline   => false,
         :ticks      => "inside",
     )
@@ -230,7 +231,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:type] = plotly_scale(axis[:scale])
         ax[:tickfont] = plotly_font(axis[:tickfont], axis[:foreground_color_text])
         ax[:tickcolor] = rgba_string(axis[:foreground_color_border])
-        ax[:linecolor] = rgba_string(axis[:foreground_color_border])
+        ax[:linecolor] = rgba_string(axis[:foreground_color_grid])
 
         # lims
         lims = axis[:lims]

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -5,7 +5,7 @@ const _plotly_attr = merge_with_base_supported([
     :annotations,
     :background_color_legend, :background_color_inside, :background_color_outside,
     :foreground_color_legend, :foreground_color_guide,
-    :foreground_color_grid, :foreground_color_axis,
+    # :foreground_color_grid, :foreground_color_axis,
     :foreground_color_text, :foreground_color_border,
     :foreground_color_title,
     :label,
@@ -213,7 +213,6 @@ function plotly_axis(axis::Axis, sp::Subplot)
     letter = axis[:letter]
     ax = KW(
         :title      => axis[:guide],
-        :gridcolor  => rgba_string(axis[:foreground_color_grid]),
         :showgrid   => !(axis[:grid] in (nothing, false)),
         :zeroline   => false,
         :ticks      => "inside",
@@ -230,8 +229,8 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:titlefont] = plotly_font(axis[:guidefont], axis[:foreground_color_guide])
         ax[:type] = plotly_scale(axis[:scale])
         ax[:tickfont] = plotly_font(axis[:tickfont], axis[:foreground_color_text])
-        ax[:tickcolor] = rgba_string(axis[:foreground_color_axis])
-        ax[:linecolor] = rgba_string(axis[:foreground_color_axis])
+        ax[:tickcolor] = rgba_string(axis[:foreground_color_border])
+        ax[:linecolor] = rgba_string(axis[:foreground_color_border])
 
         # lims
         lims = axis[:lims]

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -5,7 +5,7 @@ const _plotly_attr = merge_with_base_supported([
     :annotations,
     :background_color_legend, :background_color_inside, :background_color_outside,
     :foreground_color_legend, :foreground_color_guide,
-    # :foreground_color_grid, :foreground_color_axis,
+    :foreground_color_grid, :foreground_color_axis,
     :foreground_color_text, :foreground_color_border,
     :foreground_color_title,
     :label,
@@ -19,7 +19,8 @@ const _plotly_attr = merge_with_base_supported([
     :window_title,
     :guide, :lims, :ticks, :scale, :flip, :rotation,
     :tickfont, :guidefont, :legendfont,
-    :grid, :legend, :colorbar, :colorbar_title,
+    :grid, :gridalpha, :gridlinewidth,
+    :legend, :colorbar, :colorbar_title,
     :marker_z, :fill_z, :levels,
     :ribbon, :quiver,
     :orientation,
@@ -213,7 +214,9 @@ function plotly_axis(axis::Axis, sp::Subplot)
     letter = axis[:letter]
     ax = KW(
         :title      => axis[:guide],
-        :showgrid   => !(axis[:grid] in (nothing, false)),
+        :showgrid   => axis[:grid],
+        :gridcolor  => rgba_string(plot_color(axis[:foreground_color_grid], axis[:gridalpha])),
+        :gridwidth  => axis[:gridlinewidth],
         :zeroline   => false,
         :ticks      => "inside",
     )
@@ -229,8 +232,8 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:titlefont] = plotly_font(axis[:guidefont], axis[:foreground_color_guide])
         ax[:type] = plotly_scale(axis[:scale])
         ax[:tickfont] = plotly_font(axis[:tickfont], axis[:foreground_color_text])
-        ax[:tickcolor] = rgba_string(axis[:foreground_color_border])
-        ax[:linecolor] = rgba_string(axis[:foreground_color_border])
+        ax[:tickcolor] = rgba_string(axis[:foreground_color_axis])
+        ax[:linecolor] = rgba_string(axis[:foreground_color_axis])
 
         # lims
         lims = axis[:lims]

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -5,8 +5,7 @@ const _plotly_attr = merge_with_base_supported([
     :annotations,
     :background_color_legend, :background_color_inside, :background_color_outside,
     :foreground_color_legend, :foreground_color_guide,
-    :foreground_color_grid,
-    # :foreground_color_axis,
+    :foreground_color_grid, :foreground_color_axis,
     :foreground_color_text, :foreground_color_border,
     :foreground_color_title,
     :label,
@@ -214,6 +213,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
     letter = axis[:letter]
     ax = KW(
         :title      => axis[:guide],
+        :gridcolor  => rgba_string(axis[:foreground_color_grid]),
         :showgrid   => !(axis[:grid] in (nothing, false)),
         :zeroline   => false,
         :ticks      => "inside",
@@ -230,8 +230,8 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:titlefont] = plotly_font(axis[:guidefont], axis[:foreground_color_guide])
         ax[:type] = plotly_scale(axis[:scale])
         ax[:tickfont] = plotly_font(axis[:tickfont], axis[:foreground_color_text])
-        ax[:tickcolor] = rgba_string(axis[:foreground_color_border])
-        ax[:linecolor] = rgba_string(axis[:foreground_color_grid])
+        ax[:tickcolor] = rgba_string(axis[:foreground_color_axis])
+        ax[:linecolor] = rgba_string(axis[:foreground_color_axis])
 
         # lims
         lims = axis[:lims]

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1064,8 +1064,8 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 lab[:set_family](axis[:tickfont].family)
                 lab[:set_rotation](axis[:rotation])
             end
-            if sp[:grid]
-                fgcolor = py_color(sp[:foreground_color_grid])
+            if !(axis[:grid] in (nothing, false))
+                fgcolor = py_color(axis[:foreground_color_grid])
                 pyaxis[:grid](true, color = fgcolor, linestyle = ":")
                 ax[:set_axisbelow](true)
             end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -17,7 +17,8 @@ const _pyplot_attr = merge_with_base_supported([
     :window_title,
     :guide, :lims, :ticks, :scale, :flip, :rotation,
     :tickfont, :guidefont, :legendfont,
-    :grid, :legend, :legendtitle, :colorbar,
+    :grid, :gridalpha, :gridstyle, :gridlinewidth,
+    :legend, :legendtitle, :colorbar,
     :marker_z, :line_z, :fill_z,
     :levels,
     :ribbon, :quiver, :arrow,
@@ -1064,9 +1065,13 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 lab[:set_family](axis[:tickfont].family)
                 lab[:set_rotation](axis[:rotation])
             end
-            if !(axis[:grid] in (nothing, false))
+            if axis[:grid]
                 fgcolor = py_color(axis[:foreground_color_grid])
-                pyaxis[:grid](true, color = fgcolor, linestyle = ":")
+                pyaxis[:grid](true,
+                    color = fgcolor,
+                    linestyle = py_linestyle(:line, axis[:gridstyle]),
+                    linewidth = axis[:gridlinewidth],
+                    alpha = axis[:gridalpha])
                 ax[:set_axisbelow](true)
             end
             py_set_axis_colors(ax, axis)

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -329,6 +329,18 @@ PlotExample("Spy",
     end)]
 ),
 
+PlotExample("Magic grid argument",
+    "The grid lines can be modified individually for each axis with the magic grid argument",
+    [:(begin
+    x = rand(10)
+    p1 = plot(x, title = "Default looks")
+    p2 = plot(x, grid = (:y, :olivedrab, :solid, 0.5), title = "Modified y grid")
+    p3 = plot(deepcopy(p2), title = "Add x grid")
+    xgrid!(p3, :on, :cadetblue, 2, :dashdot)
+    plot(p1, p2, p3, layout = (1, 3), label = "", fillrange = 0, fillalpha = 0.3)
+    end)]
+),
+
 ]
 
 # ---------------------------------------------------------------------------------

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -321,7 +321,7 @@ PlotExample("Animation with subplots",
 ),
 
 PlotExample("Spy",
-    "For a matrix `mat` with unique nonzeros `spy(mat)` returns a colorless plot. If `mat` has various different nonzero values, a colorbar is added. The colorbar can be disabled with `legend = nothing`. As always, the marker shape and size can be changed with `spy(mat, markersize = 3, markershape = :star)`",
+    "For a matrix `mat` with unique nonzeros `spy(mat)` returns a colorless plot. If `mat` has various different nonzero values, a colorbar is added. The colorbar can be disabled with `legend = nothing`. As always, the marker shape and size can be changed with `spy(mat, markersize = 3, markershape = :star)`.",
     [:(begin
     a = spdiagm((ones(50), ones(49), ones(49), ones(40), ones(40)),(0, 1, -1, 10, -10))
     b = spdiagm((1:50, 1:49, 1:49, 1:40, 1:40),(0, 1, -1, 10, -10))
@@ -330,13 +330,13 @@ PlotExample("Spy",
 ),
 
 PlotExample("Magic grid argument",
-    "The grid lines can be modified individually for each axis with the magic grid argument",
+    "The grid lines can be modified individually for each axis with the magic grid argument.",
     [:(begin
     x = rand(10)
     p1 = plot(x, title = "Default looks")
-    p2 = plot(x, grid = (:y, :olivedrab, :solid, 0.5), title = "Modified y grid")
+    p2 = plot(x, grid = (:y, :olivedrab, :dot, 1, 0.9), title = "Modified y grid")
     p3 = plot(deepcopy(p2), title = "Add x grid")
-    xgrid!(p3, :on, :cadetblue, 2, :dashdot)
+    xgrid!(p3, :on, :cadetblue, 2, :dashdot, 0.4)
     plot(p1, p2, p3, layout = (1, 3), label = "", fillrange = 0, fillalpha = 0.3)
     end)]
 ),


### PR DESCRIPTION
This makes `grid` and `foreground_color_grid` Axis attributes instead of Subplot attributes (cf #675).
A lot of this work has already been done by @GuessWhoSamFoo in #695, so credits to him!!!
I just tried to make it work on all different backends and also made `foreground_color_grid` an Axis attribute.

I tested the changes with the following code:
```julia
using Plots

x = rand(10)
plot(
    plot(x, xgrid = false, title = "xgrid = false"),
    plot(x, ygrid = nothing, title = "ygrid = nothing"),
    plot(x, grid = false, title = "grid = false"),
    plot(x, xforeground_color_grid = :red, title = "xfcg = :red"),
    plot(x, foreground_color_grid = :red, title = "fcg = :red"),
    plot(x, xforeground_color_grid = :red, yforeground_color_grid = :green, title = "xfcg = :red, yfcg = :green"),
    label = "",
    )
```

Here are the resulting plots for the different backends:
* **GR**
![grid_axis_gr](https://user-images.githubusercontent.com/16589944/29187939-c14368a6-7e11-11e7-9c70-e7341814a624.png)

* **PyPlot**
![grid_axis_pyplot](https://user-images.githubusercontent.com/16589944/29188033-0e957590-7e12-11e7-9a6d-3593548cadac.png)

* **Plotly(JS)**
![grid_axis_plotlyjs](https://user-images.githubusercontent.com/16589944/29188418-4a7b2c7a-7e13-11e7-8ecd-1561ebfb1b49.png)

* **GLVisualize**
![grid_axis_glvisualize](https://user-images.githubusercontent.com/16589944/29188164-8cafbab2-7e12-11e7-9dfd-561379c8e5e4.png)

The following backends do not support `foreground_color_grid`:

* **InspectDR**
![grid_axis_inspectdr](https://user-images.githubusercontent.com/16589944/29188192-9ff19d3e-7e12-11e7-896e-4efe836f2cab.png)

* **PGFPlots**
![grid_axis_pgfplots](https://user-images.githubusercontent.com/16589944/29188211-b0f8ed08-7e12-11e7-9fba-fb014d6a2a5c.png)

@jheinen, @SimonDanisch and @ma-laforge could you please check the changes to your respective backends?
