### PR TITLE
Extend grid lines to axes limits for GR (and GLVisualize)

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -577,7 +577,7 @@ function axis_drawing_info(sp::Subplot)
                     push!(xtick_segs, (xtick, tick_start), (xtick, tick_stop)) # bottom tick
                 end
                 # sp[:draw_axes_border] && push!(xaxis_segs, (xtick, ymax), (xtick, t2)) # top tick
-                xaxis[:grid] && push!(xgrid_segs,  (xtick, t1),   (xtick, t2)) # vertical grid
+                xaxis[:grid] && push!(xgrid_segs, (xtick, ymin), (xtick, ymax)) # vertical grid
             end
         end
 
@@ -616,7 +616,7 @@ function axis_drawing_info(sp::Subplot)
                     push!(ytick_segs, (tick_start, ytick), (tick_stop, ytick)) # left tick
                 end
                 # sp[:draw_axes_border] && push!(yaxis_segs, (xmax, ytick), (t2, ytick)) # right tick
-                yaxis[:grid] && push!(ygrid_segs,  (t1, ytick),   (t2, ytick)) # horizontal grid
+                yaxis[:grid] && push!(ygrid_segs, (xmin, ytick), (xmax, ytick)) # horizontal grid
             end
         end
     end


### PR DESCRIPTION
This changes
```julia
plot(cumsum(randn(1000, 2), 1), bg_inside = RGB(0.8, 0.8, 0.8), grid = (:white, 0.9), framestyle = :grid, bg_legend = RGB(0.9, 0.9, 0.9))
```
from
![gridold](https://user-images.githubusercontent.com/16589944/33427730-a75ff6f4-d5c6-11e7-948b-81b6f21d9d0f.png)

to
![gridnew](https://user-images.githubusercontent.com/16589944/33427739-adf946dc-d5c6-11e7-9014-a06e52d99cc6.png)
