### PR TITLE
Add stats_mode=diff and diff_mode=rectangle

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -72,9 +72,11 @@ function buildanimation(animdir::AbstractString, fn::AbstractString,
 
     if is_animated_gif
         # generate a colorpalette first so ffmpeg does not have to guess it
-        run(`ffmpeg -v 0 -i $(animdir)/%06d.png -vf palettegen -y palette.png`)
+        # use stats_mode=diff to emphasize changes and avoid bias for static white background
+        run(`ffmpeg -v 0 -i $(animdir)/%06d.png -vf palettegen=stats_mode=diff -y palette.png`)
         # then apply the palette to get better results
-        run(`ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -i palette.png -lavfi paletteuse -y $fn`)
+        # use diff_mode=rectangle to improve rendering quality and reduce file-size
+        run(`ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -i palette.png -lavfi paletteuse=diff_mode=rectangle -y $fn`)
     else
         run(`ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -pix_fmt yuv420p -y $fn`)
     end


### PR DESCRIPTION
`stats_mode=diff` makes `palettegen` focus on the changes between frames instead of the whole frame.
Given that the whole frame (usually) consists mainly of a static white background, this is likely to improve image quality

`diff_mode=rectangle` makes the gif encoding crop to the bounding box of the changing parts. This again is likely to improve image quality because it avoids error diffusion to parts of the image that do not change. It can also greatly reduce file-size for GIFs where only a small section of the image changes between frames.

See this comment for more details: 

https://github.com/JuliaPlots/Plots.jl/issues/423#issuecomment-342173040