### PR TITLE
To be merged together with PlotUtils #26: accept axis with 4 ticks

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -185,7 +185,7 @@ function optimal_ticks_and_labels(axis::Axis, ticks = nothing)
         scaled_ticks = optimize_ticks(
             sf(amin),
             sf(amax);
-            k_min = 5, # minimum number of ticks
+            k_min = 4, # minimum number of ticks
             k_max = 8, # maximum number of ticks
         )[1]
     elseif typeof(ticks) <: Int


### PR DESCRIPTION
See [#26](https://github.com/JuliaPlots/PlotUtils.jl/pull/26), accept axis with 4 to 8 ticks.

This is not the only options, also 5 to 9 ticks is a possible solution, not sure which one is best.