### PR TITLE
RFC: Fix `line_z` for PyPlot backend (fix #1021)

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -508,11 +508,12 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                 handle = if is3d(st)
                     for rng in iter_segments(x, y, z)
                         length(rng) < 2 && continue
-                        push!(segments, [(_cycle(x,i),_cycle(y,i),_cycle(z,i)) for i in rng])
+                        for i in rng[1:end-1]
+                            push!(segments, [(_cycle(x,i),_cycle(y,i),_cycle(z,i)),
+                                             (_cycle(x,i+1),_cycle(y,i+1),_cycle(z,i+1))])
+                        end
                     end
-                    # for i=1:n
-                    #     segments[i] = [(_cycle(x,i), _cycle(y,i), _cycle(z,i)), (_cycle(x,i+1), _cycle(y,i+1), _cycle(z,i+1))]
-                    # end
+
                     lc = pyart3d["Line3DCollection"](segments; kw...)
                     lc[:set_array](lz)
                     ax[:add_collection3d](lc, zs=z) #, zdir='y')
@@ -520,11 +521,11 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                 else
                     for rng in iter_segments(x, y)
                         length(rng) < 2 && continue
-                        push!(segments, [(_cycle(x,i),_cycle(y,i)) for i in rng])
+                        for i in rng[1:end-1]
+                            push!(segments, [(_cycle(x,i),_cycle(y,i)), (_cycle(x,i+1),_cycle(y,i+1))])
+                        end
                     end
-                    # for i=1:n
-                    #     segments[i] = [(_cycle(x,i), _cycle(y,i)), (_cycle(x,i+1), _cycle(y,i+1))]
-                    # end
+
                     lc = pycollections["LineCollection"](segments; kw...)
                     lc[:set_array](lz)
                     ax[:add_collection](lc)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -499,11 +499,9 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     :zorder => plt.n,
                     :cmap => py_linecolormap(series),
                     :linewidth => py_dpi_scale(plt, series[:linewidth]),
-                    :linestyle => py_linestyle(st, series[:linestyle])
+                    :linestyle => py_linestyle(st, series[:linestyle]),
+                    :norm => pycolors["Normalize"](; extrakw...)
                 )
-                if needs_colorbar
-                    kw[:norm] = pycolors["Normalize"](; extrakw...)
-                end
                 lz = collect(series[:line_z])
                 handle = if is3d(st)
                     for rng in iter_segments(x, y, z)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -502,7 +502,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     :linestyle => py_linestyle(st, series[:linestyle]),
                     :norm => pycolors["Normalize"](; extrakw...)
                 )
-                lz = collect(series[:line_z])
+                lz = _cycle(series[:line_z], 1:n)
                 handle = if is3d(st)
                     for rng in iter_segments(x, y, z)
                         length(rng) < 2 && continue


### PR DESCRIPTION
```julia
s = linspace(0, 10, 50)
plot(s.*cos.(s), s.*sin.(s), s, line_z = s, lw = 3)
```
![3d_linez](https://user-images.githubusercontent.com/7328215/31200727-f35dac8c-a910-11e7-887b-707ec27d8201.png)
```julia
n = 10; x = linspace(0,1,n); y=cumsum(rand(n));
plot(x,y,line_z=1:n, w=5)
```
![2d_linez](https://user-images.githubusercontent.com/7328215/31200821-30a69568-a911-11e7-8854-c5e9da62c079.png)
