### PR TITLE
only flip colorbar for marker_z on gr

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -336,6 +336,7 @@ function gr_draw_markers(series::Series, x, y)
     GR.setfillintstyle(GR.INTSTYLE_SOLID)
     gr_draw_markers(series, x, y, series[:markersize], mz)
     if mz != nothing
+        GR.setscale(0)
         gr_colorbar(series[:subplot])
     end
 end
@@ -863,7 +864,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 if series[:marker_z] != nothing
                     zmin, zmax = extrema(series[:marker_z])
                     GR.setspace(zmin, zmax, 0, 90)
-                    GR.setscale(0)
                 end
                 gr_draw_markers(series, x, y)
             end


### PR DESCRIPTION
With #1005 not only the colorbar is flipped for marker_z on GR but also the yaxis. See, e.g `test_examples(:gr, 32)`:

![gr32_old](https://user-images.githubusercontent.com/16589944/29384319-f30ca426-82d3-11e7-8967-605fd10e440d.png)

With this PR only the colorbar is flipped:

![gr32_new](https://user-images.githubusercontent.com/16589944/29384374-16125d94-82d4-11e7-85a2-be65ba9c23df.png)
