### PR TITLE
RFC: Add :origin framestyle

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -181,13 +181,14 @@ function hasgrid(arg::Symbol, letter)
 end
 hasgrid(arg::AbstractString, letter) = hasgrid(Symbol(arg), letter)
 
-const _allFramestyles = [:box, :semi, :axes, :grid, :none]
+const _allFramestyles = [:box, :semi, :axes, :origin, :grid, :none]
 const _framestyleAliases = Dict{Symbol, Symbol}(
     :frame              => :box,
     :border             => :box,
     :on                 => :box,
     :transparent        => :semi,
     :semitransparent    => :semi,
+    :zeroline           => :origin,
 )
 # -----------------------------------------------------------------------------
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -189,6 +189,7 @@ const _framestyleAliases = Dict{Symbol, Symbol}(
     :transparent        => :semi,
     :semitransparent    => :semi,
     :zeroline           => :origin,
+    :zero               => :origin,
 )
 # -----------------------------------------------------------------------------
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -181,15 +181,13 @@ function hasgrid(arg::Symbol, letter)
 end
 hasgrid(arg::AbstractString, letter) = hasgrid(Symbol(arg), letter)
 
-const _allFramestyles = [:box, :semi, :axes, :origin, :grid, :none]
+const _allFramestyles = [:box, :semi, :axes, :origin, :zerolines, :grid, :none]
 const _framestyleAliases = Dict{Symbol, Symbol}(
     :frame              => :box,
     :border             => :box,
     :on                 => :box,
     :transparent        => :semi,
     :semitransparent    => :semi,
-    :zeroline           => :origin,
-    :zero               => :origin,
 )
 # -----------------------------------------------------------------------------
 

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -516,7 +516,13 @@ function axis_drawing_info(sp::Subplot)
     if !(sp[:framestyle] == :none)
         # xaxis
         sp[:framestyle] in (:grid, :origin) || push!(xaxis_segs, (xmin,ymin), (xmax,ymin)) # bottom spine / xaxis
-        sp[:framestyle] == :origin && push!(xaxis_segs, (xmin, 0.0), (xmax, 0.0))
+        if sp[:framestyle] == :origin
+            push!(xaxis_segs, (xmin, 0.0), (xmax, 0.0))
+            # don't show the 0 tick label for the origin framestyle
+            if length(yticks) > 1
+                xticks[2][xticks[1] .== 0] = ""
+            end
+        end
         sp[:framestyle] in (:semi, :box) && push!(xborder_segs, (xmin,ymax), (xmax,ymax)) # top spine
         if !(xaxis[:ticks] in (nothing, false))
             f = scalefunc(yaxis[:scale])
@@ -539,7 +545,13 @@ function axis_drawing_info(sp::Subplot)
 
         # yaxis
         sp[:framestyle] in (:grid, :origin) || push!(yaxis_segs, (xmin,ymin), (xmin,ymax)) # left spine / yaxis
-        sp[:framestyle] == :origin && push!(yaxis_segs, (0.0, ymin), (0.0, ymax))
+        if sp[:framestyle] == :origin
+            push!(yaxis_segs, (0.0, ymin), (0.0, ymax))
+            # don't show the 0 tick label for the origin framestyle
+            if length(yticks) > 1
+                yticks[2][yticks[1] .== 0] = ""
+            end
+        end
         sp[:framestyle] in (:semi, :box) && push!(yborder_segs, (xmax,ymin), (xmax,ymax)) # right spine
         if !(yaxis[:ticks] in (nothing, false))
             f = scalefunc(xaxis[:scale])

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -508,6 +508,8 @@ function axis_drawing_info(sp::Subplot)
     yticks = get_ticks(yaxis)
     xaxis_segs = Segments(2)
     yaxis_segs = Segments(2)
+    xtick_segs = Segments(2)
+    ytick_segs = Segments(2)
     xgrid_segs = Segments(2)
     ygrid_segs = Segments(2)
     xborder_segs = Segments(2)
@@ -515,12 +517,13 @@ function axis_drawing_info(sp::Subplot)
 
     if !(sp[:framestyle] == :none)
         # xaxis
-        sp[:framestyle] in (:grid, :origin) || push!(xaxis_segs, (xmin,ymin), (xmax,ymin)) # bottom spine / xaxis
-        if sp[:framestyle] == :origin
+        sp[:framestyle] in (:grid, :origin, :zerolines) || push!(xaxis_segs, (xmin,ymin), (xmax,ymin)) # bottom spine / xaxis
+        if sp[:framestyle] in (:origin, :zerolines)
             push!(xaxis_segs, (xmin, 0.0), (xmax, 0.0))
             # don't show the 0 tick label for the origin framestyle
-            if length(yticks) > 1
-                xticks[2][xticks[1] .== 0] = ""
+            if sp[:framestyle] == :origin && length(xticks) > 1
+                showticks = xticks[1] .!= 0
+                xticks = (xticks[1][showticks], xticks[2][showticks])
             end
         end
         sp[:framestyle] in (:semi, :box) && push!(xborder_segs, (xmin,ymax), (xmax,ymax)) # top spine
@@ -537,19 +540,20 @@ function axis_drawing_info(sp::Subplot)
                 else
                     xaxis[:mirror] ? (ymax, t2) : (ymin, t1)
                 end
-                push!(xaxis_segs, (xtick, tick_start), (xtick, tick_stop)) # bottom tick
+                push!(xtick_segs, (xtick, tick_start), (xtick, tick_stop)) # bottom tick
                 # sp[:draw_axes_border] && push!(xaxis_segs, (xtick, ymax), (xtick, t2)) # top tick
                 xaxis[:grid] && push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
             end
         end
 
         # yaxis
-        sp[:framestyle] in (:grid, :origin) || push!(yaxis_segs, (xmin,ymin), (xmin,ymax)) # left spine / yaxis
-        if sp[:framestyle] == :origin
+        sp[:framestyle] in (:grid, :origin, :zerolines) || push!(yaxis_segs, (xmin,ymin), (xmin,ymax)) # left spine / yaxis
+        if sp[:framestyle] in (:origin, :zerolines)
             push!(yaxis_segs, (0.0, ymin), (0.0, ymax))
             # don't show the 0 tick label for the origin framestyle
-            if length(yticks) > 1
-                yticks[2][yticks[1] .== 0] = ""
+            if sp[:framestyle] == :origin && length(yticks) > 1
+                showticks = yticks[1] .!= 0
+                yticks = (yticks[1][showticks], yticks[2][showticks])
             end
         end
         sp[:framestyle] in (:semi, :box) && push!(yborder_segs, (xmax,ymin), (xmax,ymax)) # right spine
@@ -566,12 +570,12 @@ function axis_drawing_info(sp::Subplot)
                 else
                     yaxis[:mirror] ? (xmax, t2) : (xmin, t1)
                 end
-                push!(yaxis_segs, (tick_start, ytick), (tick_stop, ytick)) # left tick
+                push!(ytick_segs, (tick_start, ytick), (tick_stop, ytick)) # left tick
                 # sp[:draw_axes_border] && push!(yaxis_segs, (xmax, ytick), (t2, ytick)) # right tick
                 yaxis[:grid] && push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
             end
         end
     end
 
-    xticks, yticks, xaxis_segs, yaxis_segs, xgrid_segs, ygrid_segs, xborder_segs, yborder_segs
+    xticks, yticks, xaxis_segs, yaxis_segs, xtick_segs, ytick_segs, xgrid_segs, ygrid_segs, xborder_segs, yborder_segs
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -515,7 +515,8 @@ function axis_drawing_info(sp::Subplot)
 
     if !(sp[:framestyle] == :none)
         # xaxis
-        sp[:framestyle] == :grid || push!(xaxis_segs, (xmin,ymin), (xmax,ymin)) # bottom spine / xaxis
+        sp[:framestyle] in (:grid, :origin) || push!(xaxis_segs, (xmin,ymin), (xmax,ymin)) # bottom spine / xaxis
+        sp[:framestyle] == :origin && push!(xaxis_segs, (xmin, 0.0), (xmax, 0.0))
         sp[:framestyle] in (:semi, :box) && push!(xborder_segs, (xmin,ymax), (xmax,ymax)) # top spine
         if !(xaxis[:ticks] in (nothing, false))
             f = scalefunc(yaxis[:scale])
@@ -531,7 +532,8 @@ function axis_drawing_info(sp::Subplot)
         end
 
         # yaxis
-        sp[:framestyle] == :grid || push!(yaxis_segs, (xmin,ymin), (xmin,ymax)) # left spine / yaxis
+        sp[:framestyle] in (:grid, :origin) || push!(yaxis_segs, (xmin,ymin), (xmin,ymax)) # left spine / yaxis
+        sp[:framestyle] == :origin && push!(yaxis_segs, (0.0, ymin), (0.0, ymax))
         sp[:framestyle] in (:semi, :box) && push!(yborder_segs, (xmax,ymin), (xmax,ymax)) # right spine
         if !(yaxis[:ticks] in (nothing, false))
             f = scalefunc(xaxis[:scale])

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -523,9 +523,15 @@ function axis_drawing_info(sp::Subplot)
             invf = invscalefunc(yaxis[:scale])
             t1 = invf(f(ymin) + 0.015*(f(ymax)-f(ymin)))
             t2 = invf(f(ymax) - 0.015*(f(ymax)-f(ymin)))
+            t3 = invf(f(0) - 0.015*(f(ymax)-f(ymin)))
 
             for xtick in xticks[1]
-                push!(xaxis_segs, (xtick, ymin), (xtick, t1)) # bottom tick
+                tick_start, tick_stop = if sp[:framestyle] == :origin
+                    (0, xaxis[:mirror] ? -t3 : t3)
+                else
+                    xaxis[:mirror] ? (ymax, t2) : (ymin, t1)
+                end
+                push!(xaxis_segs, (xtick, tick_start), (xtick, tick_stop)) # bottom tick
                 # sp[:draw_axes_border] && push!(xaxis_segs, (xtick, ymax), (xtick, t2)) # top tick
                 xaxis[:grid] && push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
             end
@@ -540,9 +546,15 @@ function axis_drawing_info(sp::Subplot)
             invf = invscalefunc(xaxis[:scale])
             t1 = invf(f(xmin) + 0.015*(f(xmax)-f(xmin)))
             t2 = invf(f(xmax) - 0.015*(f(xmax)-f(xmin)))
+            t3 = invf(f(0) - 0.015*(f(xmax)-f(xmin)))
 
             for ytick in yticks[1]
-                push!(yaxis_segs, (xmin, ytick), (t1, ytick)) # left tick
+                tick_start, tick_stop = if sp[:framestyle] == :origin
+                    (0, yaxis[:mirror] ? -t3 : t3)
+                else
+                    yaxis[:mirror] ? (xmax, t2) : (xmin, t1)
+                end
+                push!(yaxis_segs, (tick_start, ytick), (tick_stop, ytick)) # left tick
                 # sp[:draw_axes_border] && push!(yaxis_segs, (xmax, ytick), (t2, ytick)) # right tick
                 yaxis[:grid] && push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
             end

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -604,7 +604,7 @@ end
 pointsize(font) = font.pointsize * 2
 
 function draw_ticks(
-        axis, ticks, isx, lims, m, text = "",
+        axis, ticks, isx, isorigin, lims, m, text = "",
         positions = Point2f0[], offsets=Vec2f0[]
     )
     sz = pointsize(axis[:tickfont])
@@ -622,7 +622,11 @@ function draw_ticks(
     for (cv, dv) in zip(ticks...)
 
         x, y = cv, lims[1]
-        xy = isx ? (x, y) : (y, x)
+        xy = if isorigin
+            isx ? (x, 0) : (0, x)
+        else
+            isx ? (x, y) : (y, x)
+        end
         _pos = m * GeometryTypes.Vec4f0(xy[1], xy[2], 0, 1)
         startpos = Point2f0(_pos[1], _pos[2]) - axis_gap
         str = string(dv)
@@ -711,10 +715,10 @@ function gl_draw_axes_2d(sp::Plots.Subplot{Plots.GLVisualizeBackend}, model, are
     if !(xaxis[:ticks] in (nothing, false, :none)) && !(sp[:framestyle] == :none)
         ticklabels = map(model) do m
             mirror = xaxis[:mirror]
-            t, positions, offsets = draw_ticks(xaxis, xticks, true, ylim, m)
+            t, positions, offsets = draw_ticks(xaxis, xticks, true, sp[:framestyle] == :origin, ylim, m)
             mirror = xaxis[:mirror]
             t, positions, offsets = draw_ticks(
-                yaxis, yticks, false, xlim, m,
+                yaxis, yticks, false, sp[:framestyle] == :origin, xlim, m,
                 t, positions, offsets
             )
         end

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -682,7 +682,7 @@ function text_model(font, pivot)
     end
 end
 function gl_draw_axes_2d(sp::Plots.Subplot{Plots.GLVisualizeBackend}, model, area)
-    xticks, yticks, xspine_segs, yspine_segs, xgrid_segs, ygrid_segs, xborder_segs, yborder_segs = Plots.axis_drawing_info(sp)
+    xticks, yticks, xspine_segs, yspine_segs, xtick_segs, ytick_segs, xgrid_segs, ygrid_segs, xborder_segs, yborder_segs = Plots.axis_drawing_info(sp)
     xaxis = sp[:xaxis]; yaxis = sp[:yaxis]
 
     xgc = Colors.color(Plots.gl_color(xaxis[:foreground_color_grid]))
@@ -706,6 +706,25 @@ function gl_draw_axes_2d(sp::Plots.Subplot{Plots.GLVisualizeBackend}, model, are
     if alpha(yaxis[:foreground_color_axis]) > 0
         spine = draw_grid_lines(sp, yspine_segs, 1f0, :solid, model, RGBA(yac, 1.0f0))
         push!(axis_vis, spine)
+    end
+    if sp[:framestyle] in (:zerolines, :grid)
+        if alpha(xaxis[:foreground_color_grid]) > 0
+            spine = draw_grid_lines(sp, xtick_segs, 1f0, :solid, model, RGBA(xgc, xaxis[:gridalpha]))
+            push!(axis_vis, spine)
+        end
+        if alpha(yaxis[:foreground_color_grid]) > 0
+            spine = draw_grid_lines(sp, ytick_segs, 1f0, :solid, model, RGBA(ygc, yaxis[:gridalpha]))
+            push!(axis_vis, spine)
+        end
+    else
+        if alpha(xaxis[:foreground_color_axis]) > 0
+            spine = draw_grid_lines(sp, xtick_segs, 1f0, :solid, model, RGBA(xac, 1.0f0))
+            push!(axis_vis, spine)
+        end
+        if alpha(yaxis[:foreground_color_axis]) > 0
+            spine = draw_grid_lines(sp, ytick_segs, 1f0, :solid, model, RGBA(yac, 1.0f0))
+            push!(axis_vis, spine)
+        end
     end
     fcolor = Plots.gl_color(xaxis[:foreground_color_axis])
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -793,7 +793,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             flip, mirror = gr_set_xticks_font(sp)
             for (cv, dv) in zip(xticks...)
                 # use xor ($) to get the right y coords
-                xi, yi = GR.wctondc(cv, xor(flip, mirror) ? ymax : ymin)
+                xi, yi = GR.wctondc(cv, sp[:framestyle] == :origin ? 0 : xor(flip, mirror) ? ymax : ymin)
                 # @show cv dv ymin xi yi flip mirror (flip $ mirror)
                 gr_text(xi, yi + (mirror ? 1 : -1) * 5e-3, string(dv))
             end
@@ -804,7 +804,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             flip, mirror = gr_set_yticks_font(sp)
             for (cv, dv) in zip(yticks...)
                 # use xor ($) to get the right y coords
-                xi, yi = GR.wctondc(xor(flip, mirror) ? xmax : xmin, cv)
+                xi, yi = GR.wctondc(sp[:framestyle] == :origin ? 0 : xor(flip, mirror) ? xmax : xmin, cv)
                 # @show cv dv xmin xi yi
                 gr_text(xi + (mirror ? 1 : -1) * 1e-2, yi, string(dv))
             end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -760,7 +760,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             GR.setwindow(xmin, xmax, ymin, ymax)
         end
 
-        xticks, yticks, xspine_segs, yspine_segs, xgrid_segs, ygrid_segs, xborder_segs, yborder_segs = axis_drawing_info(sp)
+        xticks, yticks, xspine_segs, yspine_segs, xtick_segs, ytick_segs, xgrid_segs, ygrid_segs, xborder_segs, yborder_segs = axis_drawing_info(sp)
         # @show xticks yticks #spine_segs grid_segs
 
         # draw the grid lines
@@ -785,6 +785,25 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         gr_set_line(1, :solid, yaxis[:foreground_color_axis])
         GR.setclip(0)
         gr_polyline(coords(yspine_segs)...)
+        GR.setclip(1)
+
+        # axis ticks
+        if sp[:framestyle] in (:zerolines, :grid)
+            gr_set_line(1, :solid, xaxis[:foreground_color_grid])
+            GR.settransparency(xaxis[:gridalpha])
+        else
+            gr_set_line(1, :solid, xaxis[:foreground_color_axis])
+        end
+        GR.setclip(0)
+        gr_polyline(coords(xtick_segs)...)
+        if sp[:framestyle] in (:zerolines, :grid)
+            gr_set_line(1, :solid, yaxis[:foreground_color_grid])
+            GR.settransparency(yaxis[:gridalpha])
+        else
+            gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+        end
+        GR.setclip(0)
+        gr_polyline(coords(ytick_segs)...)
         GR.setclip(1)
 
         # tick marks

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -971,14 +971,15 @@ function py_set_scale(ax, axis::Axis)
 end
 
 
-function py_set_axis_colors(ax, a::Axis)
+function py_set_axis_colors(sp, ax, a::Axis)
     for (loc, spine) in ax[:spines]
         spine[:set_color](py_color(a[:foreground_color_border]))
     end
     axissym = Symbol(a[:letter], :axis)
     if haskey(ax, axissym)
+        tickcolor = sp[:framestyle] == :zerolines ? py_color(plot_color(a[:foreground_color_grid], a[:gridalpha])) : py_color(a[:foreground_color_axis])
         ax[:tick_params](axis=string(a[:letter]), which="both",
-                         colors=py_color(a[:foreground_color_axis]),
+                         colors=tickcolor,
                          labelcolor=py_color(a[:foreground_color_text]))
         ax[axissym][:label][:set_color](py_color(a[:foreground_color_guide]))
     end
@@ -1055,9 +1056,13 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                     ax[:spines]["bottom"][:set_position]("zero")
                     ax[:spines]["left"][:set_position]("zero")
                 end
-            elseif sp[:framestyle] in (:grid, :none, :origin)
+            elseif sp[:framestyle] in (:grid, :none, :zerolines)
                 for (loc, spine) in ax[:spines]
                     spine[:set_visible](false)
+                end
+                if sp[:framestyle] == :zerolines
+                    ax[:axhline](y = 0, color = py_color(sp[:xaxis][:foreground_color_axis]), lw = 0.75)
+                    ax[:axvline](x = 0, color = py_color(sp[:yaxis][:foreground_color_axis]), lw = 0.75)
                 end
             end
         end
@@ -1102,7 +1107,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                     alpha = axis[:gridalpha])
                 ax[:set_axisbelow](true)
             end
-            py_set_axis_colors(ax, axis)
+            py_set_axis_colors(sp, ax, axis)
         end
 
         # aspect ratio

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1040,6 +1040,28 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             # ax[:set_title](sp[:title], loc = loc)
         end
 
+        # framestyle
+        if !ispolar(sp) && !is3d(sp)
+            if sp[:framestyle] == :semi
+                intensity = 0.5
+                ax[:spines]["right"][:set_alpha](intensity)
+                ax[:spines]["top"][:set_alpha](intensity)
+                ax[:spines]["right"][:set_linewidth](intensity)
+                ax[:spines]["top"][:set_linewidth](intensity)
+            elseif sp[:framestyle] in (:axes, :origin)
+                ax[:spines]["right"][:set_visible](false)
+                ax[:spines]["top"][:set_visible](false)
+                if sp[:framestyle] == :origin
+                    ax[:spines]["bottom"][:set_position]("zero")
+                    ax[:spines]["left"][:set_position]("zero")
+                end
+            elseif sp[:framestyle] in (:grid, :none, :origin)
+                for (loc, spine) in ax[:spines]
+                    spine[:set_visible](false)
+                end
+            end
+        end
+
         # axis attributes
         for letter in (:x, :y, :z)
             axissym = Symbol(letter, :axis)
@@ -1091,27 +1113,6 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
         # this sets the bg color inside the grid
         ax[set_facecolor_sym](py_color(sp[:background_color_inside]))
 
-        # framestyle
-        if !ispolar(sp) && !is3d(sp)
-            if sp[:framestyle] == :semi
-                intensity = 0.5
-                ax[:spines]["right"][:set_alpha](intensity)
-                ax[:spines]["top"][:set_alpha](intensity)
-                ax[:spines]["right"][:set_linewidth](intensity)
-                ax[:spines]["top"][:set_linewidth](intensity)
-            elseif sp[:framestyle] == :axes
-                ax[:spines]["right"][:set_visible](false)
-                ax[:spines]["top"][:set_visible](false)
-            elseif sp[:framestyle] in (:grid, :none, :origin)
-                for (loc, spine) in ax[:spines]
-                    spine[:set_visible](false)
-                end
-                if sp[:framestyle] == :origin
-                    ax[:axhline](y = 0, color= py_color(sp[:xaxis][:foreground_color_axis]), lw = 0.5)
-                    ax[:axvline](x = 0, color= py_color(sp[:yaxis][:foreground_color_axis]), lw = 0.5)
-                end
-            end
-        end
     end
     py_drawfig(fig)
 end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1077,6 +1077,10 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             py_set_scale(ax, axis)
             py_set_lims(ax, axis)
             ticks = sp[:framestyle] == :none ? nothing : get_ticks(axis)
+            # don't show the 0 tick label for the origin framestyle
+            if sp[:framestyle] == :origin && length(ticks) > 1
+                ticks[2][ticks[1] .== 0] = ""
+            end
             py_set_ticks(ax, ticks, letter)
             ax[Symbol("set_", letter, "label")](axis[:guide])
             if get(axis.d, :flip, false)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1099,16 +1099,16 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 ax[:spines]["top"][:set_alpha](intensity)
                 ax[:spines]["right"][:set_linewidth](intensity)
                 ax[:spines]["top"][:set_linewidth](intensity)
-            elseif sp[:framestyle] in (:axes, :origin)
+            elseif sp[:framestyle] == :axes
                 ax[:spines]["right"][:set_visible](false)
                 ax[:spines]["top"][:set_visible](false)
-                if sp[:framestyle] == :origin
-                    ax[:spines]["left"][:set_position]("zero")
-                    ax[:spines]["bottom"][:set_position]("zero")
-                end
-            elseif sp[:framestyle] in (:grid, :none)
+            elseif sp[:framestyle] in (:grid, :none, :origin)
                 for (loc, spine) in ax[:spines]
                     spine[:set_visible](false)
+                end
+                if sp[:framestyle] == :origin
+                    ax[:axhline](y = 0, color= py_color(sp[:xaxis][:foreground_color_axis]), lw = 0.5)
+                    ax[:axvline](x = 0, color= py_color(sp[:yaxis][:foreground_color_axis]), lw = 0.5)
                 end
             end
         end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1099,9 +1099,13 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 ax[:spines]["top"][:set_alpha](intensity)
                 ax[:spines]["right"][:set_linewidth](intensity)
                 ax[:spines]["top"][:set_linewidth](intensity)
-            elseif sp[:framestyle] == :axes
+            elseif sp[:framestyle] in (:axes, :origin)
                 ax[:spines]["right"][:set_visible](false)
                 ax[:spines]["top"][:set_visible](false)
+                if sp[:framestyle] == :origin
+                    ax[:spines]["left"][:set_position]("zero")
+                    ax[:spines]["bottom"][:set_position]("zero")
+                end
             elseif sp[:framestyle] in (:grid, :none)
                 for (loc, spine) in ax[:spines]
                     spine[:set_visible](false)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -365,7 +365,7 @@ function _expand_subplot_extrema(sp::Subplot, d::KW, st::Symbol)
         expand_extrema!(sp, d)
     end
     # expand for zerolines (axes through origin)
-    if sp[:framestyle] == :origin
+    if sp[:framestyle] in (:origin, :zerolines)
         expand_extrema!(sp[:xaxis], 0.0)
         expand_extrema!(sp[:yaxis], 0.0)
     end

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -364,6 +364,11 @@ function _expand_subplot_extrema(sp::Subplot, d::KW, st::Symbol)
     elseif !(st in (:pie, :histogram, :bins2d, :histogram2d))
         expand_extrema!(sp, d)
     end
+    # expand for zerolines (axes through origin)
+    if sp[:framestyle] == :origin
+        expand_extrema!(sp[:xaxis], 0.0)
+        expand_extrema!(sp[:yaxis], 0.0)
+    end
 end
 
 function _add_the_series(plt, sp, d)


### PR DESCRIPTION
This adds the `:origin` option and its alias `:zeroline` to the newly introduced `framestyle` attribute (cf #1029).
```julia
x, y = [randn(10) rand(10) + 1], [randn(10) rand(10) + 1]
scatter(x, y, framestyle = :origin,
    title = ["Origin inside data" "Origin outside data"], layout = 2, label = "")
```
**GR**
![origin_gr](https://user-images.githubusercontent.com/16589944/29841603-4fe16c7c-8d06-11e7-841f-c91cf8ec4692.png)

**PyPlot**
![origin_pyplot](https://user-images.githubusercontent.com/16589944/29841597-47ded258-8d06-11e7-9449-b12383b918ca.png)

**GLVisualize**
![origin_glvisualize](https://user-images.githubusercontent.com/16589944/29838767-660d745a-8cfc-11e7-91ec-f7c32d085a9d.png)

cc: @mkborregaard 