### PR TITLE
histogram: ensure the number of bins is finite

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -501,7 +501,7 @@ wand_edges(x...) = (warn("Load the StatPlots package in order to use :wand bins.
 
 function _auto_binning_nbins{N}(vs::NTuple{N,AbstractVector}, dim::Integer; mode::Symbol = :auto)
     _cl(x) = ceil(Int, NaNMath.max(x, one(x)))
-    _iqr(v) = quantile(v, 0.75) - quantile(v, 0.25)
+    _iqr(v) = (q = quantile(v, 0.75) - quantile(v, 0.25); q > 0 ? q : oftype(q, 1))
     _span(v) = ignorenan_maximum(v) - ignorenan_minimum(v)
 
     n_samples = length(linearindices(first(vs)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,6 +129,9 @@ end
     @test Plots.ignorenan_extrema(axis) == (0.5, 7.5)
 end
 
+@testset "NoFail" begin
+    histogram([1, 0, 0, 0, 0, 0])
+end
 
 # tests for preprocessing recipes
 


### PR DESCRIPTION
Fixes the following error:
```julia
julia> histogram([1, 0, 0, 0, 0, 0])
ERROR: InexactError()
Stacktrace:
 [1] trunc(::Type{Int64}, ::Float64) at ./float.jl:672
 [2] #_auto_binning_nbins#214(::Symbol, ::Function, ::Tuple{Array{Int64,1}}, ::Int64) at /home/tim/.julia/v0.6/Plots/src/recipes.jl:528
 [3] (::Plots.#kw##_auto_binning_nbins)(::Array{Any,1}, ::Plots.#_auto_binning_nbins, ::Tuple{Array{Int64,1}}, ::Int64) at ./<missing>:0
 [4] map(::Plots.##220#221{Tuple{Array{Int64,1}},Symbol}, ::Tuple{Int64}) at ./tuple.jl:158
 [5] #_make_hist#222(::Bool, ::Void, ::Function, ::Tuple{Array{Int64,1}}, ::Symbol) at /home/tim/.julia/v0.6/Plots/src/recipes.jl:550
 [6] (::Plots.#kw##_make_hist)(::Array{Any,1}, ::Plots.#_make_hist, ::Tuple{Array{Int64,1}}, ::Symbol) at ./<missing>:0
 [7] macro expansion at /home/tim/.julia/v0.6/Plots/src/recipes.jl:566 [inlined]
 [8] apply_recipe(::Dict{Symbol,Any}, ::Type{Val{:barhist}}, ::UnitRange{Int64}, ::Array{Int64,1}, ::Void) at /home/tim/.julia/v0.6/RecipesBase/src/RecipesBase.jl:265
 [9] _process_seriesrecipe(::Plots.Plot{Plots.PlotlyJSBackend}, ::Dict{Symbol,Any}) at /home/tim/.julia/v0.6/Plots/src/pipeline.jl:406
 [10] _process_seriesrecipe(::Plots.Plot{Plots.PlotlyJSBackend}, ::Dict{Symbol,Any}) at /home/tim/.julia/v0.6/Plots/src/pipeline.jl:415
 [11] _plot!(::Plots.Plot{Plots.PlotlyJSBackend}, ::Dict{Symbol,Any}, ::Tuple{Array{Int64,1}}) at /home/tim/.julia/v0.6/Plots/src/plot.jl:231
 [12] (::RecipesBase.#kw##plot)(::Array{Any,1}, ::RecipesBase.#plot, ::Array{Int64,1}) at ./<missing>:0
 [13] #histogram#435(::Array{Any,1}, ::Function, ::Array{Int64,1}, ::Vararg{Array{Int64,1},N} where N) at /home/tim/.julia/v0.6/RecipesBase/src/RecipesBase.jl:359
 [14] histogram(::Array{Int64,1}, ::Vararg{Array{Int64,1},N} where N) at /home/tim/.julia/v0.6/RecipesBase/src/RecipesBase.jl:359
```
because `_iqr` used to return 0, giving `Inf` for the number of bins which can't be represented as an `Int`.
