### PR TITLE
gr: suppress default output in CI or Jupyter mode

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -580,6 +580,9 @@ function gr_get_ticks_size(ticks, i)
 end
 
 function _update_min_padding!(sp::Subplot{GRBackend})
+    if !haskey(ENV, "GKSwstype") && isijulia()
+        ENV["GKSwstype"] = "svg"
+    end
     # Add margin given by the user
     leftpad   = 2mm  + sp[:left_margin]
     toppad    = 2mm  + sp[:top_margin]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ default(show=false, reuse=true)
 img_eps = isinteractive() ? 1e-2 : 10e-2
 
 @testset "GR" begin
+    ENV["GKSwstype"] = "100"
     @test gr() == Plots.GRBackend()
     @test backend() == Plots.GRBackend()
 


### PR DESCRIPTION
_update_min_padding() is called before the backend is "started".
In GR, this triggers an automatic initialization and starts the
default output driver (X11, Quartz or GDI). This doesn't make
sense in headless testing environments (CI) or when using Plots
in Jupyter notebooks.

These patches correct this behavour - but it's unclear (to me),
why the call of _update_min_padding() can't be postponed.