### PR TITLE
plotly: bar_width and stroke_width support for bar plots

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -542,7 +542,6 @@ function plotly_series(plt::Plot, series::Series)
             y, x, "h"
         end
         d_out[:width] = series[:bar_width]
-        info(series[:strokewidth])
         d_out[:marker] = KW(:color => rgba_string(series[:fillcolor]),
                             :width => series[:strokewidth])
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -541,7 +541,10 @@ function plotly_series(plt::Plot, series::Series)
         else
             y, x, "h"
         end
-        d_out[:marker] = KW(:color => rgba_string(series[:fillcolor]))
+        d_out[:width] = series[:bar_width]
+        info(series[:strokewidth])
+        d_out[:marker] = KW(:color => rgba_string(series[:fillcolor]),
+                            :width => series[:strokewidth])
 
     elseif st == :heatmap
         d_out[:type] = "heatmap"


### PR DESCRIPTION
Fixes #1303 and uses `stroke_width` to put border on bars for plotly.

```julia
histogram(randn(1000))
```

<img width="596" alt="screen shot 2017-12-12 at 3 16 57 pm" src="https://user-images.githubusercontent.com/8075494/33906383-c5caad4a-df4f-11e7-804b-bb8d3cef8b83.png">
