### PR TITLE
Change default bar width to 0.8

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -193,6 +193,8 @@ const _framestyleAliases = Dict{Symbol, Symbol}(
     :transparent        => :semi,
     :semitransparent    => :semi,
 )
+
+const _bar_width = 0.8
 # -----------------------------------------------------------------------------
 
 const _series_defaults = KW(

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -365,7 +365,7 @@ function expand_extrema!(sp::Subplot, d::KW)
 
         bw = d[:bar_width]
         if bw == nothing
-            bw = d[:bar_width] = ignorenan_mean(diff(data))
+            bw = d[:bar_width] = _bar_width * ignorenan_mean(diff(data))
         end
         axis = sp.attr[Symbol(dsym, :axis)]
         expand_extrema!(axis, ignorenan_maximum(data) + 0.5maximum(bw))

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -289,7 +289,7 @@ end
     # compute half-width of bars
     bw = d[:bar_width]
     hw = if bw == nothing
-        0.5ignorenan_mean(diff(procx))
+        0.5*_bar_width*ignorenan_mean(diff(procx))
     else
         Float64[0.5_cycle(bw,i) for i=1:length(procx)]
     end


### PR DESCRIPTION
The current default bar width in Plots is that adjacent bars touch, like in a histogram. This should not be the default for bars.