### PR TITLE
Polar plots consistency

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -239,8 +239,13 @@ function get_ticks(axis::Axis)
         # discrete ticks...
         axis[:continuous_values], dvals
     elseif ticks == :auto
-        # compute optimal ticks and labels
-        optimal_ticks_and_labels(axis)
+        if ispolar(axis.sps[1]) && axis[:letter] == :x
+            #force theta axis to be full circle
+            (collect(0:pi/4:7pi/4), string.(0:45:315))
+        else
+            # compute optimal ticks and labels
+            optimal_ticks_and_labels(axis)
+        end
     elseif typeof(ticks) <: Union{AVec, Int}
         # override ticks, but get the labels
         optimal_ticks_and_labels(axis, ticks)
@@ -427,7 +432,16 @@ function axis_limits(axis::Axis, should_widen::Bool = default_should_widen(axis)
     if !isfinite(amin) && !isfinite(amax)
         amin, amax = 0.0, 1.0
     end
-    if should_widen
+    if ispolar(axis.sps[1])
+        if axis[:letter] == :x
+            amin, amax = 0, 2pi
+        elseif lims == :auto
+            #widen max radius so ticks dont overlap with theta axis
+            amin, 1.1*amax
+        else
+            amin, amax
+        end
+    elseif should_widen
         widen(amin, amax)
     else
         amin, amax

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -437,7 +437,7 @@ function axis_limits(axis::Axis, should_widen::Bool = default_should_widen(axis)
             amin, amax = 0, 2pi
         elseif lims == :auto
             #widen max radius so ticks dont overlap with theta axis
-            amin, 1.1*amax
+            amin, amax + 0.1 * abs(amax - amin)
         else
             amin, amax
         end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -214,8 +214,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     a = α .+ 90
     sinf = sind.(a)
     cosf = cosd.(a)
-    tick = 0.5 * GR.tick(rmin, rmax)
-    n = round(Int, (rmax - rmin) / tick + 0.5)
+    rtick_values, rtick_labels = get_ticks(yaxis)
 
     #draw angular grid
     if xaxis[:grid]
@@ -230,9 +229,9 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     if yaxis[:grid]
         gr_set_line(yaxis[:gridlinewidth], yaxis[:gridstyle], yaxis[:foreground_color_grid])
         GR.settransparency(yaxis[:gridalpha])
-        for i in 0:n
-            r = float(i) * tick / rmax
-            if r <= 1.0
+        for i in 1:length(rtick_values)
+            r = (rtick_values[i] - rmin) / (rmax - rmin)
+            if r <= 1.0 && r >= 0.0
                 GR.drawarc(-r, r, -r, r, 0, 359)
             end
         end
@@ -255,11 +254,11 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
 
     #draw radial ticks
     if yaxis[:showaxis]
-        for i in 0:n
-            r = float(i) * tick / rmax
-            if i % 2 == 0 && r <= 1.0
+        for i in 1:length(rtick_values)
+            r = (rtick_values[i] - rmin) / (rmax - rmin)
+            if r <= 1.0 && r >= 0.0
                 x, y = GR.wctondc(0.05, r)
-                GR.text(x, y, string(signif(rmin + i * tick, 12)))
+                gr_text(x, y, _cycle(rtick_labels, i))
             end
         end
     end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -231,15 +231,12 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
         gr_set_line(yaxis[:gridlinewidth], yaxis[:gridstyle], yaxis[:foreground_color_grid])
         GR.settransparency(yaxis[:gridalpha])
         for i in 0:n
-            r = float(i) / n
-            if i % 2 == 0
-                if i > 0
-                    GR.drawarc(-r, r, -r, r, 0, 359)
-                end
-            else
+            r = float(i) * tick / rmax
+            if r <= 1.0
                 GR.drawarc(-r, r, -r, r, 0, 359)
             end
         end
+        GR.drawarc(-1, 1, -1, 1, 0, 359)
     end
 
     #prepare to draw ticks
@@ -259,8 +256,8 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     #draw radial ticks
     if yaxis[:showaxis]
         for i in 0:n
-            r = float(i) / n
-            if i % 2 == 0
+            r = float(i) * tick / rmax
+            if i % 2 == 0 && r <= 1.0
                 x, y = GR.wctondc(0.05, r)
                 GR.text(x, y, string(signif(rmin + i * tick, 12)))
             end

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -245,7 +245,7 @@ function _series_added(plt::Plot{InspectDRBackend}, series::Series)
     #No support for polar grid... but can still perform polar transformation:
     if ispolar(sp)
         Θ = x; r = y
-        x = r.*cos(Θ); y = r.*sin(Θ)
+        x = r.*cos.(Θ); y = r.*sin.(Θ)
     end
 
     # doesn't handle mismatched x/y - wrap data (pyplot behaviour):

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -220,6 +220,8 @@ function pgf_series(sp::Subplot, series::Series)
         # If a marker_z is used pass it as third coordinate to a 2D plot.
         # See "Scatter Plots" in PGFPlots documentation
         d[:x], d[:y], d[:marker_z]
+    elseif ispolar(sp)
+        rad2deg.(d[:x]), d[:y]
     else
         d[:x], d[:y]
     end
@@ -297,14 +299,15 @@ function pgf_axis(sp::Subplot, letter)
     # limits
     # TODO: support zlims
     if letter != :z
-        lims = axis_limits(axis)
+        lims = ispolar(sp) && letter == :x ? rad2deg.(axis_limits(axis)) : axis_limits(axis)
         kw[Symbol(letter,:min)] = lims[1]
         kw[Symbol(letter,:max)] = lims[2]
     end
 
     if !(axis[:ticks] in (nothing, false, :none)) && framestyle != :none
         ticks = get_ticks(axis)
-        push!(style, string(letter, "tick = {", join(ticks[1],","), "}"))
+        tick_values = ispolar(sp) && letter == :x ? rad2deg.(ticks[1]) : ticks[1]
+        push!(style, string(letter, "tick = {", join(tick_values,","), "}"))
         if axis[:showaxis] && axis[:scale] in (:ln, :log2, :log10) && axis[:ticks] == :auto
             # wrap the power part of label with }
             tick_labels = String[begin

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -294,6 +294,8 @@ function pgf_axis(sp::Subplot, letter)
     # grid on or off
     if axis[:grid] && framestyle != :none
         push!(style, "$(letter)majorgrids = true")
+    else
+        push!(style, "$(letter)majorgrids = false")
     end
 
     # limits

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -221,7 +221,8 @@ function pgf_series(sp::Subplot, series::Series)
         # See "Scatter Plots" in PGFPlots documentation
         d[:x], d[:y], d[:marker_z]
     elseif ispolar(sp)
-        rad2deg.(d[:x]), d[:y]
+        theta, r = filter_radial_data(d[:x], d[:y], axis_limits(sp[:yaxis]))
+        rad2deg.(theta), r
     else
         d[:x], d[:y]
     end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -717,7 +717,7 @@ end
 function plotly_polar!(d_out::KW, series::Series)
     # convert polar plots x/y to theta/radius
     if ispolar(series[:subplot])
-        d_out[:t] = rad2deg(pop!(d_out, :x))
+        d_out[:t] = rad2deg.(pop!(d_out, :x))
         d_out[:r] = pop!(d_out, :y)
     end
 end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -291,6 +291,22 @@ function plotly_axis(axis::Axis, sp::Subplot)
     ax
 end
 
+function plotly_polaraxis(axis::Axis)
+    ax = KW(
+        :visible => axis[:grid],
+        :showline => axis[:grid],
+    )
+
+    if axis[:letter] == :x
+        ax[:range] = rad2deg.(axis_limits(axis))
+    else
+        ax[:range] = axis_limits(axis)
+        ax[:orientation] = 0
+    end
+
+    ax
+end
+
 function plotly_layout(plt::Plot)
     d_out = KW()
 
@@ -345,6 +361,9 @@ function plotly_layout(plt::Plot)
                     ),
                 ),
             )
+        elseif ispolar(sp)
+            d_out[Symbol("angularaxis$spidx")] = plotly_polaraxis(sp[:xaxis])
+            d_out[Symbol("radialaxis$spidx")] = plotly_polaraxis(sp[:yaxis])
         else
             d_out[Symbol("xaxis$spidx")] = plotly_axis(sp[:xaxis], sp)
             d_out[Symbol("yaxis$spidx")] = plotly_axis(sp[:yaxis], sp)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -717,8 +717,9 @@ end
 function plotly_polar!(d_out::KW, series::Series)
     # convert polar plots x/y to theta/radius
     if ispolar(series[:subplot])
-        d_out[:t] = rad2deg.(pop!(d_out, :x))
-        d_out[:r] = pop!(d_out, :y)
+        theta, r = filter_radial_data(pop!(d_out, :x), pop!(d_out, :y), axis_limits(series[:subplot][:yaxis]))
+        d_out[:t] = rad2deg.(theta)
+        d_out[:r] = r
     end
 end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -293,7 +293,7 @@ end
 
 function plotly_polaraxis(axis::Axis)
     ax = KW(
-        :visible => axis[:grid],
+        :visible => axis[:showaxis],
         :showline => axis[:grid],
     )
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -301,7 +301,7 @@ function plotly_polaraxis(axis::Axis)
         ax[:range] = rad2deg.(axis_limits(axis))
     else
         ax[:range] = axis_limits(axis)
-        ax[:orientation] = 0
+        ax[:orientation] = -90
     end
 
     ax

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1054,6 +1054,9 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             end
             py_set_scale(ax, axis)
             py_set_lims(ax, axis)
+            if ispolar(sp) && letter == :y
+                ax[:set_rlabel_position](0)
+            end
             ticks = sp[:framestyle] == :none ? nothing : get_ticks(axis)
             # don't show the 0 tick label for the origin framestyle
             if sp[:framestyle] == :origin && length(ticks) > 1
@@ -1080,6 +1083,8 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                     linewidth = axis[:gridlinewidth],
                     alpha = axis[:gridalpha])
                 ax[:set_axisbelow](true)
+            else
+                pyaxis[:grid](false)
             end
             py_set_axis_colors(sp, ax, axis)
         end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1093,7 +1093,11 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
         if !sp[:xaxis][:showaxis]
             kw = KW()
             for dir in (:top, :bottom)
-                ax[:spines][string(dir)][:set_visible](false)
+                if ispolar(sp)
+                    ax[:spines]["polar"][:set_visible](false)
+                else
+                    ax[:spines][string(dir)][:set_visible](false)
+                end
                 kw[dir] = kw[Symbol(:label,dir)] = "off"
             end
             ax[:xaxis][:set_tick_params](; which="both", kw...)
@@ -1101,7 +1105,9 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
         if !sp[:yaxis][:showaxis]
             kw = KW()
             for dir in (:left, :right)
-                ax[:spines][string(dir)][:set_visible](false)
+                if !ispolar(sp)
+                    ax[:spines][string(dir)][:set_visible](false)
+                end
                 kw[dir] = kw[Symbol(:label,dir)] = "off"
             end
             ax[:yaxis][:set_tick_params](; which="both", kw...)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1055,7 +1055,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             py_set_scale(ax, axis)
             py_set_lims(ax, axis)
             if ispolar(sp) && letter == :y
-                ax[:set_rlabel_position](0)
+                ax[:set_rlabel_position](90)
             end
             ticks = sp[:framestyle] == :none ? nothing : get_ticks(axis)
             # don't show the 0 tick label for the origin framestyle

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -363,15 +363,26 @@ end
 
 function convert_to_polar(x, y, r_extrema = calc_r_extrema(x, y))
     rmin, rmax = r_extrema
-    phi, r = x, y
+    theta, r = filter_radial_data(x, y, r_extrema)
     r = (r - rmin) / (rmax - rmin)
-    n = max(length(phi), length(r))
-    x = zeros(n)
-    y = zeros(n)
+    x = r.*cos.(theta)
+    y = r.*sin.(theta)
+    x, y
+end
+
+# Filters radial data for points within the axis limits
+function filter_radial_data(theta, r, r_extrema::Tuple{Real, Real})
+    n = max(length(theta), length(r))
+    rmin, rmax = r_extrema
+    x, y = zeros(n), zeros(n)
     for i in 1:n
-        x[i] = _cycle(r,i) * cos.(_cycle(phi,i))
-        y[i] = _cycle(r,i) * sin.(_cycle(phi,i))
+        x[i] = _cycle(theta, i)
+        y[i] = _cycle(r, i)
     end
+    points = map((a, b) -> (a, b), x, y)
+    filter!(a -> a[2] >= rmin && a[2] <= rmax, points)
+    x = map(a -> a[1], points)
+    y = map(a -> a[2], points)
     x, y
 end
 


### PR DESCRIPTION
Fixes #1103 

```
using Plots
plot(linspace(0, 2pi, 360), linspace(0, 3, 360), proj = :polar)
```

GR: 
![polargr](https://user-images.githubusercontent.com/22132297/32414020-b5217e80-c215-11e7-9af1-1234444862cc.png)

PyPlot:
![polarpyplot](https://user-images.githubusercontent.com/22132297/32409702-992b9a02-c1a8-11e7-940a-a5323392d67f.png)

PGFPlots:
![polarpgfplots](https://user-images.githubusercontent.com/22132297/32409704-9d0b4154-c1a8-11e7-99cd-4be6c11fd9c9.png)

Plotly:
![polarplotly](https://user-images.githubusercontent.com/22132297/32409710-a2ebf4ba-c1a8-11e7-9f05-3210dd61b211.png)

InspectDR: Haven't done much testing yet

Remarks:

The `radialaxis` and `angularaxis` attributes in Plotly don't have a `tickvals` keyword (at least it's not in the PlotlyJS reference) so I don't think you can manually set the polar ticks for this backend. I've read somewhere that Plotly polar plots are badly underdeveloped.

The tick labels are in degrees even though the input is in radians. Getting the fractions of pi to display properly changes between backends and in my experience whenever latex is used there are issues with it not listening to `tickfont`. GR already displays the labels in degrees so I have just settled on that.

Currently a polar plot has it's angular limits locked at 0 to 2pi. I am personally not sure whether it makes sense to lift that restriction and allow limits to be set manually? In PGFPlots setting limits manually does what I expect and shows only a sector of the circle. In PyPlot the limits are mapped over the full circle. Also the default ticks calculated by `Plots` look bad on an angular axis.

Issues:
- `yflip` doesn't work
- PGFPlots has issues with negative data `linspace(0, -3, 360)` breaks but linspace(-1, -3, 360) works.
- Logarithmic scales don't work.