### PR TITLE
Seriestype error (fix #1068)

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1276,6 +1276,7 @@ end
 
 # -----------------------------------------------------------------------------
 
+has_black_border_for_default(st) = error("The seriestype attribute only accepts Symbols, you passed $st.")
 function has_black_border_for_default(st::Symbol)
     like_histogram(st) || st in (:hexbin, :bar, :shape)
 end

--- a/src/args.jl
+++ b/src/args.jl
@@ -1276,7 +1276,8 @@ end
 
 # -----------------------------------------------------------------------------
 
-has_black_border_for_default(st) = error("The seriestype attribute only accepts Symbols, you passed $st.")
+has_black_border_for_default(st) = error("The seriestype attribute only accepts Symbols, you passed the $(typeof(st)) $st.")
+has_black_border_for_default(st::Function) = error("The seriestype attribute only accepts Symbols, you passed the function $st.")
 function has_black_border_for_default(st::Symbol)
     like_histogram(st) || st in (:hexbin, :bar, :shape)
 end


### PR DESCRIPTION
Changes
```julia
julia> plot(rand(10), seriestype = scatter)
ERROR: MethodError: no method matching has_black_border_for_default(::Plots.#scatter)
```
to
```julia
julia> plot(rand(10), seriestype = scatter)
ERROR: The seriestype attribute only accepts Symbols, you passed the function Plots.scatter.
```