### PR TITLE
Allow plotting empty Vector{Any} (fix #1078)

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -174,6 +174,7 @@ _apply_type_recipe(d, v) = RecipesBase.apply_recipe(d, typeof(v), v)[1].args[1]
 # This sort of recipe should return a pair of functions... one to convert to number,
 # and one to format tick values.
 function _apply_type_recipe(d, v::AbstractArray)
+    isempty(v) && return Float64[]
     args = RecipesBase.apply_recipe(d, typeof(v[1]), v[1])[1].args
     if length(args) == 2 && typeof(args[1]) <: Function && typeof(args[2]) <: Function
         numfunc, formatter = args


### PR DESCRIPTION
makes `plot([])`, `plot([], [])` and `plot([], [], [])` return a plot with an empty series.