### PR TITLE
Fix default log scale ticks in GR backend. Fixes #1203

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -860,7 +860,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 # use xor ($) to get the right y coords
                 xi, yi = GR.wctondc(cv, sp[:framestyle] == :origin ? 0 : xor(flip, mirror) ? ymax : ymin)
                 # @show cv dv ymin xi yi flip mirror (flip $ mirror)
-                gr_text(xi, yi + (mirror ? 1 : -1) * 5e-3 * (xaxis[:tick_direction] == :out ? 1.5 : 1.0), string(dv))
+                # ensure correct dispatch in gr_text for automatic log ticks
+                dv = xaxis[:scale] in (:ln, :log10, :log2) && xaxis[:ticks] == :auto ? string(dv, "\\ ") : string(dv)
+                gr_text(xi, yi + (mirror ? 1 : -1) * 5e-3 * (xaxis[:tick_direction] == :out ? 1.5 : 1.0), dv)
             end
         end
 
@@ -871,7 +873,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 # use xor ($) to get the right y coords
                 xi, yi = GR.wctondc(sp[:framestyle] == :origin ? 0 : xor(flip, mirror) ? xmax : xmin, cv)
                 # @show cv dv xmin xi yi
-                gr_text(xi + (mirror ? 1 : -1) * 1e-2 * (yaxis[:tick_direction] == :out ? 1.5 : 1.0), yi, string(dv))
+                # ensure correct dispatch in gr_text for automatic log ticks
+                dv = yaxis[:scale] in (:ln, :log10, :log2) && yaxis[:ticks] == :auto ? string(dv, "\\ ") : string(dv)
+                gr_text(xi + (mirror ? 1 : -1) * 1e-2 * (yaxis[:tick_direction] == :out ? 1.5 : 1.0), yi, dv)
             end
         end
 


### PR DESCRIPTION
#1203 
```
using Plots
gr()
plot(abs(rand(10)), yaxis=(:log10, (1e-3,1e3)))
savefig("gr.png")
```
![gr](https://user-images.githubusercontent.com/22132297/33786223-28729518-dc60-11e7-8be4-d8fe0fc80aae.png)
