### PR TITLE
change pgfplots legend symbol for shapes and filled plots (fix #1215)

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -207,6 +207,9 @@ function pgf_series(sp::Subplot, series::Series)
     # add to legend?
     if sp[:legend] != :none && should_add_to_legend(series)
         kw[:legendentry] = d[:label]
+        if st == :shape || d[:fillrange] != nothing
+            push!(style, "area legend")
+        end
     else
         push!(style, "forget plot")
     end


### PR DESCRIPTION
```julia
using Plots; pgfplots()
plot(
    plot(Shape([1, 2, 4, 2, 1], [2, 1, 3, 4, 2]), fillcolor = 2),
    bar(rand(10)),
    histogram(randn(100), color = 3, linecolor = :match, fillalpha = 0.5),
    plot(rand(10), color = 4, fill = true)
)
```
![pgfplots-legend-symbol](https://user-images.githubusercontent.com/16589944/32574536-c6cbf9e4-c4d1-11e7-81d9-33380bd42d9f.png)

and
```julia
using StatPlots; pgfplots()
groupedbar(rand(10,3), bar_position = :stack)
```
![pgfplots-legend-symbol_groupedbar](https://user-images.githubusercontent.com/16589944/32574547-ced0ca3e-c4d1-11e7-95dd-e632859f5c1b.png)

Unrelated: Not sure, what's wrong with the pngs though ... Looks fine as pdf:
[pgfplots-legend-symbol.pdf](https://github.com/JuliaPlots/Plots.jl/files/1455448/pgfplots-legend-symbol.pdf)
