### PR TITLE
WIP: Callable type support

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -11,7 +11,21 @@ const FuncOrFuncs{F} = Union{F, Vector{F}, Matrix{F}}
 all3D(d::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image), get(d, :seriestype, :none))
 
 # unknown
-convertToAnyVector(x, d::KW) = error("No user recipe defined for $(typeof(x))")
+# in this case, check if it's actually a callable type and use as a function
+# otherwise it's unsupported and throw an error.
+function convertToAnyVector(x, d::KW)
+    try
+        x(0.0)
+    catch
+        try
+            x(0.0,0.0)
+        catch
+            error("No user recipe defined for $(typeof(x))")
+        end
+    end
+    @show "here!"
+    Any[(v...)->x(v...)]
+end
 
 # missing
 convertToAnyVector(v::Void, d::KW) = Any[nothing], nothing
@@ -371,7 +385,7 @@ end
 end
 
 # try some intervals over which the function may be defined
-function tryrange(F::AbstractArray, vec) 
+function tryrange(F::AbstractArray, vec)
     rets = [tryrange(f, vec) for f in F] # get the preferred for each
     maxind = maximum(indexin(rets, vec)) # get the last attempt that succeeded (most likely to fit all)
     rets .= [tryrange(f, vec[maxind:maxind]) for f in F] # ensure that all functions compute there

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,6 +133,13 @@ end
     histogram([1, 0, 0, 0, 0, 0])
 end
 
+@testset "Callable Functions" begin
+    struct MyFun end
+    (::MyFun)(x) = sin(x)
+    A = MyFun()
+    plot(A, -pi, pi, markershape = :circle)
+end
+
 # tests for preprocessing recipes
 
 # @testset "recipes" begin


### PR DESCRIPTION
Attempts to solve #1087. Current issue is:

```julia
BoundsError: attempt to access 1-element Array{Any,1} at index [2]
macro expansion at series.jl:131 [inlined]
apply_recipe(::Dict{Symbol,Any}, ::Type{Plots.SliceIt}, ::MyFun, ::Float64, ::Irrational{:π}) at RecipesBase.jl:287
_process_userrecipes(::Plots.Plot{Plots.PlotlyBackend}, ::Dict{Symbol,Any}, ::Tuple{MyFun,Float64,Irrational{:π}}) at pipeline.jl:81
_plot!(::Plots.Plot{Plots.PlotlyBackend}, ::Dict{Symbol,Any}, ::Tuple{MyFun,Float64,Irrational{:π}}) at plot.jl:175
#plot#143(::Array{Any,1}, ::Function, ::MyFun, ::Vararg{Any,N} where N) at plot.jl:56
(::RecipesBase.#kw##plot)(::Array{Any,1}, ::RecipesBase.#plot, ::MyFun, ::Float64, ::Vararg{Any,N} where N) at <missing>:0
include_string(::String, ::String) at loading.jl:515
include_string(::String, ::String, ::Int64) at eval.jl:30
include_string(::Module, ::String, ::String, ::Int64, ::Vararg{Int64,N} where N) at eval.jl:34
(::Atom.##49#53{String,Int64,String})() at eval.jl:50
withpath(::Atom.##49#53{String,Int64,String}, ::String) at utils.jl:30
withpath(::Function, ::String) at eval.jl:38
macro expansion at eval.jl:49 [inlined]
(::Atom.##48#52{Dict{String,Any}})() at task.jl:80
```

I am not sure where this is supposed to be pointing to.

Other issue is, I don't have the other arguments for the test, so `0` may be out of bounds or the wrong type. Is there any way to know the type of the other arguments in here?