### PR TITLE
RFC: Subplot labeling. Fixes #998

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1294,11 +1294,9 @@ end
 
 function _update_subplot_periphery(sp::Subplot, anns::AVec)
     # extend annotations, and ensure we always have a (x,y,PlotText) tuple
-    newanns = vcat(anns, sp[:annotations])
-    for (i,ann) in enumerate(newanns)
-        x,y,tmp = ann
-        ptxt = isa(tmp, PlotText) ? tmp : text(tmp)
-        newanns[i] = (x,y,ptxt)
+    newanns = []
+    for ann in vcat(anns, sp[:annotations])
+        append!(newanns, process_annotation(sp, ann...))
     end
     sp.attr[:annotations] = newanns
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -159,6 +159,21 @@ const _markerAliases = Dict{Symbol,Symbol}(
     :spike        => :vline,
 )
 
+const _positionAliases = Dict{Symbol,Symbol}(
+    :top_left      => :topleft,
+    :tl            => :topleft,
+    :top_center    => :topcenter,
+    :tc            => :topcenter,
+    :top_right     => :topright,
+    :tr            => :topright,
+    :bottom_left   => :bottomleft,
+    :bl            => :bottomleft,
+    :bottom_center => :bottomcenter,
+    :bc            => :bottomcenter,
+    :bottom_right  => :bottomright,
+    :br            => :bottomright,
+)
+
 const _allScales = [:identity, :ln, :log2, :log10, :asinh, :sqrt]
 const _logScales = [:ln, :log2, :log10]
 const _logScaleBases = Dict(:ln => e, :log2 => 2.0, :log10 => 10.0)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1330,7 +1330,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         end
     end
     for ann in sp[:annotations]
-        x, y, val = ann
+        x, y, val = locate_annotation(sp, ann...)
         x, y = if is3d(sp)
             # GR.wc3towc(x, y, z)
         else

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -465,7 +465,7 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
 
         # add the annotations
         for ann in sp[:annotations]
-            pgf_add_annotation!(o,ann...)
+            pgf_add_annotation!(o, locate_annotation(sp, ann...)...)
         end
 
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -385,8 +385,9 @@ function plotly_layout(plt::Plot)
         end
 
         # annotations
-        append!(d_out[:annotations], KW[plotly_annotation_dict(ann...; xref = "x$spidx", yref = "y$spidx") for ann in sp[:annotations]])
-
+        for ann in sp[:annotations]
+            append!(d_out[:annotations], KW[plotly_annotation_dict(locate_annotation(sp, ann...)...; xref = "x$spidx", yref = "y$spidx")])
+        end
         # series_annotations
         for series in series_list(sp)
             anns = series[:series_annotations]

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -969,7 +969,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 
         # add the annotations
         for ann in sp[:annotations]
-            py_add_annotations(sp, ann...)
+            py_add_annotations(sp, locate_annotation(sp, ann...)...)
         end
 
         # title

--- a/src/components.jl
+++ b/src/components.jl
@@ -557,6 +557,7 @@ function process_annotation(sp::Subplot, positions::Union{AVec{Symbol},Symbol}, 
     positions, labs = makevec(positions), makevec(labs)
     for i in 1:max(length(positions), length(labs))
         pos, lab = _cycle(positions, i), _cycle(labs, i)
+        pos = get(_positionAliases, pos, pos)
         if lab == :auto
             alphabet = "abcdefghijklmnopqrstuvwxyz"
             push!(anns, (pos, text(string("(", alphabet[sp[:subplot_index]], ")"), font)))
@@ -570,12 +571,12 @@ end
 # Give each annotation coordinates based on specified position
 function locate_annotation(sp::Subplot, pos::Symbol, lab::PlotText)
     position_multiplier = Dict{Symbol, Tuple{Float64,Float64}}(
-        :top_left => (0.1, 0.9),
-        :top_center => (0.5, 0.9),
-        :top_right => (0.9, 0.9),
-        :bottom_right => (0.9, 0.1),
-        :bottom_left => (0.1, 0.9),
-        :bottom_center => (0.5,0.1),
+        :topleft       => (0.1, 0.9),
+        :topcenter     => (0.5, 0.9),
+        :topright      => (0.9, 0.9),
+        :bottomleft    => (0.1, 0.1),
+        :bottomcenter  => (0.5, 0.1),
+        :bottomright   => (0.9, 0.1),
     )
     xmin, xmax = ignorenan_extrema(sp[:xaxis])
     ymin, ymax = ignorenan_extrema(sp[:yaxis])

--- a/src/components.jl
+++ b/src/components.jl
@@ -348,6 +348,7 @@ PlotText(str) = PlotText(string(str), font())
 Create a PlotText object wrapping a string with font info, for plot annotations
 """
 text(t::PlotText) = t
+text(t::PlotText, font::Font) = PlotText(t.str, font)
 text(str::AbstractString, f::Font) = PlotText(str, f)
 function text(str, args...)
   PlotText(string(str), font(args...))
@@ -535,6 +536,53 @@ annotations(anns::AVec) = anns
 annotations(anns) = Any[anns]
 annotations(sa::SeriesAnnotations) = sa
 
+# Expand arrays of coordinates, positions and labels into induvidual annotations
+# and make sure labels are of type PlotText
+function process_annotation(sp::Subplot, xs, ys, labs, font = font())
+    anns = []
+    labs = makevec(labs)
+    for i in 1:max(length(xs), length(ys), length(labs))
+        x, y, lab = _cycle(xs, i), _cycle(ys, i), _cycle(labs, i)
+        if lab == :auto
+            alphabet = "abcdefghijklmnopqrstuvwxyz"
+            push!(anns, (x, y, text(string("(", alphabet[sp[:subplot_index]], ")"), font)))
+        else
+            push!(anns, (x, y, isa(lab, PlotText) ? lab : text(lab, font)))
+        end
+    end
+    anns
+end
+function process_annotation(sp::Subplot, positions::Union{AVec{Symbol},Symbol}, labs, font = font())
+    anns = []
+    positions, labs = makevec(positions), makevec(labs)
+    for i in 1:max(length(positions), length(labs))
+        pos, lab = _cycle(positions, i), _cycle(labs, i)
+        if lab == :auto
+            alphabet = "abcdefghijklmnopqrstuvwxyz"
+            push!(anns, (pos, text(string("(", alphabet[sp[:subplot_index]], ")"), font)))
+        else
+            push!(anns, (pos, isa(lab, PlotText) ? lab : text(lab, font)))
+        end
+    end
+    anns
+end
+
+# Give each annotation coordinates based on specified position
+function locate_annotation(sp::Subplot, pos::Symbol, lab::PlotText)
+    position_multiplier = Dict{Symbol, Tuple{Float64,Float64}}(
+        :top_left => (0.1, 0.9),
+        :top_center => (0.5, 0.9),
+        :top_right => (0.9, 0.9),
+        :bottom_right => (0.9, 0.1),
+        :bottom_left => (0.1, 0.9),
+        :bottom_center => (0.5,0.1),
+    )
+    xmin, xmax = ignorenan_extrema(sp[:xaxis])
+    ymin, ymax = ignorenan_extrema(sp[:yaxis])
+    x, y = (xmin, ymin).+ position_multiplier[pos].* (xmax - xmin, ymax - ymin)
+    (x, y, lab)
+end
+locate_annotation(sp::Subplot, x, y, label::PlotText) = (x, y, label)
 # -----------------------------------------------------------------------
 
 "type which represents z-values for colors and sizes (and anything else that might come up)"


### PR DESCRIPTION
#998 
I opted for `ann = (:top_left, :auto)` instead of `ann = :top` as it makes the processing easier. 
```
using Plots
plot(rand(10,8), ann = (:top_left, :auto), layout = grid(2,2))
```

![autolabels](https://user-images.githubusercontent.com/22132297/34463414-2b5206e4-ee10-11e7-8943-085d92aca377.png)

```
plot(rand(10,8), 
ann = [([:top_left, :top_right], ["test", "(b)"]) (:top_center, :auto) ([5, 9], 0.5, ["middle", "stuff"])],
layout = grid(2,2))
```

![customlabels](https://user-images.githubusercontent.com/22132297/34463415-2eb2c1de-ee10-11e7-973b-5c41eb6ba395.png)

Note:
- Polar plot annotations don't behave well. The interpretation of annotation coordinates differs between backends.
- 3D plots also don't work.
