### PR TITLE
Group now groups kw arguments as well

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -854,7 +854,7 @@ end
 # expecting a mapping of "group label" to "group indices"
 function extractGroupArgs{T, V<:AVec{Int}}(idxmap::Dict{T,V}, args...)
     groupLabels = sortedkeys(idxmap)
-    groupIds = VecI[collect(idxmap[k]) for k in groupLabels]
+    groupIds = Vector{Int}[collect(idxmap[k]) for k in groupLabels]
     GroupBy(groupLabels, groupIds)
 end
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -840,16 +840,24 @@ end
 
 
 # this is when given a vector-type of values to group by
-function extractGroupArgs(v::AVec, args...)
+function extractGroupArgs(v::AVec, args...; legendEntry = string)
     groupLabels = sort(collect(unique(v)))
     n = length(groupLabels)
     if n > 100
         warn("You created n=$n groups... Is that intended?")
     end
     groupIds = Vector{Int}[filter(i -> v[i] == glab, 1:length(v)) for glab in groupLabels]
-    GroupBy(map(string, groupLabels), groupIds)
+    GroupBy(map(legendEntry, groupLabels), groupIds)
 end
 
+legendEntryFromTuple(ns::Tuple) = string(("$n " for n in ns)...)
+
+# this is when given a tuple of vectors of values to group by
+function extractGroupArgs(vs::Tuple, args...)
+    (vs == ()) && return GroupBy([""], [1:size(args[1],1)])
+    v = collect(zip(vs...))
+    extractGroupArgs(v, args...; legendEntry = legendEntryFromTuple)
+end
 
 # expecting a mapping of "group label" to "group indices"
 function extractGroupArgs{T, V<:AVec{Int}}(idxmap::Dict{T,V}, args...)

--- a/src/series.jl
+++ b/src/series.jl
@@ -515,6 +515,13 @@ end
         @series begin
             label     --> string(glab)
             idxfilter --> groupby.groupIds[i]
+            for (key,val) in d
+                length(args) == 0 && break
+                if key != :group && isa(val, AbstractArray) && size(val,1) == size(args[1],1)
+                    n = ndims(val)
+                    :($key) := val[groupby.groupIds[i], fill(Colon(), n-1)...]
+                end
+            end
             args
         end
     end

--- a/src/series.jl
+++ b/src/series.jl
@@ -511,13 +511,13 @@ end
 
 # split the group into 1 series per group, and set the label and idxfilter for each
 @recipe function f(groupby::GroupBy, args...)
+    lengthGroup = maximum(union(groupby.groupIds...))
     for (i,glab) in enumerate(groupby.groupLabels)
         @series begin
             label     --> string(glab)
             idxfilter --> groupby.groupIds[i]
             for (key,val) in d
-                length(args) == 0 && break
-                if key != :group && isa(val, AbstractArray) && size(val,1) == size(args[1],1)
+                if key != :group && isa(val, AbstractArray) && size(val,1) >= lengthGroup
                     n = ndims(val)
                     :($key) := val[groupby.groupIds[i], fill(Colon(), n-1)...]
                 end


### PR DESCRIPTION
With this PR, when grouping, also keyword arguments get grouped, provided they are long enough in the first dimension. Fixes #1031 and #962 
New behavior:

```
using Plots
using DataFrames
import RDatasets
gr()
iris = RDatasets.dataset("datasets","iris");
scatter(iris[:PetalLength], iris[:PetalWidth], group = iris[:Species],
layout = 3, marker_z = iris[:SepalLength], markersize = iris[:SepalWidth])
```

![group](https://user-images.githubusercontent.com/6333339/29525465-aa94af80-868a-11e7-82ef-b7d95d8f168a.png)

Also, there was a forgotten method to group, which gives a Dict of indices instead of a column: it is fixed with this PR. Example syntax:

`scatter(iris[:PetalLength], iris[:PetalWidth], group = Dict(:a => collect(1:50), :b => collect(51:150)))`

Issue with this PR: in case of overlaid plots with colorbar, we get superimposed colorbars. We'd need a working keyword to make sure the user can set them to be the same:

`scatter(iris[:PetalLength], iris[:PetalWidth], group = iris[:Species], marker_z = iris[:SepalLength])
`
![groupbad](https://user-images.githubusercontent.com/6333339/29525615-2b5a4134-868b-11e7-9a61-db53548da03b.png)