### PR TITLE
allow setting the linewidth for contour plots in GR

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -4,7 +4,7 @@
 # significant contributions by @jheinen
 
 @require Revise begin
-    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "gr.jl")) 
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "gr.jl"))
 end
 
 const _gr_attr = merge_with_base_supported([
@@ -997,11 +997,13 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             if series[:fillrange] != nothing
                 GR.surface(x, y, z, GR.OPTION_CELL_ARRAY)
             else
+                GR.setlinewidth(series[:linewidth])
                 GR.contour(x, y, h, z, 1000)
             end
 
             # create the colorbar of contour levels
             if cmap
+                gr_set_line(1, :solid, yaxis[:foreground_color_axis])
                 gr_set_viewport_cmap(sp)
                 l = round.(Int32, 1000 + (h - ignorenan_minimum(h)) / (ignorenan_maximum(h) - ignorenan_minimum(h)) * 255)
                 GR.setwindow(xmin, xmax, zmin, zmax)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -998,7 +998,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 GR.surface(x, y, z, GR.OPTION_CELL_ARRAY)
             else
                 GR.setlinetype(gr_linetype[series[:linestyle]])
-                width, height = gr_plot_size
                 GR.setlinewidth(max(0, series[:linewidth] / (sum(gr_plot_size) * 0.001)))
                 GR.contour(x, y, h, z, 1000)
             end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -997,7 +997,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             if series[:fillrange] != nothing
                 GR.surface(x, y, z, GR.OPTION_CELL_ARRAY)
             else
-                GR.setlinewidth(series[:linewidth])
+                GR.setlinetype(gr_linetype[series[:linestyle]])
+                width, height = gr_plot_size
+                GR.setlinewidth(max(0, series[:linewidth] / (sum(gr_plot_size) * 0.001)))
                 GR.contour(x, y, h, z, 1000)
             end
 


### PR DESCRIPTION
cf https://github.com/JuliaPlots/Plots.jl/issues/1218
```julia
using Plots; gr()
contourf((1:100)*(1:100)', c = :turbid)
contour!((1:100)*(1:100)', c = :gray, lw = 10)
```
![gr_contour_colors](https://user-images.githubusercontent.com/16589944/32346607-1fdf3334-c00e-11e7-8ea1-baa765e5b48a.png)
