### PR TITLE
showaxis attribute

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -110,11 +110,11 @@ const _arg_desc = KW(
 :foreground_color_text    => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of tick labels.",
 :foreground_color_guide   => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of axis guides (axis labels).",
 :mirror                   => "Bool.  Switch the side of the tick labels (right or top).",
-:grid                     => "Bool, Symbol, String or `nothing`. Show the grid lines? `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:none`, `:off`",
+:grid                     => "Bool, Symbol, String or `nothing`. Show the grid lines? `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:none`, `:off`",
 :foreground_color_grid    => "Color Type or `:match` (matches `:foreground_color_subplot`). Color of grid lines.",
 :gridalpha                => "Number in [0,1]. The alpha/opacity override for the grid lines.",
 :gridstyle                => "Symbol. Style of the grid lines. Choose from $(_allStyles)",
 :gridlinewidth            => "Number. Width of the grid lines (in pixels)",
 :tick_direction           => "Symbol.  Direction of the ticks. `:in` or `:out`",
-:showaxis                 => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:none`, `:off`"
+:showaxis                 => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`"
 )

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -115,5 +115,6 @@ const _arg_desc = KW(
 :gridalpha                => "Number in [0,1]. The alpha/opacity override for the grid lines.",
 :gridstyle                => "Symbol. Style of the grid lines. Choose from $(_allStyles)",
 :gridlinewidth            => "Number. Width of the grid lines (in pixels)",
-:tick_direction         => "Symbol. Direction of the ticks. `:in` or `:out`"
+:tick_direction           => "Symbol.  Direction of the ticks. `:in` or `:out`",
+:showaxis                 => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:none`, `:off`"
 )

--- a/src/args.jl
+++ b/src/args.jl
@@ -170,8 +170,8 @@ const _scaleAliases = Dict{Symbol,Symbol}(
 const _allGridSyms = [:x, :y, :z,
                     :xy, :xz, :yx, :yz, :zx, :zy,
                     :xyz, :xzy, :yxz, :yzx, :zxy, :zyx,
-                    :all, :both, :on,
-                    :none, :off,]
+                    :all, :both, :on, :yes,
+                    :none, :off, :no]
 const _allGridArgs = [_allGridSyms; string.(_allGridSyms); nothing]
 hasgrid(arg::Void, letter) = false
 hasgrid(arg::Bool, letter) = arg
@@ -184,6 +184,24 @@ function hasgrid(arg::Symbol, letter)
     end
 end
 hasgrid(arg::AbstractString, letter) = hasgrid(Symbol(arg), letter)
+
+const _allShowaxisSyms = [:x, :y, :z,
+                    :xy, :xz, :yx, :yz, :zx, :zy,
+                    :xyz, :xzy, :yxz, :yzx, :zxy, :zyx,
+                    :all, :both, :on, :yes,
+                    :none, :off, :no]
+const _allShowaxisArgs = [_allGridSyms; string.(_allGridSyms)]
+showaxis(arg::Void, letter) = false
+showaxis(arg::Bool, letter) = arg
+function hasgrid(arg::Symbol, letter)
+    if arg in _allGridSyms
+        arg in (:all, :both, :on, :yes) || contains(string(arg), string(letter))
+    else
+        warn("Unknown showaxis argument $arg; $(Symbol(letter, :showaxis)) was set to `true` instead.")
+        true
+    end
+end
+showaxis(arg::AbstractString, letter) = hasgrid(Symbol(arg), letter)
 
 const _allFramestyles = [:box, :semi, :axes, :origin, :zerolines, :grid, :none]
 const _framestyleAliases = Dict{Symbol, Symbol}(

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -70,6 +70,9 @@ function process_axis_arg!(d::KW, arg, letter = "")
     elseif arg == nothing
         d[Symbol(letter,:ticks)] = []
 
+    elseif arg in _allShowaxisArgs
+        d[Symbol(letter,:showaxis)] = showaxis(arg, letter)
+
     elseif typeof(arg) <: Number
         d[Symbol(letter,:rotation)] = arg
 
@@ -517,16 +520,18 @@ function axis_drawing_info(sp::Subplot)
 
     if !(sp[:framestyle] == :none)
         # xaxis
-        sp[:framestyle] in (:grid, :origin, :zerolines) || push!(xaxis_segs, (xmin,ymin), (xmax,ymin)) # bottom spine / xaxis
-        if sp[:framestyle] in (:origin, :zerolines)
-            push!(xaxis_segs, (xmin, 0.0), (xmax, 0.0))
-            # don't show the 0 tick label for the origin framestyle
-            if sp[:framestyle] == :origin && length(xticks) > 1
-                showticks = xticks[1] .!= 0
-                xticks = (xticks[1][showticks], xticks[2][showticks])
+        if xaxis[:showaxis]
+            sp[:framestyle] in (:grid, :origin, :zerolines) || push!(xaxis_segs, (xmin,ymin), (xmax,ymin)) # bottom spine / xaxis
+            if sp[:framestyle] in (:origin, :zerolines)
+                push!(xaxis_segs, (xmin, 0.0), (xmax, 0.0))
+                # don't show the 0 tick label for the origin framestyle
+                if sp[:framestyle] == :origin && length(xticks) > 1
+                    showticks = xticks[1] .!= 0
+                    xticks = (xticks[1][showticks], xticks[2][showticks])
+                end
             end
+            sp[:framestyle] in (:semi, :box) && push!(xborder_segs, (xmin,ymax), (xmax,ymax)) # top spine
         end
-        sp[:framestyle] in (:semi, :box) && push!(xborder_segs, (xmin,ymax), (xmax,ymax)) # top spine
         if !(xaxis[:ticks] in (nothing, false))
             f = scalefunc(yaxis[:scale])
             invf = invscalefunc(yaxis[:scale])
@@ -536,28 +541,32 @@ function axis_drawing_info(sp::Subplot)
             t3 = invf(f(0) + 0.015 * (f(ymax) - f(ymin)) * ticks_in)
 
             for xtick in xticks[1]
-                tick_start, tick_stop = if sp[:framestyle] == :origin
-                    (0, t3)
-                else
-                    xaxis[:mirror] ? (ymax, t2) : (ymin, t1)
+                if xaxis[:showaxis]
+                    tick_start, tick_stop = if sp[:framestyle] == :origin
+                        (0, t3)
+                    else
+                        xaxis[:mirror] ? (ymax, t2) : (ymin, t1)
+                    end
+                    push!(xtick_segs, (xtick, tick_start), (xtick, tick_stop)) # bottom tick
                 end
-                push!(xtick_segs, (xtick, tick_start), (xtick, tick_stop)) # bottom tick
                 # sp[:draw_axes_border] && push!(xaxis_segs, (xtick, ymax), (xtick, t2)) # top tick
                 xaxis[:grid] && push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
             end
         end
 
         # yaxis
-        sp[:framestyle] in (:grid, :origin, :zerolines) || push!(yaxis_segs, (xmin,ymin), (xmin,ymax)) # left spine / yaxis
-        if sp[:framestyle] in (:origin, :zerolines)
-            push!(yaxis_segs, (0.0, ymin), (0.0, ymax))
-            # don't show the 0 tick label for the origin framestyle
-            if sp[:framestyle] == :origin && length(yticks) > 1
-                showticks = yticks[1] .!= 0
-                yticks = (yticks[1][showticks], yticks[2][showticks])
+        if yaxis[:showaxis]
+            sp[:framestyle] in (:grid, :origin, :zerolines) || push!(yaxis_segs, (xmin,ymin), (xmin,ymax)) # left spine / yaxis
+            if sp[:framestyle] in (:origin, :zerolines)
+                push!(yaxis_segs, (0.0, ymin), (0.0, ymax))
+                # don't show the 0 tick label for the origin framestyle
+                if sp[:framestyle] == :origin && length(yticks) > 1
+                    showticks = yticks[1] .!= 0
+                    yticks = (yticks[1][showticks], yticks[2][showticks])
+                end
             end
+            sp[:framestyle] in (:semi, :box) && push!(yborder_segs, (xmax,ymin), (xmax,ymax)) # right spine
         end
-        sp[:framestyle] in (:semi, :box) && push!(yborder_segs, (xmax,ymin), (xmax,ymax)) # right spine
         if !(yaxis[:ticks] in (nothing, false))
             f = scalefunc(xaxis[:scale])
             invf = invscalefunc(xaxis[:scale])
@@ -567,12 +576,14 @@ function axis_drawing_info(sp::Subplot)
             t3 = invf(f(0) + 0.015 * (f(xmax) - f(xmin)) * ticks_in)
 
             for ytick in yticks[1]
-                tick_start, tick_stop = if sp[:framestyle] == :origin
-                    (0, t3)
-                else
-                    yaxis[:mirror] ? (xmax, t2) : (xmin, t1)
+                if yaxis[:showaxis]
+                    tick_start, tick_stop = if sp[:framestyle] == :origin
+                        (0, t3)
+                    else
+                        yaxis[:mirror] ? (xmax, t2) : (xmin, t1)
+                    end
+                    push!(ytick_segs, (tick_start, ytick), (tick_stop, ytick)) # left tick
                 end
-                push!(ytick_segs, (tick_start, ytick), (tick_stop, ytick)) # left tick
                 # sp[:draw_axes_border] && push!(yaxis_segs, (xmax, ytick), (t2, ytick)) # right tick
                 yaxis[:grid] && push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
             end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -70,7 +70,7 @@ function process_axis_arg!(d::KW, arg, letter = "")
     elseif arg == nothing
         d[Symbol(letter,:ticks)] = []
 
-    elseif arg in _allShowaxisArgs
+    elseif T <: Bool || arg in _allShowaxisArgs
         d[Symbol(letter,:showaxis)] = showaxis(arg, letter)
 
     elseif typeof(arg) <: Number
@@ -79,7 +79,7 @@ function process_axis_arg!(d::KW, arg, letter = "")
     elseif typeof(arg) <: Function
         d[Symbol(letter,:formatter)] = arg
 
-    else
+    elseif !handleColors!(d, arg, Symbol(letter, :foreground_color_axis))
         warn("Skipped $(letter)axis arg $arg")
 
     end

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -732,15 +732,25 @@ function gl_draw_axes_2d(sp::Plots.Subplot{Plots.GLVisualizeBackend}, model, are
     xlim = Plots.axis_limits(xaxis)
     ylim = Plots.axis_limits(yaxis)
 
-    if !(xaxis[:ticks] in (nothing, false, :none)) && !(sp[:framestyle] == :none)
+    if !(xaxis[:ticks] in (nothing, false, :none)) && !(sp[:framestyle] == :none) && xaxis[:showaxis]
         ticklabels = map(model) do m
             mirror = xaxis[:mirror]
             t, positions, offsets = draw_ticks(xaxis, xticks, true, sp[:framestyle] == :origin, ylim, m)
-            mirror = xaxis[:mirror]
-            t, positions, offsets = draw_ticks(
-                yaxis, yticks, false, sp[:framestyle] == :origin, xlim, m,
-                t, positions, offsets
-            )
+        end
+        kw_args = Dict{Symbol, Any}(
+            :position => map(x-> x[2], ticklabels),
+            :offset => map(last, ticklabels),
+            :color => fcolor,
+            :relative_scale => pointsize(xaxis[:tickfont]),
+            :scale_primitive => false
+        )
+        push!(axis_vis, visualize(map(first, ticklabels), Style(:default), kw_args))
+    end
+
+    if !(yaxis[:ticks] in (nothing, false, :none)) && !(sp[:framestyle] == :none) && yaxis[:showaxis]
+        ticklabels = map(model) do m
+            mirror = yaxis[:mirror]
+            t, positions, offsets = draw_ticks(yaxis, yticks, false, sp[:framestyle] == :origin, xlim, m)
         end
         kw_args = Dict{Symbol, Any}(
             :position => map(x-> x[2], ticklabels),

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -793,35 +793,43 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         GR.settransparency(1.0)
 
         # axis lines
-        gr_set_line(1, :solid, xaxis[:foreground_color_axis])
-        GR.setclip(0)
-        gr_polyline(coords(xspine_segs)...)
-        gr_set_line(1, :solid, yaxis[:foreground_color_axis])
-        GR.setclip(0)
-        gr_polyline(coords(yspine_segs)...)
+        if xaxis[:showaxis]
+            gr_set_line(1, :solid, xaxis[:foreground_color_axis])
+            GR.setclip(0)
+            gr_polyline(coords(xspine_segs)...)
+        end
+        if yaxis[:showaxis]
+            gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+            GR.setclip(0)
+            gr_polyline(coords(yspine_segs)...)
+        end
         GR.setclip(1)
 
         # axis ticks
-        if sp[:framestyle] in (:zerolines, :grid)
-            gr_set_line(1, :solid, xaxis[:foreground_color_grid])
-            GR.settransparency(xaxis[:gridalpha])
-        else
-            gr_set_line(1, :solid, xaxis[:foreground_color_axis])
+        if xaxis[:showaxis]
+            if sp[:framestyle] in (:zerolines, :grid)
+                gr_set_line(1, :solid, xaxis[:foreground_color_grid])
+                GR.settransparency(xaxis[:gridalpha])
+            else
+                gr_set_line(1, :solid, xaxis[:foreground_color_axis])
+            end
+            GR.setclip(0)
+            gr_polyline(coords(xtick_segs)...)
         end
-        GR.setclip(0)
-        gr_polyline(coords(xtick_segs)...)
-        if sp[:framestyle] in (:zerolines, :grid)
-            gr_set_line(1, :solid, yaxis[:foreground_color_grid])
-            GR.settransparency(yaxis[:gridalpha])
-        else
-            gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+        if  yaxis[:showaxis]
+            if sp[:framestyle] in (:zerolines, :grid)
+                gr_set_line(1, :solid, yaxis[:foreground_color_grid])
+                GR.settransparency(yaxis[:gridalpha])
+            else
+                gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+            end
+            GR.setclip(0)
+            gr_polyline(coords(ytick_segs)...)
         end
-        GR.setclip(0)
-        gr_polyline(coords(ytick_segs)...)
         GR.setclip(1)
 
         # tick marks
-        if !(xticks in (:none, nothing, false))
+        if !(xticks in (:none, nothing, false)) && xaxis[:showaxis]
             # x labels
             flip, mirror = gr_set_xticks_font(sp)
             for (cv, dv) in zip(xticks...)
@@ -832,7 +840,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             end
         end
 
-        if !(yticks in (:none, nothing, false))
+        if !(yticks in (:none, nothing, false)) && yaxis[:showaxis]
             # y labels
             flip, mirror = gr_set_yticks_font(sp)
             for (cv, dv) in zip(yticks...)

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -32,6 +32,7 @@ const _pgfplots_attr = merge_with_base_supported([
     :aspect_ratio,
     # :match_dimensions,
     :tick_direction,
+    :framestyle,
   ])
 const _pgfplots_seriestype = [:path, :path3d, :scatter, :steppre, :stepmid, :steppost, :histogram2d, :ysticks, :xsticks, :contour, :shape]
 const _pgfplots_style = [:auto, :solid, :dash, :dot, :dashdot, :dashdotdot]
@@ -106,6 +107,18 @@ const _pgf_annotation_halign = KW(
     :left => "right",
     :right => "left"
 )
+
+const _pgf_framestyles = [:box, :axes, :grid, :none]
+const _pgf_framestyle_defaults = Dict(:semi => :box, :origin => :axes, :zerolines => :axes)
+function pgf_framestyle(style::Symbol)
+    if style in _pgf_framestyles
+        return style
+    else
+        default_style = get(_pgf_framestyle_defaults, style, :axes)
+        warn("Framestyle :$style is not (yet) supported by the PGFPlots backend. :$default_style was cosen instead.")
+        default_style
+    end
+end
 
 # --------------------------------------------------------------------------------------
 
@@ -246,6 +259,9 @@ function pgf_axis(sp::Subplot, letter)
     style = []
     kw = KW()
 
+    # set to supported framestyle
+    framestyle = pgf_framestyle(sp[:framestyle])
+
     # axis guide
     kw[Symbol(letter,:label)] = axis[:guide]
 
@@ -263,12 +279,12 @@ function pgf_axis(sp::Subplot, letter)
     end
 
     # ticks on or off
-    if axis[:ticks] in (nothing, false)
+    if axis[:ticks] in (nothing, false) || framestyle == :none
         push!(style, "$(letter)majorticks=false")
     end
 
     # grid on or off
-    if axis[:grid]
+    if axis[:grid] && framestyle != :none
         push!(style, "$(letter)majorgrids = true")
     end
 
@@ -280,11 +296,27 @@ function pgf_axis(sp::Subplot, letter)
         kw[Symbol(letter,:max)] = lims[2]
     end
 
-    if !(axis[:ticks] in (nothing, false, :none))
+    if !(axis[:ticks] in (nothing, false, :none)) && framestyle != :none
         ticks = get_ticks(axis)
         push!(style, string(letter, "tick = {", join(ticks[1],","), "}"))
-        push!(style, string(letter, "ticklabels = {", join(ticks[2],","), "}"))
+        if axis[:showaxis]
+            push!(style, string(letter, "ticklabels = {", join(ticks[2],","), "}"))
+        else
+            push!(style, string(letter, "ticklabels = {}"))
+        end
         push!(style, string(letter, "tick align = ", (axis[:tick_direction] == :out ? "outside" : "inside")))
+    end
+
+    # framestyle
+    if sp[:framestyle] == :axes
+        push!(style, "axis lines = left")
+    end
+
+    if !axis[:showaxis]
+        push!(style, "separate axis lines")
+    end
+    if !axis[:showaxis] || framestyle in (:grid, :none)
+        push!(style, string(letter, " axis line style = {draw opacity = 0}"))
     end
 
     # return the style list and KW args

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -108,8 +108,8 @@ const _pgf_annotation_halign = KW(
     :right => "left"
 )
 
-const _pgf_framestyles = [:box, :axes, :grid, :none]
-const _pgf_framestyle_defaults = Dict(:semi => :box, :origin => :axes, :zerolines => :axes)
+const _pgf_framestyles = [:box, :axes, :origin, :zerolines, :grid, :none]
+const _pgf_framestyle_defaults = Dict(:semi => :box)
 function pgf_framestyle(style::Symbol)
     if style in _pgf_framestyles
         return style
@@ -308,14 +308,22 @@ function pgf_axis(sp::Subplot, letter)
     end
 
     # framestyle
-    if sp[:framestyle] == :axes
-        push!(style, "axis lines = left")
+    if framestyle in (:axes, :origin)
+        axispos = framestyle == :axes ? "left" : "middle"
+        # the * after lines disables the arrows at the axes
+        push!(style, string("axis lines* = ", axispos))
+    end
+
+    if framestyle == :zerolines
+        push!(style, string("extra ", letter, " ticks = 0"))
+        push!(style, string("extra ", letter, " tick labels = "))
+        push!(style, string("extra ", letter, " tick style = {grid = major, major grid style = {color = black, draw opacity=1.0, line width=0.5), solid}}"))
     end
 
     if !axis[:showaxis]
         push!(style, "separate axis lines")
     end
-    if !axis[:showaxis] || framestyle in (:grid, :none)
+    if !axis[:showaxis] || framestyle in (:zerolines, :grid, :none)
         push!(style, string(letter, " axis line style = {draw opacity = 0}"))
     end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -234,10 +234,11 @@ function plotly_axis(axis::Axis, sp::Subplot)
         :gridwidth  => axis[:gridlinewidth],
         :zeroline   => framestyle == :zerolines,
         :zerolinecolor => rgba_string(axis[:foreground_color_axis]),
-        :showline   => framestyle in (:box, :axes),
+        :showline   => framestyle in (:box, :axes) && axis[:showaxis],
         :linecolor  => rgba_string(plot_color(axis[:foreground_color_axis])),
         :ticks      => axis[:tick_direction] == :out ? "outside" : "inside",
         :mirror     => framestyle == :box,
+        :showticklabels => axis[:showaxis],
     )
 
     if letter in (:x,:y)
@@ -251,7 +252,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:titlefont] = plotly_font(axis[:guidefont], axis[:foreground_color_guide])
         ax[:type] = plotly_scale(axis[:scale])
         ax[:tickfont] = plotly_font(axis[:tickfont], axis[:foreground_color_text])
-        ax[:tickcolor] = framestyle in (:zerolines, :grid) ? rgba_string(invisible()) : rgb_string(axis[:foreground_color_axis])
+        ax[:tickcolor] = framestyle in (:zerolines, :grid) || !axis[:showaxis] ? rgba_string(invisible()) : rgb_string(axis[:foreground_color_axis])
         ax[:linecolor] = rgba_string(axis[:foreground_color_axis])
 
         # lims

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1077,6 +1077,24 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             py_set_axis_colors(sp, ax, axis)
         end
 
+        # showaxis
+        if !sp[:xaxis][:showaxis]
+            kw = KW()
+            for dir in (:top, :bottom)
+                ax[:spines][string(dir)][:set_visible](false)
+                kw[dir] = kw[Symbol(:label,dir)] = "off"
+            end
+            ax[:xaxis][:set_tick_params](; which="both", kw...)
+        end
+        if !sp[:yaxis][:showaxis]
+            kw = KW()
+            for dir in (:left, :right)
+                ax[:spines][string(dir)][:set_visible](false)
+                kw[dir] = kw[Symbol(:label,dir)] = "off"
+            end
+            ax[:yaxis][:set_tick_params](; which="both", kw...)
+        end
+
         # aspect ratio
         aratio = sp[:aspect_ratio]
         if aratio != :none


### PR DESCRIPTION
* This implements the `showaxis` attribute to control whether an individual axis is shown.
* Furthermore I added some minor axis argument preprocessing fixes (one can now e.g. do `plot(rand(10), axis = ("my label", [], :red, font(20)))` with the attributes applying to all axes) and added showaxis attribute to the magic axis arg.
* Possible values are :x, :y, :z, :xy, :xz, :yx, :yz, :zx, :zy, :xyz, :xzy, :yxz, :yzx, :zxy, :zyx, :all, :both, :on, :yes, :show, :off, :no, :hide as Symbol or String and `true` or `false`.

This allows e.g. `xshowaxis = false`, `xaxis = :hide`, `axis = :y`, ... to hide the x axis in a plot:
This has been implemented for GR, PyPlot, PlotlyJS, GLVisualize and PGFPlots and should make it easier to reproduce something like facets:
```julia
plot([plot(rand(10), axis = sa) for sa in (:y, :hide, :both, :x)]..., layout = (2, 2), label = "", link = :all)
```
* **GR**
![hide-axis-gr](https://user-images.githubusercontent.com/16589944/31058359-bba667c2-a6f2-11e7-85a9-461f4b2ab29d.png)

* **PyPlot**
![hide-axis-pyplot](https://user-images.githubusercontent.com/16589944/31058424-8a5d146c-a6f3-11e7-960a-bc6d7f31ee30.png)

* **Plotly(JS)**
![hide-axis-plotlyjs](https://user-images.githubusercontent.com/16589944/31058375-d0cd291a-a6f2-11e7-946c-4e18de691ec4.png)
It seems like `link` is not working for plotly(js). Is this a known issue?

* **GLVisualize**
![hide-axis-glvisualize](https://user-images.githubusercontent.com/16589944/31058378-ded6f342-a6f2-11e7-8eb3-db40c99559ed.png)

* **PGFPlots**
![hide-axis-pgfplots](https://user-images.githubusercontent.com/16589944/31058384-f116d9e6-a6f2-11e7-9a21-549ceb1d3a95.png)

Furthermore I implemented four basic framestyles for PGFPlots here:
![framestyle_pgfplots](https://user-images.githubusercontent.com/16589944/31058396-1eef7e0e-a6f3-11e7-8f64-4035c00a976a.png)

