### PR TITLE
fix axes limits for fill=true in 3d plots (fix #1267)

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -355,7 +355,7 @@ function expand_extrema!(sp::Subplot, d::KW)
     if fr == nothing && d[:seriestype] == :bar
         fr = 0.0
     end
-    if fr != nothing
+    if fr != nothing && !all3D(d)
         axis = sp.attr[vert ? :yaxis : :xaxis]
         if typeof(fr) <: Tuple
             for fri in fr


### PR DESCRIPTION
#1213 set `fillrange = 0` for `fill=true`. This extended the yaxis limits to 0 for 3D plots, which is not expected. This should fix this.