### PR TITLE
Enforce plot order in user recipes

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -73,7 +73,7 @@ function _process_userrecipes(plt::Plot, d::KW, args)
         next_series = shift!(still_to_process)
         # recipedata should be of type RecipeData.  if it's not then the inputs must not have been fully processed by recipes
         if !(typeof(next_series) <: RecipeData)
-            error("Inputs couldn't be processed... expected RecipeData but got: $recipedata")
+            error("Inputs couldn't be processed... expected RecipeData but got: $next_series")
         end
         if isempty(next_series.args)
             _process_userrecipe(plt, kw_list, next_series)


### PR DESCRIPTION
Process user recipes depth-first rather than breadth-first to enforce the plot order given in the recipe. Fixes the problems addressed in [#25](https://github.com/JuliaPlots/RecipesBase.jl/issues/25)

Passes all tests on GR and PyPlot backends.