### PR TITLE
Plotly : always define range explicitely. Solves axis linking #1124

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -252,7 +252,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
     end
 
     ax[:tickangle] = -axis[:rotation]
-
+    ax[:range] = axis_limits(axis)
     if !(axis[:ticks] in (nothing, :none))
         ax[:titlefont] = plotly_font(axis[:guidefont], axis[:foreground_color_guide])
         ax[:type] = plotly_scale(axis[:scale])
@@ -288,6 +288,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:showgrid] = false
     end
 
+    
     ax
 end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -262,12 +262,6 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:tickcolor] = framestyle in (:zerolines, :grid) || !axis[:showaxis] ? rgba_string(invisible()) : rgb_string(axis[:foreground_color_axis])
         ax[:linecolor] = rgba_string(axis[:foreground_color_axis])
 
-        # lims
-       
-        #if lims != :auto && limsType(lims) == :limits
-        #ax[:range] = map(scalefunc(axis[:scale]), lims)
-        #end
-
         # flip
         if axis[:flip]
             ax[:autorange] = "reversed"

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -252,7 +252,9 @@ function plotly_axis(axis::Axis, sp::Subplot)
     end
 
     ax[:tickangle] = -axis[:rotation]
-    ax[:range] = axis_limits(axis)
+    lims = axis_limits(axis)
+    ax[:range] = map(scalefunc(axis[:scale]), lims)
+    
     if !(axis[:ticks] in (nothing, :none))
         ax[:titlefont] = plotly_font(axis[:guidefont], axis[:foreground_color_guide])
         ax[:type] = plotly_scale(axis[:scale])
@@ -261,10 +263,10 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:linecolor] = rgba_string(axis[:foreground_color_axis])
 
         # lims
-        lims = axis[:lims]
-        if lims != :auto && limsType(lims) == :limits
-            ax[:range] = map(scalefunc(axis[:scale]), lims)
-        end
+       
+        #if lims != :auto && limsType(lims) == :limits
+        #ax[:range] = map(scalefunc(axis[:scale]), lims)
+        #end
 
         # flip
         if axis[:flip]


### PR DESCRIPTION
Repairs axes linking in plotly.

```julia
using Plots
plotlyjs()
plot(rand(10,2).*[1 10],layout=(1,2),link=:y)
```

![newplot](https://user-images.githubusercontent.com/1626262/32967976-8cf333c6-cbad-11e7-8e94-d89d7e7248e0.png)
