### PR TITLE
PyPlot: set tick marks color to match grid color for framestyle = :grid

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -924,7 +924,7 @@ function py_set_axis_colors(sp, ax, a::Axis)
     end
     axissym = Symbol(a[:letter], :axis)
     if haskey(ax, axissym)
-        tickcolor = sp[:framestyle] == :zerolines ? py_color(plot_color(a[:foreground_color_grid], a[:gridalpha])) : py_color(a[:foreground_color_axis])
+        tickcolor = sp[:framestyle] in (:zerolines, :grid) ? py_color(plot_color(a[:foreground_color_grid], a[:gridalpha])) : py_color(a[:foreground_color_axis])
         ax[:tick_params](axis=string(a[:letter]), which="both",
                          colors=tickcolor,
                          labelcolor=py_color(a[:tickfontcolor]))


### PR DESCRIPTION
```julia
plot(rand(10), framestyle = :grid)
```

Before:
![pyplot-grid-ticks_old](https://user-images.githubusercontent.com/16589944/33489329-dd130852-d6b3-11e7-8faf-5aacc679854a.png)

After:
![pyplot-grid-ticks_new](https://user-images.githubusercontent.com/16589944/33489347-e6499ec2-d6b3-11e7-8134-128e5ff3f3e8.png)
