### PR TITLE
RFC: Error if linecolor is a vector

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -394,6 +394,10 @@ function _process_seriesrecipe(plt::Plot, d::KW)
         d[:fillrange] = nothing
     end
 
+    if (d[:seriestype] == :path) && typeof(d[:linecolor]) <: Vector
+        error("1D column vectors not supported for color specification in line plots. Perhaps you meant to use a 2D row vector?")
+    end
+
     # if it's natively supported, finalize processing and pass along to the backend, otherwise recurse
     if is_seriestype_supported(st)
         sp = _prepare_subplot(plt, d)


### PR DESCRIPTION
I don't think this is ready to merge yet, but I wanted to push something up and get everyone's take on it. This does fix #1325, but it will break code that currently works. 

A few questions:

- Is this the best place to throw this error? I'm still not completely sure how the whole pipeline works, but this looks like the first place that we definitely know `seriestype==:path` and `linecolor<:Vector`.
- Is that the right condition? Is there ever a situation with `seriestype==:path`, but it is okay for linecolor to be a vector?
- Perhaps a smoother transition is required, say warning when linecolor is a vector for a few releases then start erroring.

I'm also happy to change the wording of the error message.
