### PR TITLE
RFC: added ribbon to plotly

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1096,7 +1096,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 st = series[:seriestype]
                 gr_set_line(series[:linewidth], series[:linestyle], series[:linecolor]) #, series[:linealpha])
 
-                if st == :shape || series[:fillrange] != nothing
+                if (st == :shape || series[:fillrange] != nothing) && series[:ribbon] == nothing
                     gr_set_fill(series[:fillcolor]) #, series[:fillalpha])
                     l, r = xpos-0.07, xpos-0.01
                     b, t = ypos-0.4dy, ypos+0.4dy

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -589,9 +589,9 @@ function plotly_series(plt::Plot, series::Series)
         # if hasfillrange is true, return two dictionaries (one for original
         # series, one for series being filled to) instead of one
         d_out_fillrange = deepcopy(d_out)
+        d_out_fillrange[:showlegend] = false
         if isa(series[:fillrange], AbstractVector)
             d_out_fillrange[:y] = series[:fillrange]
-            d_out_fillrange[:showlegend] = false
             delete!(d_out_fillrange, :fill)
             delete!(d_out_fillrange, :fillcolor)
         else
@@ -600,7 +600,6 @@ function plotly_series(plt::Plot, series::Series)
             d_out_fillrange[:x], d_out_fillrange[:y] =
                 concatenate_fillrange(series[:x], series[:fillrange])
             d_out_fillrange[:line][:width] = 0
-            d_out[:showlegend] = false
             delete!(d_out, :fill)
             delete!(d_out, :fillcolor)
         end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -438,7 +438,8 @@ function plotly_series(plt::Plot, series::Series)
     isscatter = st in (:scatter, :scatter3d, :scattergl)
     hasmarker = isscatter || series[:markershape] != :none
     hasline = st in (:path, :path3d)
-    hasfillrange = st in (:path, :scatter, :scattergl) && isa(series[:fillrange], AbstractVector)
+    hasfillrange = st in (:path, :scatter, :scattergl) &&
+        (isa(series[:fillrange], AbstractVector) || isa(series[:fillrange], Tuple))
 
     # for surface types, set the data
     if st in (:heatmap, :contour, :surface, :wireframe)
@@ -462,7 +463,7 @@ function plotly_series(plt::Plot, series::Series)
         else
             hasline ? "lines" : "none"
         end
-        if series[:fillrange] == true || series[:fillrange] == 0
+        if series[:fillrange] == true || series[:fillrange] == 0 || isa(series[:fillrange], Tuple)
             d_out[:fill] = "tozeroy"
             d_out[:fillcolor] = rgba_string(series[:fillcolor])
         elseif isa(series[:fillrange], AbstractVector)
@@ -587,11 +588,22 @@ function plotly_series(plt::Plot, series::Series)
     if hasfillrange
         # if hasfillrange is true, return two dictionaries (one for original
         # series, one for series being filled to) instead of one
-        d_out_fillrange = copy(d_out)
-        d_out_fillrange[:y] = series[:fillrange]
-        d_out_fillrange[:showlegend] = false
-        delete!(d_out_fillrange, :fill)
-        delete!(d_out_fillrange, :fillcolor)
+        d_out_fillrange = deepcopy(d_out)
+        if isa(series[:fillrange], AbstractVector)
+            d_out_fillrange[:y] = series[:fillrange]
+            d_out_fillrange[:showlegend] = false
+            delete!(d_out_fillrange, :fill)
+            delete!(d_out_fillrange, :fillcolor)
+        else
+            # if fillrange is a tuple with upper and lower limit, d_out_fillrange
+            # is the series that will do the filling
+            d_out_fillrange[:x], d_out_fillrange[:y] =
+                concatenate_fillrange(series[:x], series[:fillrange])
+            d_out_fillrange[:line][:width] = 0
+            d_out[:showlegend] = false
+            delete!(d_out, :fill)
+            delete!(d_out, :fillcolor)
+        end
 
         return [d_out_fillrange, d_out]
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -496,6 +496,7 @@ function make_fillrange_from_ribbon(kw::KW)
     rib1, rib2 = -first(rib), last(rib)
     # kw[:ribbon] = nothing
     kw[:fillrange] = make_fillrange_side(y, rib1), make_fillrange_side(y, rib2)
+    (get(kw, :fillalpha, nothing) == nothing) && (kw[:fillalpha] = 0.5)
 end
 
 #turn tuple of fillranges to one path

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -498,6 +498,14 @@ function make_fillrange_from_ribbon(kw::KW)
     kw[:fillrange] = make_fillrange_side(y, rib1), make_fillrange_side(y, rib2)
 end
 
+#turn tuple of fillranges to one path
+function concatenate_fillrange(x,y::Tuple)
+    rib1, rib2 = first(y), last(y)
+    yline = vcat(rib1,(rib2)[end:-1:1])
+    xline = vcat(x,x[end:-1:1])
+    return xline, yline
+end
+
 function get_sp_lims(sp::Subplot, letter::Symbol)
     axis_limits(sp[Symbol(letter, :axis)])
 end


### PR DESCRIPTION
Added a slightly modified version of #969 to allow ribbon plots in plotly(js). Now `plot(sin, ribbon = 0.1)` gives:

![newplot-5](https://user-images.githubusercontent.com/6333339/29486008-27fd5c0a-84d4-11e7-99e3-7c4feb410f83.png)
