### PR TITLE
Adds camera attribute for 3D plots.

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -94,7 +94,7 @@ const _arg_desc = KW(
 :subplot_index            => "Integer.  Internal (not set by user).  Specifies the index of this subplot in the Plot's `plt.subplot` list.",
 :colorbar_title           => "String.  Title of colorbar.",
 :framestyle               => "Symbol.  Style of the axes frame. Choose from $(_allFramestyles)",
-:camera                   => "NTuple{2, Int(GR)/Real(Other)}. Sets the view angle (azimuthal, elevation) for 3D plots",
+:camera                   => "NTuple{2, Real}. Sets the view angle (azimuthal, elevation) for 3D plots",
 
 # axis args
 :guide     				  => "String. Axis guide (label).",

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -94,6 +94,7 @@ const _arg_desc = KW(
 :subplot_index            => "Integer.  Internal (not set by user).  Specifies the index of this subplot in the Plot's `plt.subplot` list.",
 :colorbar_title           => "String.  Title of colorbar.",
 :framestyle               => "Symbol.  Style of the axes frame. Choose from $(_allFramestyles)",
+:camera                   => "NTuple{2, Int(GR)/Real(Other)}. Sets the view angle (azimuthal, elevation) for 3D plots",
 
 # axis args
 :guide     				  => "String. Axis guide (label).",

--- a/src/args.jl
+++ b/src/args.jl
@@ -533,7 +533,7 @@ add_aliases(:gridlinewidth, :gridwidth, :grid_linewidth, :grid_width, :gridlw, :
 add_aliases(:gridstyle, :grid_style, :gridlinestyle, :grid_linestyle, :grid_ls, :gridls)
 add_aliases(:framestyle, :frame_style, :frame, :axesstyle, :axes_style, :boxstyle, :box_style, :box, :borderstyle, :border_style, :border)
 add_aliases(:tick_direction, :tickdirection, :tick_dir, :tickdir, :tick_orientation, :tickorientation, :tick_or, :tickor)
-add_aliases(:camera, :cam)
+add_aliases(:camera, :cam, :view, :viewangle, :view_angle)
 
 # add all pluralized forms to the _keyAliases dict
 for arg in keys(_series_defaults)

--- a/src/args.jl
+++ b/src/args.jl
@@ -533,7 +533,7 @@ add_aliases(:gridlinewidth, :gridwidth, :grid_linewidth, :grid_width, :gridlw, :
 add_aliases(:gridstyle, :grid_style, :gridlinestyle, :grid_linestyle, :grid_ls, :gridls)
 add_aliases(:framestyle, :frame_style, :frame, :axesstyle, :axes_style, :boxstyle, :box_style, :box, :borderstyle, :border_style, :border)
 add_aliases(:tick_direction, :tickdirection, :tick_dir, :tickdir, :tick_orientation, :tickorientation, :tick_or, :tickor)
-add_aliases(:camera, :cam, :view, :viewangle, :view_angle)
+add_aliases(:camera, :cam, :viewangle, :view_angle)
 
 # add all pluralized forms to the _keyAliases dict
 for arg in keys(_series_defaults)

--- a/src/args.jl
+++ b/src/args.jl
@@ -316,6 +316,7 @@ const _subplot_defaults = KW(
     :subplot_index            => -1,
     :colorbar_title           => "",
     :framestyle               => :axes,
+    :camera                   => (30,30),
 )
 
 const _axis_defaults = KW(
@@ -532,6 +533,7 @@ add_aliases(:gridlinewidth, :gridwidth, :grid_linewidth, :grid_width, :gridlw, :
 add_aliases(:gridstyle, :grid_style, :gridlinestyle, :grid_linestyle, :grid_ls, :gridls)
 add_aliases(:framestyle, :frame_style, :frame, :axesstyle, :axes_style, :boxstyle, :box_style, :box, :borderstyle, :border_style, :border)
 add_aliases(:tick_direction, :tickdirection, :tick_dir, :tickdir, :tick_orientation, :tickorientation, :tick_or, :tickor)
+add_aliases(:camera, :cam)
 
 # add all pluralized forms to the _keyAliases dict
 for arg in keys(_series_defaults)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -751,7 +751,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             isfinite(clims[1]) && (zmin = clims[1])
             isfinite(clims[2]) && (zmax = clims[2])
         end
-        GR.setspace(zmin, zmax, map(Int,map(round,sp[:camera]))...)
+        GR.setspace(zmin, zmax, round.(Int, sp[:camera])...)
         xtick = GR.tick(xmin, xmax) / 2
         ytick = GR.tick(ymin, ymax) / 2
         ztick = GR.tick(zmin, zmax) / 2

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -34,6 +34,7 @@ const _gr_attr = merge_with_base_supported([
     :arrow,
     :framestyle,
     :tick_direction,
+    :camera,
 ])
 const _gr_seriestype = [
     :path, :scatter,
@@ -750,7 +751,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             isfinite(clims[1]) && (zmin = clims[1])
             isfinite(clims[2]) && (zmax = clims[2])
         end
-        GR.setspace(zmin, zmax, 35, 60)
+        GR.setspace(zmin, zmax, sp[:camera]...)
         xtick = GR.tick(xmin, xmax) / 2
         ytick = GR.tick(ymin, ymax) / 2
         ztick = GR.tick(zmin, zmax) / 2

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -751,7 +751,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             isfinite(clims[1]) && (zmin = clims[1])
             isfinite(clims[2]) && (zmax = clims[2])
         end
-        GR.setspace(zmin, zmax, sp[:camera]...)
+        GR.setspace(zmin, zmax, map(Int,map(round,sp[:camera]))...)
         xtick = GR.tick(xmin, xmax) / 2
         ytick = GR.tick(ymin, ymax) / 2
         ztick = GR.tick(zmin, zmax) / 2

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -33,6 +33,7 @@ const _pgfplots_attr = merge_with_base_supported([
     # :match_dimensions,
     :tick_direction,
     :framestyle,
+    :camera,
   ])
 const _pgfplots_seriestype = [:path, :path3d, :scatter, :steppre, :stepmid, :steppost, :histogram2d, :ysticks, :xsticks, :contour, :shape]
 const _pgfplots_style = [:auto, :solid, :dash, :dot, :dashdot, :dashdotdot]
@@ -378,6 +379,11 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
         legpos = sp[:legend]
         if haskey(_pgfplots_legend_pos, legpos)
             kw[:legendPos] = _pgfplots_legend_pos[legpos]
+        end
+
+        if is3d(sp)
+            azim, elev = sp[:camera]
+            kw[:view] = "{$(azim)}{$(elev)}"
         end
 
         axisf = PGFPlots.Axis

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -35,6 +35,7 @@ const _plotly_attr = merge_with_base_supported([
     :clims,
     :framestyle,
     :tick_direction,
+    :camera,
   ])
 
 const _plotly_seriestype = [
@@ -324,10 +325,21 @@ function plotly_layout(plt::Plot)
 
         # if any(is3d, seriesargs)
         if is3d(sp)
+            azim = sp[:camera][1] - 90 #convert azimuthal to match GR behaviour
+            theta = 90 - sp[:camera][2] #spherical coordinate angle from z axis
             d_out[:scene] = KW(
                 Symbol("xaxis$spidx") => plotly_axis(sp[:xaxis], sp),
                 Symbol("yaxis$spidx") => plotly_axis(sp[:yaxis], sp),
                 Symbol("zaxis$spidx") => plotly_axis(sp[:zaxis], sp),
+
+                #2.6 multiplier set camera eye such that whole plot can be seen
+                :camera => KW(
+                    :eye => KW(
+                        :x => cosd(azim)*sind(theta)*2.6,
+                        :y => sind(azim)*sind(theta)*2.6,
+                        :z => cosd(theta)*2.6,
+                    ),
+                ),
             )
         else
             d_out[Symbol("xaxis$spidx")] = plotly_axis(sp[:xaxis], sp)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -35,6 +35,7 @@ const _pyplot_attr = merge_with_base_supported([
     :stride,
     :framestyle,
     :tick_direction,
+    :camera,
   ])
 const _pyplot_seriestype = [
         :path, :steppre, :steppost, :shape,
@@ -1102,6 +1103,13 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
         aratio = sp[:aspect_ratio]
         if aratio != :none
             ax[:set_aspect](isa(aratio, Symbol) ? string(aratio) : aratio, anchor = "C")
+        end
+
+        #camera/view angle
+        if is3d(sp)
+            #convert azimuthal to match GR behaviour
+            #view_init(elevation, azimuthal) so reverse :camera args
+            ax[:view_init]((sp[:camera].-(90,0))[end:-1:1]...)
         end
 
         # legend


### PR DESCRIPTION
This adds the camera attribute from #288 for GR, PyPlot, PGFPlots and Plotly/PlotlyJS.
```
x = 1:1:10
y = z = rand(10)
p = plot(x, y, [z, z], layout = 2)
plot!(p[1], camera = (20,50))
```
(Default view on the right)

GR:
![gr](https://user-images.githubusercontent.com/22132297/31285173-945781f6-aab2-11e7-8970-1e13d6aa07dc.png)

PyPlot:
![pyplot](https://user-images.githubusercontent.com/22132297/31285283-d8e1ab26-aab2-11e7-93f7-4052c8701234.png)

PGFPlots:
![pgfplots](https://user-images.githubusercontent.com/22132297/31285299-deba893c-aab2-11e7-87cb-e41e17f4a75f.png)

Plotly/PlotlyJS:
Unfortunately due to #945 the code doesn't work. 
Default:
![newplot](https://user-images.githubusercontent.com/22132297/31337013-5c2eb10a-acf1-11e7-9e63-429649bd44ee.png)
Camera = (20,50):
![camera](https://user-images.githubusercontent.com/22132297/31337021-673228a2-acf1-11e7-9ead-10393c70aee9.png)


GLVIsualize:
Can't get GLVisualize to work on my mac 😟 . So I have not been able to implement camera functionality yet.

Issues:
GR: 
- `GR.setspace(zmin, zmax, rotation, tilt)` doesn't do anything when the input for rotation or tilt is negative.

Plotly:
- `camera = (0,90)` gives a much different view than `(0,89)` or `(0,91)`

All:
- Extreme viewing angles can make tick labels hard to read.

Notes:
I'm not too sure about GR the default elevation of 30 degrees looks different than for the other backends but I'm pretty sure the tilt argument in `GR.setspace()` is the elevation and not the theta angle from the z-axis.

EDIT: Added images for Plotly/PlotlyJS 