### PR TITLE
Fix GR marker_z and clims (fix #1063)

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -539,6 +539,28 @@ xlims(sp_idx::Int = 1) = xlims(current(), sp_idx)
 ylims(sp_idx::Int = 1) = ylims(current(), sp_idx)
 zlims(sp_idx::Int = 1) = zlims(current(), sp_idx)
 
+
+function get_clims(sp::Subplot)
+    zmin, zmax = Inf, -Inf
+    for series in series_list(sp)
+        for vals in (series[:z], series[:line_z], series[:marker_z])
+            if (typeof(vals) <: AbstractSurface) && (eltype(vals.surf) <: Real)
+                zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals.surf)...)
+            elseif (vals != nothing) && (eltype(vals) <: Real)
+                zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals)...)
+            end
+        end
+    end
+    clims = sp[:clims]
+    if is_2tuple(clims)
+        isfinite(clims[1]) && (zmin = clims[1])
+        isfinite(clims[2]) && (zmax = clims[2])
+    end
+    return zmin < zmax ? (zmin, zmax) : (0.0, 0.0)
+end
+
+_update_clims(zmin, zmax, emin, emax) = min(zmin, emin), max(zmax, emax)
+
 # ---------------------------------------------------------------
 
 makekw(; kw...) = KW(kw)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ include("imgcomp.jl")
 # don't actually show the plots
 srand(1234)
 default(show=false, reuse=true)
-img_eps = isinteractive() ? 1e-2 : 10e-2
+img_eps = isinteractive() ? 1e-4 : 12e-2
 
 @testset "GR" begin
     ENV["GKSwstype"] = "100"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ include("imgcomp.jl")
 # don't actually show the plots
 srand(1234)
 default(show=false, reuse=true)
-img_eps = isinteractive() ? 1e-4 : 12e-2
+img_eps = isinteractive() ? 1e-2 : 10e-2
 
 @testset "GR" begin
     ENV["GKSwstype"] = "100"


### PR DESCRIPTION
This changes
```julia
using Plots; gr()
y1 = rand(10)
y2 = rand(10) + 2
scatter([y1 y2], marker_z = [y1 y2], markershape = [:star5 :circle], clims = (0, 5), markersize = 10)
```
from
![markerzgrold](https://user-images.githubusercontent.com/16589944/30232312-9e82ab5c-94ef-11e7-8cd4-2a4304c91f53.png)
to
![markerzgrnew](https://user-images.githubusercontent.com/16589944/30232319-a808f53c-94ef-11e7-9a43-3952472dab05.png)
