### PR TITLE
3D marker_z handling. Fixes #1205

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -553,8 +553,9 @@ zlims(sp_idx::Int = 1) = zlims(current(), sp_idx)
 
 function get_clims(sp::Subplot)
     zmin, zmax = Inf, -Inf
+    z_colored_series = (:contour, :contour3d, :heatmap, :histogram2d, :surface)
     for series in series_list(sp)
-        for vals in (series[:z], series[:line_z], series[:marker_z], series[:fill_z])
+        for vals in (series[:seriestype] in z_colored_series ? series[:z] : nothing, [:line_z], series[:marker_z], series[:fill_z])
             if (typeof(vals) <: AbstractSurface) && (eltype(vals.surf) <: Real)
                 zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals.surf)...)
             elseif (vals != nothing) && (eltype(vals) <: Real)


### PR DESCRIPTION
#1205 
Not sure if I have all the seriestypes which use z values to color themselves in `z_colored_series`.
```
using Plots
scatter(1:10,1:10,1:10,marker_z=0.9:-0.1:0.0, markersize = 10)
```
GR
![marker_z](https://user-images.githubusercontent.com/22132297/34063578-d34fab26-e1ea-11e7-83ad-60db90fb8a8e.png)
PyPlot
![markerz](https://user-images.githubusercontent.com/22132297/34063580-d4c6f310-e1ea-11e7-86b1-45c2f5c30f20.png)
