### PR TITLE
Fix for wrong setting of logscale for values below 1e-16

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -903,7 +903,7 @@ function py_set_scale(ax, axis::Axis)
         elseif scale == :log10
             10
         end
-        kw[Symbol(:linthresh,letter)] = NaNMath.max(1e-16, py_compute_axis_minval(axis))
+        kw[Symbol(:linthresh,letter)] = NaNMath.min(1e-16, py_compute_axis_minval(axis))
         "symlog"
     end
     func(arg; kw...)


### PR DESCRIPTION
This fixes the issue https://github.com/JuliaPlots/Plots.jl/issues/1095 for PyPlot backend