### PR TITLE
Make revise possible

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -15,6 +15,8 @@ using Base.Meta
 import Showoff
 import StatsBase
 
+using Requires
+
 export
     grid,
     bbox,

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -9,6 +9,10 @@ TODO
     * fix units in all visuals (e.g dotted lines, marker scale, surfaces)
 =#
 
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "glvisualize.jl")) 
+end
+
 const _glvisualize_attr = merge_with_base_supported([
     :annotations,
     :background_color_legend, :background_color_inside, :background_color_outside,

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -3,6 +3,9 @@
 
 # significant contributions by @jheinen
 
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "gr.jl")) 
+end
 
 const _gr_attr = merge_with_base_supported([
     :annotations,

--- a/src/backends/hdf5.jl
+++ b/src/backends/hdf5.jl
@@ -28,6 +28,9 @@ Read from .hdf5 file using:
     - Should be reliable for archival purposes.
 ==#
 
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "hdf5.jl")) 
+end
 
 import FixedPointNumbers: N0f8 #In core Julia
 
@@ -128,7 +131,7 @@ function _hdf5_merge!(dest::Dict, src::Dict)
             _hdf5_merge!(dest[k].d, v.d)
         else
             dest[k] = v
-        end    
+        end
     end
     return
 end

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -13,6 +13,10 @@ Add in functionality to Plots.jl:
     :aspect_ratio,
 =#
 
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "inspectdr.jl")) 
+end
+
 # ---------------------------------------------------------------------------
 #TODO: remove features
 const _inspectdr_attr = merge_with_base_supported([

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -2,6 +2,10 @@
 
 # significant contributions by: @pkofod
 
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "pgfplots.jl"))
+end
+
 const _pgfplots_attr = merge_with_base_supported([
     :annotations,
     # :background_color_legend,

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1,6 +1,10 @@
 
 # https://plot.ly/javascript/getting-started
 
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "plotly.jl")) 
+end
+
 const _plotly_attr = merge_with_base_supported([
     :annotations,
     :background_color_legend, :background_color_inside, :background_color_outside,

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -1,3 +1,6 @@
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "plotlyjs.jl")) 
+end
 
 # https://github.com/spencerlyon2/PlotlyJS.jl
 

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1,6 +1,9 @@
 
 # https://github.com/stevengj/PyPlot.jl
 
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "pyplot.jl")) 
+end
 
 const _pyplot_attr = merge_with_base_supported([
     :annotations,

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -1,6 +1,10 @@
 
 # https://github.com/Evizero/UnicodePlots.jl
 
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "unicodeplots.jl")) 
+end
+
 const _unicodeplots_attr = merge_with_base_supported([
     :label,
     :legend,

--- a/src/backends/web.jl
+++ b/src/backends/web.jl
@@ -2,7 +2,9 @@
 # NOTE:  backend should implement `html_body` and `html_head`
 
 # CREDIT: parts of this implementation were inspired by @joshday's PlotlyLocal.jl
-
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "web.jl")) 
+end
 
 function standalone_html(plt::AbstractPlot; title::AbstractString = get(plt.attr, :window_title, "Plots.jl"))
     """

--- a/src/output.jl
+++ b/src/output.jl
@@ -258,7 +258,6 @@ end
 
 const _ijulia_output = String["text/html"]
 
-using Requires
 @require IJulia begin
     if IJulia.inited
         export set_ijulia_output


### PR DESCRIPTION
Explicitly register the `eval`-included backend files with Revise