### PR TITLE
WIP: allow to group user recipes

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -516,8 +516,9 @@ splittable_kw(key, val::Tuple, lengthGroup) = all(splittable_kw.(key, val, lengt
 split_kw(key, val::AbstractArray, indices) = val[indices, fill(Colon(), ndims(val)-1)...]
 split_kw(key, val::Tuple, indices) = Tuple(split_kw(key, v, indices) for v in val)
 
-function build_arg_mat(x_ind, x, y, groupby)
-    y_mat = fill(NaN, length(keys(x_ind)), length(groupby.groupLabels))
+function groupedvec2mat(x_ind, x, y::AbstractArray, groupby, def_val = y[1])
+    y_mat = Array{promote_type(eltype(y), typeof(def_val))}(length(keys(x_ind)), length(groupby.groupLabels))
+    fill!(y_mat, def_val)
     for i in 1:length(groupby.groupLabels)
         xi = x[groupby.groupIds[i]]
         yi = y[groupby.groupIds[i]]
@@ -525,6 +526,8 @@ function build_arg_mat(x_ind, x, y, groupby)
     end
     return y_mat
 end
+
+groupedvec2mat(x_ind, x, y::Tuple, groupby) = Tuple(groupedvec2mat(x_ind, x, v, groupby) for v in y)
 
 group_as_matrix(t) = false
 
@@ -558,7 +561,12 @@ group_as_matrix(t) = false
         end
         x_u = unique(x)
         x_ind = Dict(zip(x_u, 1:length(x_u)))
+        for (key,val) in d
+            if splittable_kw(key, val, lengthGroup)
+                :($key) := groupedvec2mat(x_ind, x, val, groupby)
+            end
+        end
         label --> reshape(groupby.groupLabels, 1, :)
-        typeof(g)((x_u, (build_arg_mat(x_ind, x, arg, groupby) for arg in last_args)...))
+        typeof(g)((x_u, (groupedvec2mat(x_ind, x, arg, groupby, NaN) for arg in last_args)...))
     end
 end

--- a/src/series.jl
+++ b/src/series.jl
@@ -516,10 +516,12 @@ splittable_kw(key, val::Tuple, lengthGroup) = all(splittable_kw.(key, val, lengt
 split_kw(key, val::AbstractArray, indices) = val[indices, fill(Colon(), ndims(val)-1)...]
 split_kw(key, val::Tuple, indices) = Tuple(split_kw(key, v, indices) for v in val)
 
+group_as_matrix(t) = false
+
 # split the group into 1 series per group, and set the label and idxfilter for each
 @recipe function f(groupby::GroupBy, args...)
     lengthGroup = maximum(union(groupby.groupIds...))
-    if !(RecipesBase.group_as_matrix(args[1]))
+    if !(group_as_matrix(args[1]))
         for (i,glab) in enumerate(groupby.groupLabels)
             @series begin
                 label     --> string(glab)


### PR DESCRIPTION
This PR allows to choose custom grouping behavior for user recipes (a notable example being `groupedbar`, see [#83](https://github.com/JuliaPlots/StatPlots.jl/pull/83) ). Now if the user recipe is set to `group_as_matrix`, it will be grouped as a matrix so `x,y` will go from being two vector to being a 1D array and a matrix, as required by some user recipes.

With the PRs:

```julia
using StatPlots
groupedbar([1 ,2 ,1 ,2 ,1 ,2], rand(6), group = [1,1,2,2, 3, 3])
```

![bar](https://user-images.githubusercontent.com/6333339/29940138-300f716a-8e86-11e7-8c20-e235fd40dd3f.png)
