### PR TITLE
fix #750 : save svg plotlyjs

### DIFF
--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -85,7 +85,8 @@ end
 
 # ----------------------------------------------------------------
 
-function _show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyJSBackend})
+function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend})
+    prepare_output(plt)
     if isijulia() && !_use_remote[]
         write(io, PlotlyJS.html_body(PlotlyJS.JupyterPlot(plt.o)))
     else
@@ -98,6 +99,7 @@ function plotlyjs_save_hack(io::IO, plt::Plot{PlotlyJSBackend}, ext::String)
     PlotlyJS.savefig(plt.o, tmpfn)
     write(io, read(open(tmpfn)))
 end
+_show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "svg")
 _show(io::IO, ::MIME"image/png", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "png")
 _show(io::IO, ::MIME"application/pdf", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "pdf")
 _show(io::IO, ::MIME"image/eps", plt::Plot{PlotlyJSBackend}) = plotlyjs_save_hack(io, plt, "eps")


### PR DESCRIPTION
Superseeds #751 in a less invasive way: now PlotlyJS plots are diplayed exactly as they used to be in the Jupyter notebook, but `savefig("test.svg")` saves in svg rather than html format (as instead it does on master).