### PR TITLE
Fix mismatched legend color when linecolor is given. Fixes #1319

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1234,7 +1234,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                     )
                 elseif series[:seriestype] == :path
                     PyPlot.plt[:Line2D]((0,1),(0,0),
-                        color = py_color(_cycle(series[:fillcolor],1)),
+                        color = py_color(_cycle(series[:linecolor],1)),
                         linewidth = py_dpi_scale(plt, clamp(series[:linewidth], 0, 5)),
                         linestyle = py_linestyle(:path,series[:linestyle]),
                         marker = py_marker(series[:markershape]),


### PR DESCRIPTION
#1319 
```
using Plots
pyplot()
plot(rand(10), linecolor = :red)
```
![legend](https://user-images.githubusercontent.com/22132297/34073992-08502040-e29e-11e7-8594-526385cf885e.png)
