### PR TITLE
Use the :fontsize keys so the scalefontsizes command works

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -419,10 +419,10 @@ const _all_defaults = KW[
 const _initial_defaults = deepcopy(_all_defaults)
 
 # to be able to reset font sizes to initial values
-const _initial_fontsizes = Dict(:titlefont  => _subplot_defaults[:titlefontsize],
-                                :legendfont => _subplot_defaults[:legendfontsize],
-                                :tickfont   => _axis_defaults[:tickfontsize],
-                                :guidefont  => _axis_defaults[:guidefontsize])
+const _initial_fontsizes = Dict(:titlefontsize  => _subplot_defaults[:titlefontsize],
+                                :legendfontsize => _subplot_defaults[:legendfontsize],
+                                :tickfontsize   => _axis_defaults[:tickfontsize],
+                                :guidefontsize  => _axis_defaults[:guidefontsize])
 
 const _all_args = sort(collect(union(map(keys, _all_defaults)...)))
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -305,7 +305,7 @@ end
 
 function scalefontsize(k::Symbol, factor::Number)
     f = default(k)
-    f.pointsize = round(Int, factor * f.pointsize)
+    f = round(Int, factor * f)
     default(k, f)
 end
 
@@ -315,7 +315,7 @@ end
 Scales all **current** font sizes by `factor`. For example `scalefontsizes(1.1)` increases all current font sizes by 10%. To reset to initial sizes, use `scalefontsizes()`
 """
 function scalefontsizes(factor::Number)
-    for k in (:titlefont, :guidefont, :tickfont, :legendfont)
+    for k in (:titlefontsize, :guidefontsize, :tickfontsize, :legendfontsize)
         scalefontsize(k, factor)
     end
 end
@@ -326,10 +326,10 @@ end
 Resets font sizes to initial default values.
 """
 function scalefontsizes()
-  for k in (:titlefont, :guidefont, :tickfont, :legendfont)
+  for k in (:titlefontsize, :guidefontsize, :tickfontsize, :legendfontsize)
       f = default(k)
       if k in keys(_initial_fontsizes)
-        factor = f.pointsize / _initial_fontsizes[k]
+        factor = f / _initial_fontsizes[k]
         scalefontsize(k, 1.0/factor)
       end
   end


### PR DESCRIPTION
Fixes #1294

I think some usages of `:titlefont`, etc. slipped through when the font handling was changed recently.