### PR TITLE
Update iterator properly in _subplot_setup

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -264,7 +264,7 @@ function _subplot_setup(plt::Plot, d::KW, kw_list::Vector{KW})
 
         # extract subplot/axis attributes from kw and add to sp_attr
         attr = KW()
-        for (k,v) in kw
+        for (k,v) in collect(kw)
             if haskey(_subplot_defaults, k) || haskey(_axis_defaults_byletter, k)
                 attr[k] = pop!(kw, k)
             end


### PR DESCRIPTION
This seems to fix #1266 

I'm still not entirely sure why this doesn't work on master and why changing 

```julia
for (k,v) in kw
```
to
```julia
for (k,v) in collect(kw)
```
does work. I guess it's something about what happens if you update an iterator while you are iterating over it. So there may be a better way to handle this, but using `collect` seems to fix the problems referenced in the issue.