### PR TITLE
Implement new tick_direction attribute for GR, Plotly(JS), PyPlot, GLVisualize and PGFPlots

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -115,4 +115,5 @@ const _arg_desc = KW(
 :gridalpha                => "Number in [0,1]. The alpha/opacity override for the grid lines.",
 :gridstyle                => "Symbol. Style of the grid lines. Choose from $(_allStyles)",
 :gridlinewidth            => "Number. Width of the grid lines (in pixels)",
+:tick_direction         => "Symbol. Direction of the ticks. `:in` or `:out`"
 )

--- a/src/args.jl
+++ b/src/args.jl
@@ -322,6 +322,7 @@ const _axis_defaults = KW(
     :gridalpha                => 0.1,
     :gridstyle                => :solid,
     :gridlinewidth            => 0.5,
+    :tick_direction          => :in,
 )
 
 const _suppress_warnings = Set{Symbol}([
@@ -511,7 +512,7 @@ add_aliases(:stride, :wirefame_stride, :surface_stride, :surf_str, :str)
 add_aliases(:gridlinewidth, :gridwidth, :grid_linewidth, :grid_width, :gridlw, :grid_lw)
 add_aliases(:gridstyle, :grid_style, :gridlinestyle, :grid_linestyle, :grid_ls, :gridls)
 add_aliases(:framestyle, :frame_style, :frame, :axesstyle, :axes_style, :boxstyle, :box_style, :box, :borderstyle, :border_style, :border)
-
+add_aliases(:tick_direction, :tickdirection, :tick_dir, :tickdir, :tick_orientation, :tickorientation, :tick_or, :tickor)
 
 # add all pluralized forms to the _keyAliases dict
 for arg in keys(_series_defaults)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -530,13 +530,14 @@ function axis_drawing_info(sp::Subplot)
         if !(xaxis[:ticks] in (nothing, false))
             f = scalefunc(yaxis[:scale])
             invf = invscalefunc(yaxis[:scale])
-            t1 = invf(f(ymin) + 0.015*(f(ymax)-f(ymin)))
-            t2 = invf(f(ymax) - 0.015*(f(ymax)-f(ymin)))
-            t3 = invf(f(0) - 0.015*(f(ymax)-f(ymin)))
+            ticks_in = xaxis[:tick_direction] == :out ? -1 : 1
+            t1 = invf(f(ymin) + 0.013 * (f(ymax) - f(ymin)) * ticks_in)
+            t2 = invf(f(ymax) - 0.013 * (f(ymax) - f(ymin)) * ticks_in)
+            t3 = invf(f(0) + 0.013 * (f(ymax) - f(ymin)) * ticks_in)
 
             for xtick in xticks[1]
                 tick_start, tick_stop = if sp[:framestyle] == :origin
-                    (0, xaxis[:mirror] ? -t3 : t3)
+                    (0, t3)
                 else
                     xaxis[:mirror] ? (ymax, t2) : (ymin, t1)
                 end
@@ -560,13 +561,14 @@ function axis_drawing_info(sp::Subplot)
         if !(yaxis[:ticks] in (nothing, false))
             f = scalefunc(xaxis[:scale])
             invf = invscalefunc(xaxis[:scale])
-            t1 = invf(f(xmin) + 0.015*(f(xmax)-f(xmin)))
-            t2 = invf(f(xmax) - 0.015*(f(xmax)-f(xmin)))
-            t3 = invf(f(0) - 0.015*(f(xmax)-f(xmin)))
+            ticks_in = yaxis[:tick_direction] == :out ? -1 : 1
+            t1 = invf(f(xmin) + 0.013 * (f(xmax) - f(xmin)) * ticks_in)
+            t2 = invf(f(xmax) - 0.013 * (f(xmax) - f(xmin)) * ticks_in)
+            t3 = invf(f(0) + 0.013 * (f(xmax) - f(xmin)) * ticks_in)
 
             for ytick in yticks[1]
                 tick_start, tick_stop = if sp[:framestyle] == :origin
-                    (0, yaxis[:mirror] ? -t3 : t3)
+                    (0, t3)
                 else
                     yaxis[:mirror] ? (xmax, t2) : (xmin, t1)
                 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -531,9 +531,9 @@ function axis_drawing_info(sp::Subplot)
             f = scalefunc(yaxis[:scale])
             invf = invscalefunc(yaxis[:scale])
             ticks_in = xaxis[:tick_direction] == :out ? -1 : 1
-            t1 = invf(f(ymin) + 0.013 * (f(ymax) - f(ymin)) * ticks_in)
-            t2 = invf(f(ymax) - 0.013 * (f(ymax) - f(ymin)) * ticks_in)
-            t3 = invf(f(0) + 0.013 * (f(ymax) - f(ymin)) * ticks_in)
+            t1 = invf(f(ymin) + 0.015 * (f(ymax) - f(ymin)) * ticks_in)
+            t2 = invf(f(ymax) - 0.015 * (f(ymax) - f(ymin)) * ticks_in)
+            t3 = invf(f(0) + 0.015 * (f(ymax) - f(ymin)) * ticks_in)
 
             for xtick in xticks[1]
                 tick_start, tick_stop = if sp[:framestyle] == :origin
@@ -562,9 +562,9 @@ function axis_drawing_info(sp::Subplot)
             f = scalefunc(xaxis[:scale])
             invf = invscalefunc(xaxis[:scale])
             ticks_in = yaxis[:tick_direction] == :out ? -1 : 1
-            t1 = invf(f(xmin) + 0.013 * (f(xmax) - f(xmin)) * ticks_in)
-            t2 = invf(f(xmax) - 0.013 * (f(xmax) - f(xmin)) * ticks_in)
-            t3 = invf(f(0) + 0.013 * (f(xmax) - f(xmin)) * ticks_in)
+            t1 = invf(f(xmin) + 0.015 * (f(xmax) - f(xmin)) * ticks_in)
+            t2 = invf(f(xmax) - 0.015 * (f(xmax) - f(xmin)) * ticks_in)
+            t3 = invf(f(0) + 0.015 * (f(xmax) - f(xmin)) * ticks_in)
 
             for ytick in yticks[1]
                 tick_start, tick_stop = if sp[:framestyle] == :origin

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -41,6 +41,7 @@ const _glvisualize_attr = merge_with_base_supported([
     :dpi,
     :hover,
     :framestyle,
+    :tick_direction,
 ])
 const _glvisualize_seriestype = [
     :path, :shape,

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -827,7 +827,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 # use xor ($) to get the right y coords
                 xi, yi = GR.wctondc(cv, sp[:framestyle] == :origin ? 0 : xor(flip, mirror) ? ymax : ymin)
                 # @show cv dv ymin xi yi flip mirror (flip $ mirror)
-                gr_text(xi, yi + (mirror ? 1 : -1) * 5e-3, string(dv))
+                gr_text(xi, yi + (mirror ? 1 : -1) * 5e-3 * (xaxis[:tick_direction] == :out ? 1.5 : 1.0), string(dv))
             end
         end
 
@@ -838,7 +838,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 # use xor ($) to get the right y coords
                 xi, yi = GR.wctondc(sp[:framestyle] == :origin ? 0 : xor(flip, mirror) ? xmax : xmin, cv)
                 # @show cv dv xmin xi yi
-                gr_text(xi + (mirror ? 1 : -1) * 1e-2, yi, string(dv))
+                gr_text(xi + (mirror ? 1 : -1) * 1e-2 * (yaxis[:tick_direction] == :out ? 1.5 : 1.0), yi, string(dv))
             end
         end
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -33,6 +33,7 @@ const _gr_attr = merge_with_base_supported([
     :bar_width,
     :arrow,
     :framestyle,
+    :tick_direction,
 ])
 const _gr_seriestype = [
     :path, :scatter,

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -31,6 +31,7 @@ const _pgfplots_attr = merge_with_base_supported([
     # :normalize, :weights, :contours,
     :aspect_ratio,
     # :match_dimensions,
+    :tick_direction,
   ])
 const _pgfplots_seriestype = [:path, :path3d, :scatter, :steppre, :stepmid, :steppost, :histogram2d, :ysticks, :xsticks, :contour, :shape]
 const _pgfplots_style = [:auto, :solid, :dash, :dot, :dashdot, :dashdotdot]
@@ -283,6 +284,7 @@ function pgf_axis(sp::Subplot, letter)
         ticks = get_ticks(axis)
         push!(style, string(letter, "tick = {", join(ticks[1],","), "}"))
         push!(style, string(letter, "ticklabels = {", join(ticks[2],","), "}"))
+        push!(style, string(letter, "tick align = ", (axis[:tick_direction] == :out ? "outside" : "inside")))
     end
 
     # return the style list and KW args

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -280,7 +280,7 @@ function pgf_axis(sp::Subplot, letter)
         kw[Symbol(letter,:max)] = lims[2]
     end
 
-    if !(axis[:ticks] in (nothing, false, :none, :auto))
+    if !(axis[:ticks] in (nothing, false, :none))
         ticks = get_ticks(axis)
         push!(style, string(letter, "tick = {", join(ticks[1],","), "}"))
         push!(style, string(letter, "ticklabels = {", join(ticks[2],","), "}"))

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -235,7 +235,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
         :zerolinecolor => rgba_string(axis[:foreground_color_axis]),
         :showline   => framestyle in (:box, :axes),
         :linecolor  => rgba_string(plot_color(axis[:foreground_color_axis])),
-        :ticks      => "inside",
+        :ticks      => axis[:tick_direction] == :out ? "outside" : "inside",
         :mirror     => framestyle == :box,
     )
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -34,6 +34,7 @@ const _plotly_attr = merge_with_base_supported([
     :bar_width,
     :clims,
     :framestyle,
+    :tick_direction,
   ])
 
 const _plotly_seriestype = [

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -34,6 +34,7 @@ const _pyplot_attr = merge_with_base_supported([
     :colorbar_title,
     :stride,
     :framestyle,
+    :tick_direction,
   ])
 const _pyplot_seriestype = [
         :path, :steppre, :steppost, :shape,

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1052,6 +1052,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 ticks[2][ticks[1] .== 0] = ""
             end
             py_set_ticks(ax, ticks, letter)
+            pyaxis[:set_tick_params](direction = axis[:tick_direction] == :out ? "out" : "in")
             ax[Symbol("set_", letter, "label")](axis[:guide])
             if get(axis.d, :flip, false)
                 ax[Symbol("invert_", letter, "axis")]()


### PR DESCRIPTION
The attribute `tick_direction` (with aliases `tick_orientation`, `tickdirection`, `tickorientation`, `tickdir`, `tick_dir`, `tick_or` and `tickor`) takes the values `:in` or `:out`:
```julia
plot(rand(10, 2), tick_direction = [:in :out], title = [":in" ":out"], layout = 2, label = "")
```
* **GR**
![tick_direction_gr](https://user-images.githubusercontent.com/16589944/30940870-0510a23c-a3e3-11e7-830c-ab6412939f5b.png)

* **PyPlot**
![tick_direction_pyplot](https://user-images.githubusercontent.com/16589944/30940879-0d91e722-a3e3-11e7-9804-54e23417e721.png)

* **Plotly(JS)**
![tick_direction_plotlyjs](https://user-images.githubusercontent.com/16589944/30940219-9227ecf0-a3e0-11e7-90f1-b887e8db016c.png)

* **GLVisualize**
![tick_direction_glvisualize](https://user-images.githubusercontent.com/16589944/30940886-15c929aa-a3e3-11e7-9448-7729869bb636.png)

* **PGFPlots**
![tick_direction_pgfplots](https://user-images.githubusercontent.com/16589944/30940112-36991f3a-a3e0-11e7-985b-c11319e4ad0f.png)

I hope this helps @piever 😉 