### PR TITLE
Adjust margin (ticks + margin given by user) with GR ( fix #1028 )

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -326,7 +326,7 @@ function gr_draw_markers(series::Series, x, y, msize, mz)
                 cfuncind(ci)
                 GR.settransparency(_gr_gradient_alpha[ci-999])
             end
-            # don't draw filled area if marker shape is 1D  
+            # don't draw filled area if marker shape is 1D
             if !(shape in (:hline, :vline, :+, :x, :cross, :xcross))
                 gr_draw_marker(x[i], y[i], msi, shape)
             end
@@ -543,10 +543,10 @@ end
 
 
 function _update_min_padding!(sp::Subplot{GRBackend})
-    leftpad   = 10mm
-    toppad    = 2mm
-    rightpad  = 2mm
-    bottompad = 6mm
+    leftpad   = 10mm + sp[:left_margin]
+    toppad    = 2mm  + sp[:top_margin]
+    rightpad  = 2mm  + sp[:right_margin]
+    bottompad = 6mm  + sp[:bottom_margin]
     if sp[:title] != ""
         toppad += 5mm
     end
@@ -558,10 +558,11 @@ function _update_min_padding!(sp::Subplot{GRBackend})
                         valign = :top,
                         color = sp[:xaxis][:foreground_color_axis],
                         rotation = sp[:xaxis][:rotation])
-            h = 0
+            h = 0.0
             for (cv, dv) in zip(xticks...)
                 tbx, tby = gr_inqtext(0, 0, string(dv))
-                h = max(h, tby[2] - tby[1])
+                tby_min, tby_max = extrema(tby)
+                h = max(h, tby_max - tby_min)
             end
             bottompad += 1mm + gr_plot_size[2] * h * px
         else

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -542,6 +542,30 @@ function gr_display(plt::Plot)
 end
 
 
+function gr_set_xticks_font(sp)
+    flip = sp[:yaxis][:flip]
+    mirror = sp[:xaxis][:mirror]
+    gr_set_font(sp[:xaxis][:tickfont],
+                halign = (:left, :hcenter, :right)[sign(sp[:xaxis][:rotation]) + 2],
+                valign = (mirror ? :bottom : :top),
+                color = sp[:xaxis][:foreground_color_axis],
+                rotation = sp[:xaxis][:rotation])
+    return flip, mirror
+end
+
+
+function gr_set_yticks_font(sp)
+    flip = sp[:xaxis][:flip]
+    mirror = sp[:yaxis][:mirror]
+    gr_set_font(sp[:yaxis][:tickfont],
+                halign = (mirror ? :left : :right),
+                valign = (:top, :vcenter, :bottom)[sign(sp[:yaxis][:rotation]) + 2],
+                color = sp[:yaxis][:foreground_color_axis],
+                rotation = sp[:yaxis][:rotation])
+    return flip, mirror
+end
+
+
 function _update_min_padding!(sp::Subplot{GRBackend})
     # Add margin given by the user
     leftpad   = 10mm + sp[:left_margin]
@@ -747,13 +771,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
         if !(xticks in (nothing, false))
             # x labels
-            flip = sp[:yaxis][:flip]
-            mirror = sp[:xaxis][:mirror]
-            gr_set_font(sp[:xaxis][:tickfont],
-                        halign = (:left, :hcenter, :right)[sign(sp[:xaxis][:rotation]) + 2],
-                        valign = (mirror ? :bottom : :top),
-                        color = sp[:xaxis][:foreground_color_axis],
-                        rotation = sp[:xaxis][:rotation])
+            flip, mirror = gr_set_xticks_font(sp)
             for (cv, dv) in zip(xticks...)
                 # use xor ($) to get the right y coords
                 xi, yi = GR.wctondc(cv, xor(flip, mirror) ? ymax : ymin)
@@ -764,13 +782,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
         if !(yticks in (nothing, false))
             # y labels
-            flip = sp[:xaxis][:flip]
-            mirror = sp[:yaxis][:mirror]
-            gr_set_font(sp[:yaxis][:tickfont],
-                        halign = (mirror ? :left : :right),
-                        valign = (:top, :vcenter, :bottom)[sign(sp[:yaxis][:rotation]) + 2],
-                        color = sp[:yaxis][:foreground_color_axis],
-                        rotation = sp[:yaxis][:rotation])
+            flip, mirror = gr_set_yticks_font(sp)
             for (cv, dv) in zip(yticks...)
                 # use xor ($) to get the right y coords
                 xi, yi = GR.wctondc(xor(flip, mirror) ? xmax : xmin, cv)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -543,32 +543,36 @@ end
 
 
 function _update_min_padding!(sp::Subplot{GRBackend})
+    # Add margin given by the user
     leftpad   = 10mm + sp[:left_margin]
     toppad    = 2mm  + sp[:top_margin]
-    rightpad  = 2mm  + sp[:right_margin]
-    bottompad = 6mm  + sp[:bottom_margin]
+    rightpad  = 4mm  + sp[:right_margin]
+    bottompad = 2mm  + sp[:bottom_margin]
+    # Add margin for title
     if sp[:title] != ""
         toppad += 5mm
     end
-    if sp[:xaxis][:guide] != ""
-        xticks = axis_drawing_info(sp)[1]
-        if !(xticks in (nothing, false))
-            gr_set_font(sp[:xaxis][:tickfont],
-                        halign = (:left, :hcenter, :right)[sign(sp[:xaxis][:rotation]) + 2],
-                        valign = :top,
-                        color = sp[:xaxis][:foreground_color_axis],
-                        rotation = sp[:xaxis][:rotation])
-            h = 0.0
-            for (cv, dv) in zip(xticks...)
-                tbx, tby = gr_inqtext(0, 0, string(dv))
-                tby_min, tby_max = extrema(tby)
-                h = max(h, tby_max - tby_min)
-            end
-            bottompad += 1mm + gr_plot_size[2] * h * px
-        else
-            bottompad += 4mm
+    # Add margin for x ticks
+    xticks = axis_drawing_info(sp)[1]
+    if !(xticks in (nothing, false))
+        gr_set_font(sp[:xaxis][:tickfont],
+                    halign = (:left, :hcenter, :right)[sign(sp[:xaxis][:rotation]) + 2],
+                    valign = :top,
+                    color = sp[:xaxis][:foreground_color_axis],
+                    rotation = sp[:xaxis][:rotation])
+        h = 0.0
+        for (cv, dv) in zip(xticks...)
+            tbx, tby = gr_inqtext(0, 0, string(dv))
+            tby_min, tby_max = extrema(tby)
+            h = max(h, tby_max - tby_min)
         end
+        bottompad += 1mm + gr_plot_size[2] * h * px
     end
+    # Add margin for x label
+    if sp[:xaxis][:guide] != ""
+        bottompad += 4mm
+    end
+    # Add margin for y label
     if sp[:yaxis][:guide] != ""
         leftpad += 4mm
     end


### PR DESCRIPTION
Now GR takes in consideration the margin input by the user when making the plot + the ticks.

`plot(["String $i" for i in 1:10], rand(10), xrotation = 90)`

![longname](https://user-images.githubusercontent.com/6333339/29632648-8461654e-883b-11e7-9732-359bc5c5b4ff.png)

`plot(["String $i" for i in 1:10], rand(10), xrotation = 90, left_margin = 10mm)`

![longnameleft](https://user-images.githubusercontent.com/6333339/29632807-0ca67408-883c-11e7-8193-74d095704564.png)

I recommend playing with it to make sure that the default margins look good / it works robustly. I only tested on Juno as my GKS installations is a bit disfunctional.