### PR TITLE
ready for release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,11 @@
 ---
 ## (current master)
 
+## 0.13.1
+
+- fix a bug when passing a vector of functions with no bounds (e.g. `plot([sin, cos])`)
+- export pct and px from Plots.PlotMeasures
+
 ## 0.13.0
 
 - support `plotattributes` rather than `d` in recipes

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -1,4 +1,4 @@
-__precompile__(true)
+__precompile__(false)
 
 module Plots
 


### PR DESCRIPTION
- fix a bug when passing a vector of functions with no bounds (e.g. `plot([sin, cos])`)
- export pct and px from Plots.PlotMeasures