### PR TITLE
don't draw fill for 1D markers in gr

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -326,7 +326,10 @@ function gr_draw_markers(series::Series, x, y, msize, mz)
                 cfuncind(ci)
                 GR.settransparency(_gr_gradient_alpha[ci-999])
             end
-            gr_draw_marker(x[i], y[i], msi, shape)
+            # don't draw filled area if marker shape is 1D  
+            if !(shape in (:hline, :vline, :+, :x, :cross, :xcross))
+                gr_draw_marker(x[i], y[i], msi, shape)
+            end
         end
     end
 end


### PR DESCRIPTION
Solves #1032 : GR was trying to draw the "fill" part of markers even for 1D markers (i.e. `:hline, :vline, :+, :x, :cross, :xcross`)