### PR TITLE
Colorbar takes font style from Y Axis

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -999,13 +999,13 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             # create and store the colorbar object (handle) and the axis that it is drawn on.
             # note: the colorbar axis is positioned independently from the subplot axis
             fig = plt.o
-		cbax = fig[:add_axes]([0.8,0.1,0.03,0.8], label = string(gensym()))
-		cb = fig[:colorbar](handle; cax = cbax, kw...)
-		cb[:set_label](sp[:colorbar_title],size=py_dpi_scale(plt, sp[:yaxis][:guidefont].pointsize),family=sp[:yaxis][:guidefont].family)
-		for lab in cb[:ax][:yaxis][:get_ticklabels]()
-			lab[:set_fontsize](py_dpi_scale(plt, sp[:yaxis][:tickfont].pointsize))
-			lab[:set_family](sp[:yaxis][:tickfont].family)
-		end 
+            cbax = fig[:add_axes]([0.8,0.1,0.03,0.8], label = string(gensym()))
+            cb = fig[:colorbar](handle; cax = cbax, kw...)
+            cb[:set_label](sp[:colorbar_title],size=py_dpi_scale(plt, sp[:yaxis][:guidefont].pointsize),family=sp[:yaxis][:guidefont].family)
+            for lab in cb[:ax][:yaxis][:get_ticklabels]()
+                  lab[:set_fontsize](py_dpi_scale(plt, sp[:yaxis][:tickfont].pointsize))
+                  lab[:set_family](sp[:yaxis][:tickfont].family)
+            end 
             sp.attr[:cbar_handle] = cb
             sp.attr[:cbar_ax] = cbax
         end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -999,9 +999,13 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             # create and store the colorbar object (handle) and the axis that it is drawn on.
             # note: the colorbar axis is positioned independently from the subplot axis
             fig = plt.o
-            cbax = fig[:add_axes]([0.8,0.1,0.03,0.8], label = string(gensym()))
-            cb = fig[:colorbar](handle; cax = cbax, kw...)
-            cb[:set_label](sp[:colorbar_title])
+		cbax = fig[:add_axes]([0.8,0.1,0.03,0.8], label = string(gensym()))
+		cb = fig[:colorbar](handle; cax = cbax, kw...)
+		cb[:set_label](sp[:colorbar_title],size=py_dpi_scale(plt, sp[:yaxis][:guidefont].pointsize),family=sp[:yaxis][:guidefont].family)
+		for lab in cb[:ax][:yaxis][:get_ticklabels]()
+			lab[:set_fontsize](py_dpi_scale(plt, sp[:yaxis][:tickfont].pointsize))
+			lab[:set_family](sp[:yaxis][:tickfont].family)
+		end 
             sp.attr[:cbar_handle] = cb
             sp.attr[:cbar_ax] = cbax
         end


### PR DESCRIPTION
Added some examples for different font types
Source Code Pro:
![source_code_pro](https://user-images.githubusercontent.com/3662297/30850334-1d86fcc0-a2e0-11e7-8e17-5e38267c00ac.png)
Noto Sans:
![noto_sans](https://user-images.githubusercontent.com/3662297/30850336-1db016a0-a2e0-11e7-829c-3f9eb4bb460d.png)
DejaVu Serif
![dejavu_serif](https://user-images.githubusercontent.com/3662297/30850337-1db83efc-a2e0-11e7-916e-5604f9c9946f.png)
