### PR TITLE
RFC: abline! does not change axis limits; fix: #1297

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -985,9 +985,11 @@ end
 
 # -------------------------------------------------
 
-"Adds a+bx... straight line over the current plot"
+"Adds a+bx... straight line over the current plot, without changing the axis limits"
 function abline!(plt::Plot, a, b; kw...)
-    plot!(plt, [ignorenan_extrema(plt)...], x -> b + a*x; kw...)
+    xl, yl = xlims(plt), ylims(plt)
+    x1, x2 = max(xl[1], (yl[1] - b)/a), min(xl[2], (yl[2] - b)/a)
+    plot!(plt, x -> b + a*x, x1, x2; kw...)
 end
 
 abline!(args...; kw...) = abline!(current(), args...; kw...)


### PR DESCRIPTION
This leaves the axis limits in place, by only calculating the part of the line that's visible when calling the function. It's slightly hacky, though, as the line will not change when another series updates the axis limts (true for the existing implementation too, but maybe more tricky here)