### PR TITLE
Fix log scale ticks LaTeX error for PGFPlots. (fixes #1192)

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -300,7 +300,15 @@ function pgf_axis(sp::Subplot, letter)
     if !(axis[:ticks] in (nothing, false, :none)) && framestyle != :none
         ticks = get_ticks(axis)
         push!(style, string(letter, "tick = {", join(ticks[1],","), "}"))
-        if axis[:showaxis]
+        if axis[:showaxis] && axis[:scale] in (:ln, :log2, :log10) && axis[:ticks] == :auto
+            # wrap the power part of label with }
+            tick_labels = String[begin
+                base, power = split(label, "^")
+                power = string("{", power, "}")
+                string(base, "^", power)
+            end for label in ticks[2]]
+            push!(style, string(letter, "ticklabels = {\$", join(tick_labels,"\$,\$"), "\$}"))
+        elseif axis[:showaxis]
             push!(style, string(letter, "ticklabels = {", join(ticks[2],","), "}"))
         else
             push!(style, string(letter, "ticklabels = {}"))


### PR DESCRIPTION
#1192 

Many thanks to @PythonNut for finding the error in the first place 😄 !

```
using Plots
pgfplots()
plot(rand(10), xscale = :log2, yscale = :log10)
```
![log-1](https://user-images.githubusercontent.com/22132297/31776367-3b0a1218-b4e3-11e7-9449-db072e42358a.png)

