### PR TITLE
Fix ribbons slicing for several series. Fixes #1302

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -140,6 +140,14 @@ struct SliceIt end
     end
     mf = length(fillranges)
 
+    rib = pop!(plotattributes, :ribbon, nothing)
+    ribbons, _ = if typeof(rib) <: Number
+        ([fr],nothing)
+    else
+        convertToAnyVector(rib, plotattributes)
+    end
+    mr = length(ribbons)
+
     # @show zs
 
     mx = length(xs)
@@ -155,6 +163,10 @@ struct SliceIt end
             # handle fillrange
             fr = fillranges[mod1(i,mf)]
             di[:fillrange] = isa(fr, Function) ? map(fr, di[:x]) : fr
+
+            # handle ribbons
+            rib = ribbons[mod1(i,mr)]
+            di[:ribbon] = isa(rib, Function) ? map(rib, di[:x]) : rib
 
             push!(series_list, RecipeData(di, ()))
         end


### PR DESCRIPTION
#1302 
```
using Plots
plot(linspace(0,7,100),ones(100,4), ribbon = [x->sin(x),x->cos(x),x->exp(-x), ones(100,1)], layout = 4)
```
![ribbons](https://user-images.githubusercontent.com/22132297/34013521-b5da2ad4-e10f-11e7-882b-feb899fd4550.png)

