### PR TITLE
Function default x limits: fix #1109

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -363,9 +363,10 @@ end
     xmin, xmax = try
         axis_limits(plt[1][:xaxis])
     catch
-        tryrange(f, [-5,-1,0,0.01]), tryrange(f, [5,1,0.99])
+        xm = tryrange(f, [-5,-1,0,0.01])
+        xm, tryrange(f, filter(x->x>xm, [5,1,0.99, 0, -0.01]))
     end
-    
+
     f, xmin, xmax
 end
 

--- a/src/series.jl
+++ b/src/series.jl
@@ -363,11 +363,23 @@ end
     xmin, xmax = try
         axis_limits(plt[1][:xaxis])
     catch
-        -5, 5
+        tryrange(f, [-5,-1,0,0.01]), tryrange(f, [5,1,0.99])
     end
+    
     f, xmin, xmax
 end
 
+# try some intervals over which the function may be defined
+function tryrange(F, vec)
+    for v in vec
+        try
+            tmp = F(v)
+            return v
+        catch
+        end
+    end
+    error("Function not defined over the given interval, $vec")
+end
 #
 # # --------------------------------------------------------------------
 # # 2 arguments


### PR DESCRIPTION
Tries to find defined x axis limits where the function is defined. Tries (-5,-1,0,0.01) for the minimum, and (5,1,0.99) for the maximum value. Thus, it will not work for functions that only are defined for negative numbers.
Should we add that? It would require a bit fiddling to ensure that the max value was still always larger than the min, and I don't know how common such functions are.