### PR TITLE
Only one colorbar per subplot on pyplot

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -561,12 +561,25 @@ end
 
 _update_clims(zmin, zmax, emin, emax) = min(zmin, emin), max(zmax, emax)
 
+function hascolorbar(series::Series)
+    st = series[:seriestype]
+    hascbar = st in (:heatmap, :contour)
+    if series[:marker_z] != nothing || series[:line_z] != nothing
+        hascbar = true
+    end
+    # no colorbar if we are creating a surface LightSource
+    if xor(st == :surface, series[:fill_z] != nothing)
+        hascbar = true
+    end
+    return hascbar
+end
+
 function hascolorbar(sp::Subplot)
     cbar = sp[:colorbar]
     hascbar = false
     if cbar != :none
         for series in series_list(sp)
-            if series[:seriestype] in (:heatmap, :contour, :surface) || series[:marker_z] != nothing || series[:line_z] != nothing
+            if hascolorbar(series)
                 hascbar = true
             end
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -561,6 +561,19 @@ end
 
 _update_clims(zmin, zmax, emin, emax) = min(zmin, emin), max(zmax, emax)
 
+function hascolorbar(sp::Subplot)
+    cbar = sp[:colorbar]
+    hascbar = false
+    if cbar != :none
+        for series in series_list(sp)
+            if series[:seriestype] in (:heatmap, :contour, :surface) || series[:marker_z] != nothing || series[:line_z] != nothing
+                hascbar = true
+            end
+        end
+    end
+    hascbar
+end
+
 # ---------------------------------------------------------------
 
 makekw(; kw...) = KW(kw)


### PR DESCRIPTION
This changes
```julia
using Plots; pyplot()
y1 = rand(10)
y2 = rand(10) + 2
scatter([y1 y2], marker_z = [y1 y2], markershape = [:star5 :circle], clims = (0, 5), markersize = 10)
```
from
![marker_z_pyplot_old](https://user-images.githubusercontent.com/16589944/30238970-7e5a2554-9552-11e7-9886-a55c7bd1b815.png)
to
![marker_z_pyplot_new](https://user-images.githubusercontent.com/16589944/30238972-85c371c4-9552-11e7-9786-76d97f451d73.png)
