### PR TITLE
make linecolor default to :auto

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -198,7 +198,7 @@ const _series_defaults = KW(
     :seriestype        => :path,
     :linestyle         => :solid,
     :linewidth         => :auto,
-    :linecolor         => :match,
+    :linecolor         => :auto,
     :linealpha         => nothing,
     :fillrange         => nothing,   # ribbons, areas, etc
     :fillcolor         => :match,
@@ -1333,12 +1333,14 @@ function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
     # update other colors
     for s in (:line, :marker, :fill)
         csym, asym = Symbol(s,:color), Symbol(s,:alpha)
-        d[csym] = if d[csym] == :match
+        d[csym] = if d[csym] == :auto
             plot_color(if has_black_border_for_default(d[:seriestype]) && s == :line
                 sp[:foreground_color_subplot]
             else
                 d[:seriescolor]
             end, d[asym])
+        elseif d[csym] == :match
+            plot_color(d[:seriescolor], d[asym])
         else
             getSeriesRGBColor(d[csym], d[asym], sp, plotIndex)
         end


### PR DESCRIPTION
this allows the users to easily ~~get rid of the borders~~ match the linecolor to the seriescolor in shape/histogram/bar-like plots with `linecolor = :match` while still defaulting to the old behaviour:
```julia
x = randn(1000) .+ (0:2:6)'
plot(histogram(x, title = "default"), histogram(x, linecolor = :match, title = "linecolor = :match"))
```
![blackborder](https://user-images.githubusercontent.com/16589944/29714003-688e9096-89a1-11e7-87c8-cebdeb9117c8.png)
