### PR TITLE
Change GR default 3D view angles

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -750,7 +750,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             isfinite(clims[1]) && (zmin = clims[1])
             isfinite(clims[2]) && (zmax = clims[2])
         end
-        GR.setspace(zmin, zmax, 40, 70)
+        GR.setspace(zmin, zmax, 35, 60)
         xtick = GR.tick(xmin, xmax) / 2
         ytick = GR.tick(ymin, ymax) / 2
         ztick = GR.tick(zmin, zmax) / 2


### PR DESCRIPTION
#1117 
Changed default view angles for GR to better match PyPlot
PyPlot:
![pyplot](https://user-images.githubusercontent.com/22132297/31053439-0ec46bf6-a695-11e7-86be-bb9c19d0dfe2.png)
GR:
![gr](https://user-images.githubusercontent.com/22132297/31053440-10b158ac-a695-11e7-9988-fd32871c2c82.png)