### PR TITLE
fix 2dhistogram bins

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -506,7 +506,8 @@ function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode
 
     n_samples = length(linearindices(first(vs)))
     # Estimator for number of samples in one row/column of bins along each axis:
-    n = max(1, n_samples^(1/N))
+    nd = n_samples^(1/(2+N))
+
 
     v = vs[dim]
 
@@ -515,15 +516,15 @@ function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode
     end
 
     if mode == :sqrt  # Square-root choice
-        _cl(sqrt(n))
+        _cl(sqrt(n_samples))
     elseif mode == :sturges  # Sturges' formula
-        _cl(log2(n)) + 1
+        _cl(log2(n_samples)) + 1
     elseif mode == :rice  # Rice Rule
-        _cl(2 * n^(1/3))
+        _cl(2 * nd)
     elseif mode == :scott  # Scott's normal reference rule
-        _cl(_span(v) / (3.5 * std(v) / n^(1/3)))
+        _cl(_span(v) / (3.5 * std(v) / nd))
     elseif mode == :fd  # Freedman–Diaconis rule
-        _cl(_span(v) / (2 * _iqr(v) / n^(1/3)))
+        _cl(_span(v) / (2 * _iqr(v) / nd))
     elseif mode == :wand
         wand_edges(v)  # this makes this function not type stable, but the type instability does not propagate
     else

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -505,9 +505,10 @@ function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode
     _span(v) = ignorenan_maximum(v) - ignorenan_minimum(v)
 
     n_samples = length(linearindices(first(vs)))
-    # Estimator for number of samples in one row/column of bins along each axis:
-    nd = n_samples^(1/(2+N))
 
+    # The nd estimator is the key to most automatic binning methods, and is modified for twodimensional histograms to include correlation
+    nd = n_samples^(1/(2+N))
+    nd = N == 2 ? nd / (1-cor(first(vs), last(vs))^2)^(3//8) : nd # the >2-dimensional case does not have a nice solution to correlations
 
     v = vs[dim]
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -519,7 +519,7 @@ function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode
     if mode == :sqrt  # Square-root choice
         _cl(sqrt(n_samples))
     elseif mode == :sturges  # Sturges' formula
-        _cl(log2(n_samples)) + 1
+        _cl(log2(n_samples) + 1)
     elseif mode == :rice  # Rice Rule
         _cl(2 * nd)
     elseif mode == :scott  # Scott's normal reference rule


### PR DESCRIPTION
The current estimator selected too few bins for 2-dimensional histograms - edited using a principle derived from the multivariate Scott's rule (Scott 1992 - Multivariate Density Estimation: Theory, Practice, and Visualization).