### PR TITLE
Fix PyPlot ignoring alpha values of images. Fixes #1131

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -736,7 +736,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         z = if eltype(img) <: Colors.AbstractGray
             float(img)
         elseif eltype(img) <: Colorant
-            map(c -> Float64[red(c),green(c),blue(c)], img)
+            map(c -> Float64[red(c),green(c),blue(c),alpha(c)], img)
         else
             z  # hopefully it's in a data format that will "just work" with imshow
         end


### PR DESCRIPTION
#1131 
Hopefully the fix is this simple 😆 
Thanks @daschw for pointing out the function that needed to be modified.
```
using Plots, Images
plot(colorview(RGBA{Float64}, cat(1, rand(3, 10, 10), fill(0.1, 1, 10, 10))))
```
![image](https://user-images.githubusercontent.com/22132297/34156342-abad9ff2-e4b4-11e7-8a3b-0f170df9a1a5.png)
