### PR TITLE
PyPlot: change legend symbols for shapes and filled plots

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -2,7 +2,7 @@
 # https://github.com/stevengj/PyPlot.jl
 
 @require Revise begin
-    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "pyplot.jl")) 
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "pyplot.jl"))
 end
 
 const _pyplot_attr = merge_with_base_supported([
@@ -1009,7 +1009,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             for lab in cb[:ax][:yaxis][:get_ticklabels]()
                   lab[:set_fontsize](py_dpi_scale(plt, sp[:yaxis][:tickfont].pointsize))
                   lab[:set_family](sp[:yaxis][:tickfont].family)
-            end 
+            end
             sp.attr[:cbar_handle] = cb
             sp.attr[:cbar_ax] = cbax
         end
@@ -1221,10 +1221,11 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
         for series in series_list(sp)
             if should_add_to_legend(series)
                 # add a line/marker and a label
-                push!(handles, if series[:seriestype] == :shape
-                    PyPlot.plt[:Line2D]((0,1),(0,0),
-                        color = py_color(_cycle(series[:fillcolor],1)),
-                        linewidth = py_dpi_scale(plt, 4)
+                push!(handles, if series[:seriestype] == :shape || series[:fillrange] != nothing
+                    pypatches[:Patch](
+                        edgecolor = py_color(_cycle(series[:linecolor],1)),
+                        facecolor = py_color(_cycle(series[:fillcolor],1)),
+                        linewidth = py_dpi_scale(plt, series[:linewidth])
                     )
                 elseif series[:seriestype] == :path
                     PyPlot.plt[:Line2D]((0,1),(0,0),

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1225,12 +1225,12 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                     pypatches[:Patch](
                         edgecolor = py_color(_cycle(series[:linecolor],1)),
                         facecolor = py_color(_cycle(series[:fillcolor],1)),
-                        linewidth = py_dpi_scale(plt, series[:linewidth])
+                        linewidth = py_dpi_scale(plt, clamp(series[:linewidth], 0, 5)),
                     )
                 elseif series[:seriestype] == :path
-                    PyPlot.plt[:Line2D]((0,1),(0,0),
+                    PyPlot.plt[:Line2D]((0, 1),(0,0),
                         color = py_color(_cycle(series[:fillcolor],1)),
-                        linewidth = py_dpi_scale(plt, 1),
+                        linewidth = py_dpi_scale(plt, clamp(series[:linewidth], 0, 5)),
                         marker = py_marker(series[:markershape]),
                         markeredgecolor = py_markerstrokecolor(series),
                         markerfacecolor = py_markercolor(series)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1228,7 +1228,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                         linewidth = py_dpi_scale(plt, clamp(series[:linewidth], 0, 5)),
                     )
                 elseif series[:seriestype] == :path
-                    PyPlot.plt[:Line2D]((0, 1),(0,0),
+                    PyPlot.plt[:Line2D]((0,1),(0,0),
                         color = py_color(_cycle(series[:fillcolor],1)),
                         linewidth = py_dpi_scale(plt, clamp(series[:linewidth], 0, 5)),
                         marker = py_marker(series[:markershape]),


### PR DESCRIPTION
Changes
```julia
plot(
    plot(Shape([1,5,4,2,1], [0,2,5,6,0]), fillalpha = 0.5),
    plot(rand(10), lc = 2, fc = 3, lw = 3, fillrange = 0),
    plot(rand(10), lc = 4, fc = 5, lw = 3, lα = 0.5, fill = true, st = :step),
    histogram(randn(1000), c = 6, lc = :match, fα = 0.5),
)
```
from

![pyplot_legend_old](https://user-images.githubusercontent.com/16589944/32943210-ab471b02-cb8b-11e7-8344-f0a3c978573c.png)

to

![pyplot_legend_new](https://user-images.githubusercontent.com/16589944/32943217-b345a7a6-cb8b-11e7-87ba-0fdfb5cd29c8.png)
