### PR TITLE
fix marker_z for plotly

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -575,14 +575,18 @@ function plotly_series(plt::Plot, series::Series)
         )
 
         # gotta hack this (for now?) since plotly can't handle rgba values inside the gradient
-        d_out[:marker][:color] = if series[:marker_z] == nothing
-            rgba_string(series[:markercolor])
+        if series[:marker_z] == nothing
+            d_out[:marker][:color] = rgba_string(series[:markercolor])
         else
             # grad = ColorGradient(series[:markercolor], alpha=series[:markeralpha])
-            grad = as_gradient(series[:markercolor], series[:markeralpha])
-            zmin, zmax = ignorenan_extrema(series[:marker_z])
-            zrange = zmax == zmin ? 1 : zmax - zmin # if all marker_z values are the same, plot all markers same color (avoids division by zero in next line)
-            [rgba_string(grad[(zi - zmin) / zrange]) for zi in series[:marker_z]]
+            # grad = as_gradient(series[:markercolor], series[:markeralpha])
+            cmin, cmax = get_clims(sp)
+            # zrange = zmax == zmin ? 1 : zmax - zmin # if all marker_z values are the same, plot all markers same color (avoids division by zero in next line)
+            d_out[:marker][:color] = [clamp(zi, cmin, cmax) for zi in series[:marker_z]]
+            d_out[:marker][:cmin] = cmin
+            d_out[:marker][:cmax] = cmax
+            d_out[:marker][:colorscale] = plotly_colorscale(series[:markercolor], series[:markeralpha])
+            d_out[:marker][:showscale] = hascolorbar(sp)
         end
     end
 


### PR DESCRIPTION
This changes
```julia
using Plots; plotlyjs()
y1 = rand(10)
y2 = rand(10) + 2
scatter([y1 y2], marker_z = [y1 y2], markershape = [:diamond :circle], clims = (0, 5), markersize = 10)
```
from
![marker_z_plotly_old](https://user-images.githubusercontent.com/16589944/30523239-136a2d9c-9bde-11e7-9637-886d11e69fbc.png)

to
![marker_z_plotly_new](https://user-images.githubusercontent.com/16589944/30523206-98a5a32a-9bdd-11e7-9212-48c75b0efb31.png)

The hidden legend issue has to be fixed manually with e.g. `legend = (1.15, 1.0)` for now. I have not come up with a smart default legend / colorbar positioning yet.