### PR TITLE
Minor test_example changes (close #1162)

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -346,10 +346,10 @@ PlotExample("Magic grid argument",
 PlotExample("Framestyle",
     "The style of the frame/axes of a (sub)plot can be changed with the `framestyle` attribute. The default framestyle is `:axes`.",
     [:(begin
-    scatter(fill(randn(10), 7), fill(randn(10), 7),
+    scatter(fill(randn(10), 6), fill(randn(10), 6),
         framestyle = [:box :semi :origin :zerolines :grid :none],
         title = [":box" ":semi" ":origin" ":zerolines" ":grid" ":none"],
-        color = RowVector(1:7), layout = 7, label = "", markerstrokewidth = 0)
+        color = RowVector(1:6), layout = 6, label = "", markerstrokewidth = 0)
     end)]
 ),
 

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -262,7 +262,8 @@ PlotExample("Groups and Subplots",
     "",
     [:(begin
         group = rand(map(i->"group $i",1:4),100)
-        plot(rand(100), layout=@layout([a b;c]), group=group, linetype=[:bar :scatter :steppre])
+        plot(rand(100), layout=@layout([a b;c]), group=group,
+            linetype=[:bar :scatter :steppre], linewidth = [0 0 1])
     end)]
 ),
 
@@ -322,11 +323,11 @@ PlotExample("Animation with subplots",
 ),
 
 PlotExample("Spy",
-    "For a matrix `mat` with unique nonzeros `spy(mat)` returns a colorless plot. If `mat` has various different nonzero values, a colorbar is added. The colorbar can be disabled with `legend = nothing`. As always, the marker shape and size can be changed with `spy(mat, markersize = 3, markershape = :star)`.",
+    "For a matrix `mat` with unique nonzeros `spy(mat)` returns a colorless plot. If `mat` has various different nonzero values, a colorbar is added. The colorbar can be disabled with `legend = nothing`.",
     [:(begin
     a = spdiagm((ones(50), ones(49), ones(49), ones(40), ones(40)),(0, 1, -1, 10, -10))
     b = spdiagm((1:50, 1:49, 1:49, 1:40, 1:40),(0, 1, -1, 10, -10))
-    plot(spy(a, markershape = :dtriangle), spy(b), markersize = 3, title = ["Unique nonzeros" "Different nonzeros"])
+    plot(spy(a), spy(b), title = ["Unique nonzeros" "Different nonzeros"])
     end)]
 ),
 
@@ -345,8 +346,10 @@ PlotExample("Magic grid argument",
 PlotExample("Framestyle",
     "The style of the frame/axes of a (sub)plot can be changed with the `framestyle` attribute. The default framestyle is `:axes`.",
     [:(begin
-    histogram(fill(randn(1000), 5), framestyle = [:box :semi :axes :grid :none],
-        title = [":box" ":semi" ":axes" ":grid" ":none"], color = RowVector(1:5), layout = 5, label = "")
+    scatter(fill(randn(10), 7), fill(randn(10), 7),
+        framestyle = [:box :semi :origin :zerolines :grid :none],
+        title = [":box" ":semi" ":origin" ":zerolines" ":grid" ":none"],
+        color = RowVector(1:7), layout = 7, label = "", markerstrokewidth = 0)
     end)]
 ),
 

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -263,7 +263,7 @@ PlotExample("Groups and Subplots",
     [:(begin
         group = rand(map(i->"group $i",1:4),100)
         plot(rand(100), layout=@layout([a b;c]), group=group,
-            linetype=[:bar :scatter :steppre], linewidth = [0 0 1])
+            linetype=[:bar :scatter :steppre], linecolor = :match)
     end)]
 ),
 
@@ -349,7 +349,8 @@ PlotExample("Framestyle",
     scatter(fill(randn(10), 6), fill(randn(10), 6),
         framestyle = [:box :semi :origin :zerolines :grid :none],
         title = [":box" ":semi" ":origin" ":zerolines" ":grid" ":none"],
-        color = RowVector(1:6), layout = 6, label = "", markerstrokewidth = 0)
+        color = RowVector(1:6), layout = 6, label = "", markerstrokewidth = 0,
+        ticks = -2:2)
     end)]
 ),
 


### PR DESCRIPTION
Groups and Subplots (`test_examples(:gr, 26)`)
![gr_26](https://user-images.githubusercontent.com/16589944/31738924-6836e0a0-b44c-11e7-9c85-0b642c6ce298.png)

Spy (`test_examples(:gr, 32)`)
![gr_32](https://user-images.githubusercontent.com/16589944/31738970-8dfde73e-b44c-11e7-9ced-a596d3d43f5e.png)

Framestyle (`test_examples(:gr, 34)`)
![gr_34](https://user-images.githubusercontent.com/16589944/31738993-a9853b38-b44c-11e7-96ab-f6cb5477d2c5.png)
