### PR TITLE
RFC: Implement line_z and fill_z for GR

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1371,12 +1371,15 @@ function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
         getSeriesRGBColor(d[:markerstrokecolor], d[:markerstrokealpha], sp, plotIndex)
     end
 
-    # if marker_z or line_z are set, ensure we have a gradient
+    # if marker_z, fill_z or line_z are set, ensure we have a gradient
     if d[:marker_z] != nothing
         ensure_gradient!(d, :markercolor, :markeralpha)
     end
     if d[:line_z] != nothing
         ensure_gradient!(d, :linecolor, :linealpha)
+    end
+    if d[:fill_z] != nothing
+        ensure_gradient!(d, :fillcolor, :fillalpha)
     end
 
     # scatter plots don't have a line, but must have a shape

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -942,7 +942,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                         gr_set_fillcolor(get_fillcolor(sp, series, i))
                         xseg = _cycle(x, [i, i+1, i+1, i])
                         yseg = [_cycle(fr_from, [i, i+1]); _cycle(fr_to, [i+1, i])]
-                        GR.settransparency(series[:fillalpha])
+                        series[:fillalpha] != nothing && GR.settransparency(series[:fillalpha])
                         GR.fillarea(xseg, yseg)
                     end
                     gr_set_line(1, :solid, yaxis[:foreground_color_axis])

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1100,8 +1100,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
                     # get the segments
                     xseg, yseg = x[rng], y[rng]
-                    @show xseg
-                    @show yseg
 
                     # draw the interior
                     gr_set_fill(get_fillcolor(sp, series, i))
@@ -1111,9 +1109,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     gr_set_line(series[:linewidth], :solid, get_linecolor(sp, series, i))
                     GR.polyline(xseg, yseg)
                 end
-                gr_set_line(1, :solid, yaxis[:foreground_color_axis])
-                cmap && gr_colorbar(sp, clims)
             end
+            gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+            cmap && gr_colorbar(sp, clims)
 
 
         elseif st == :image

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -949,9 +949,11 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
                 # draw the line(s)
                 if st == :path
-                    gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series)) #, series[:linealpha])
-                    arrowside = isa(series[:arrow], Arrow) ? series[:arrow].side : :none
-                    gr_polyline(x, y; arrowside = arrowside)
+                    for (i,rng) in enumerate(iter_segments(series[:x], series[:y]))
+                        gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series, i)) #, series[:linealpha])
+                        arrowside = isa(series[:arrow], Arrow) ? series[:arrow].side : :none
+                        gr_polyline(series[:x][rng], series[:y][rng]; arrowside = arrowside)
+                    end
                     gr_set_line(1, :solid, yaxis[:foreground_color_axis])
                     cmap && gr_colorbar(sp, clims)
                 end
@@ -1173,7 +1175,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             for series in series_list(sp)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
-                gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series)) #, series[:linealpha])
+                gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series, 1)) #, series[:linealpha])
 
                 if (st == :shape || series[:fillrange] != nothing) && series[:ribbon] == nothing
                     gr_set_fill(series[:fillcolor]) #, series[:fillalpha])

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -22,7 +22,7 @@ const _gr_attr = merge_with_base_supported([
     :tickfont, :guidefont, :legendfont,
     :grid, :gridalpha, :gridstyle, :gridlinewidth,
     :legend, :legendtitle, :colorbar,
-    :line_z, :marker_z, :levels,
+    :fill_z, :line_z, :marker_z, :levels,
     :ribbon, :quiver,
     :orientation,
     :overwrite_figure,
@@ -898,6 +898,8 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             series[:markercolor] = gr_set_gradient(series[:markercolor])
         elseif series[:line_z] !=  nothing
             series[:linecolor] = gr_set_gradient(series[:linecolor])
+        elseif series[:fill_z] != nothing
+            series[:fillcolor] = gr_set_gradient(series[:fillcolor])
         end
 
         GR.savestate()
@@ -936,23 +938,26 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 if frng != nothing
                     GR.setfillintstyle(GR.INTSTYLE_SOLID)
                     fr_from, fr_to = (is_2tuple(frng) ? frng : (y, frng))
-                    for (i,rng) in enumerate(iter_segments(series[:x], series[:y]))
-                        if length(rng) > 1
-                            gr_set_fillcolor(_cycle(series[:fillcolor], i))
-                            fx = _cycle(x, vcat(rng, reverse(rng)))
-                            fy = vcat(_cycle(fr_from,rng), _cycle(fr_to,reverse(rng)))
-                            # @show i rng fx fy
-                            GR.fillarea(fx, fy)
-                        end
+                    for i in 1:length(x) - 1
+                        gr_set_fillcolor(get_fillcolor(sp, series, i))
+                        xseg = _cycle(x, [i, i+1, i+1, i])
+                        yseg = [_cycle(fr_from, [i, i+1]); _cycle(fr_to, [i+1, i])]
+                        GR.settransparency(series[:fillalpha])
+                        GR.fillarea(xseg, yseg)
                     end
+                    gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+                    GR.settransparency(1)
+                    cmap && gr_colorbar(sp, clims)
                 end
 
                 # draw the line(s)
                 if st == :path
-                    for (i,rng) in enumerate(iter_segments(series[:x], series[:y]))
+                    for i in 1:length(x) - 1
+                        xseg = x[i:(i + 1)]
+                        yseg = y[i:(i + 1)]
                         gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series, i)) #, series[:linealpha])
-                        arrowside = isa(series[:arrow], Arrow) ? series[:arrow].side : :none
-                        gr_polyline(series[:x][rng], series[:y][rng]; arrowside = arrowside)
+                        arrowside = (i == length(y) - 1) && isa(series[:arrow], Arrow) ? series[:arrow].side : :none
+                        gr_polyline(xseg, yseg; arrowside = arrowside)
                     end
                     gr_set_line(1, :solid, yaxis[:foreground_color_axis])
                     cmap && gr_colorbar(sp, clims)
@@ -1022,10 +1027,15 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         elseif st in (:path3d, :scatter3d)
             # draw path
             if st == :path3d
-                if length(x) > 1
-                    gr_set_line(series[:linewidth], series[:linestyle], series[:linecolor]) #, series[:linealpha])
-                    GR.polyline3d(x, y, z)
+                for i in 1:length(x) - 1
+                    xseg = x[i:(i + 1)]
+                    yseg = y[i:(i + 1)]
+                    zseg = z[i:(i + 1)]
+                    gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series, i)) #, series[:linealpha])
+                    GR.polyline3d(xseg, yseg, zseg)
                 end
+                gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+                cmap && gr_colorbar(sp, clims)
             end
 
             # draw markers
@@ -1083,22 +1093,26 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             GR.selntran(1)
 
         elseif st == :shape
-            for (i,rng) in enumerate(iter_segments(series[:x], series[:y]))
+            for (i,rng) in enumerate(iter_segments(x, y))
                 if length(rng) > 1
                     # connect to the beginning
                     rng = vcat(rng, rng[1])
 
                     # get the segments
-                    x, y = series[:x][rng], series[:y][rng]
+                    xseg, yseg = x[rng], y[rng]
+                    @show xseg
+                    @show yseg
 
                     # draw the interior
-                    gr_set_fill(_cycle(series[:fillcolor], i))
-                    GR.fillarea(x, y)
+                    gr_set_fill(get_fillcolor(sp, series, i))
+                    GR.fillarea(xseg, yseg)
 
                     # draw the shapes
-                    gr_set_line(series[:linewidth], :solid, _cycle(series[:linecolor], i))
-                    GR.polyline(x, y)
+                    gr_set_line(series[:linewidth], :solid, get_linecolor(sp, series, i))
+                    GR.polyline(xseg, yseg)
                 end
+                gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+                cmap && gr_colorbar(sp, clims)
             end
 
 
@@ -1175,10 +1189,10 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             for series in series_list(sp)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
-                gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series, 1)) #, series[:linealpha])
+                gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series)) #, series[:linealpha])
 
                 if (st == :shape || series[:fillrange] != nothing) && series[:ribbon] == nothing
-                    gr_set_fill(series[:fillcolor]) #, series[:fillalpha])
+                    gr_set_fill(get_fillcolor(sp, series)) #, series[:fillalpha])
                     l, r = xpos-0.07, xpos-0.01
                     b, t = ypos-0.4dy, ypos+0.4dy
                     x = [l, r, r, l, l]

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -22,7 +22,7 @@ const _gr_attr = merge_with_base_supported([
     :tickfont, :guidefont, :legendfont,
     :grid, :gridalpha, :gridstyle, :gridlinewidth,
     :legend, :legendtitle, :colorbar,
-    :marker_z, :levels,
+    :line_z, :marker_z, :levels,
     :ribbon, :quiver,
     :orientation,
     :overwrite_figure,
@@ -896,6 +896,8 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             gr_set_gradient(series[:fillcolor]) #, series[:fillalpha])
         elseif series[:marker_z] != nothing
             series[:markercolor] = gr_set_gradient(series[:markercolor])
+        elseif series[:line_z] !=  nothing
+            series[:linecolor] = gr_set_gradient(series[:linecolor])
         end
 
         GR.savestate()
@@ -947,9 +949,11 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
                 # draw the line(s)
                 if st == :path
-                    gr_set_line(series[:linewidth], series[:linestyle], series[:linecolor]) #, series[:linealpha])
+                    gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series)) #, series[:linealpha])
                     arrowside = isa(series[:arrow], Arrow) ? series[:arrow].side : :none
                     gr_polyline(x, y; arrowside = arrowside)
+                    gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+                    cmap && gr_colorbar(sp, clims)
                 end
             end
 
@@ -1169,7 +1173,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             for series in series_list(sp)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
-                gr_set_line(series[:linewidth], series[:linestyle], series[:linecolor]) #, series[:linealpha])
+                gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series)) #, series[:linealpha])
 
                 if (st == :shape || series[:fillrange] != nothing) && series[:ribbon] == nothing
                     gr_set_fill(series[:fillcolor]) #, series[:fillalpha])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -587,6 +587,17 @@ function hascolorbar(sp::Subplot)
     hascbar
 end
 
+function get_linecolor(sp::Subplot, series::Series)
+    lc = series[:linecolor]
+    if series[:line_z] == nothing
+        lc
+    else
+        cmin, cmax = get_clims(sp)
+        grad = isa(lc, ColorGradient) ? lc : cgrad()
+        grad[clamp((series[:line_z] - cmin) / (cmax -cmin), 0, 1)]
+    end
+end
+
 # ---------------------------------------------------------------
 
 makekw(; kw...) = KW(kw)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -587,14 +587,15 @@ function hascolorbar(sp::Subplot)
     hascbar
 end
 
-function get_linecolor(sp::Subplot, series::Series)
+function get_linecolor(sp::Subplot, series::Series, i::Int)
     lc = series[:linecolor]
-    if series[:line_z] == nothing
-        lc
+    lz = series[:line_z]
+    if lz == nothing
+        _cycle(lc, i)
     else
         cmin, cmax = get_clims(sp)
         grad = isa(lc, ColorGradient) ? lc : cgrad()
-        grad[clamp((series[:line_z] - cmin) / (cmax -cmin), 0, 1)]
+        grad[clamp((_cycle(lz, i) - cmin) / (cmax -cmin), 0, 1)]
     end
 end
 


### PR DESCRIPTION
This allows to have lines with colors corresponding to a value, multi-colored lines, "heatmaps" with custom shapes, ... e.g.
```julia
using Plots; gr()

σs = 0.5:0.1:2
normal_x = linspace(-5, 5, 100)
normal_y = [exp.(-normal_x.^2 / (2σ^2)) / (2π * σ^2) for σ in σs]

xs, ys = Plots.unzip(Plots.partialcircle(0, 2π, 50, 0.5))
shapes = [Shape(xs + i, ys + j) for i in 1:10, j in 1:10]
zvals = [i * j for i in 1:10, j in 1:10]

y = cumsum(randn(1000))

plot(
    plot(normal_x, normal_y, line_z = σs'),
    plot(shapes, fill_z = zvals),
    plot(y, line_z = y),
    plot(y, fillrange = 0, fill_z = y, fillcolor = :grays),
    label = ""
    )
```
used to look like this:
![gr_line_z_old](https://user-images.githubusercontent.com/16589944/30881363-d697e3bc-a305-11e7-96b4-fdc6bc3a778f.png)

Now it produces:
![gr_line_z](https://user-images.githubusercontent.com/16589944/30881380-ef6bcdfe-a305-11e7-9c65-bd121291a0e6.png)
If this behaviour is desirable implementations for PyPlot and Plotly will follow.