### PR TITLE
allow transparency in heatmaps (fix #1342)

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1082,7 +1082,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             zmin, zmax = clims
             GR.setspace(zmin, zmax, 0, 90)
             grad = isa(series[:fillcolor], ColorGradient) ? series[:fillcolor] : cgrad()
-            colors = [grad[clamp((zi-zmin) / (zmax-zmin), 0, 1)] for zi=z]
+            colors = [plot_color(grad[clamp((zi-zmin) / (zmax-zmin), 0, 1)], series[:fillalpha]) for zi=z]
             rgba = map(c -> UInt32( round(Int, alpha(c) * 255) << 24 +
                                     round(Int,  blue(c) * 255) << 16 +
                                     round(Int, green(c) * 255) << 8  +
@@ -1207,7 +1207,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         if cmap && st != :contour # special colorbar with steps is drawn for contours
             gr_set_line(1, :solid, yaxis[:foreground_color_axis])
             GR.settransparency(1)
-            gr_colorbar(sp, clims)
+            gr_colorbar(sp, clims, series[:fillalpha])
         end
 
         GR.restorestate()

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1207,7 +1207,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         if cmap && st != :contour # special colorbar with steps is drawn for contours
             gr_set_line(1, :solid, yaxis[:foreground_color_axis])
             GR.settransparency(1)
-            gr_colorbar(sp, clims, series[:fillalpha])
+            gr_colorbar(sp, clims)
         end
 
         GR.restorestate()

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -259,7 +259,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
     ax[:tickangle] = -axis[:rotation]
     lims = axis_limits(axis)
     ax[:range] = map(scalefunc(axis[:scale]), lims)
-    
+
     if !(axis[:ticks] in (nothing, :none))
         ax[:titlefont] = plotly_font(guidefont(axis))
         ax[:type] = plotly_scale(axis[:scale])
@@ -289,7 +289,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
         ax[:showgrid] = false
     end
 
-    
+
     ax
 end
 
@@ -430,7 +430,7 @@ end
 
 
 function plotly_colorscale(grad::ColorGradient, α)
-    [[grad.values[i], rgb_string(grad.colors[i])] for i in 1:length(grad.colors)]
+    [[grad.values[i], rgba_string(plot_color(grad.colors[i], α))] for i in 1:length(grad.colors)]
 end
 plotly_colorscale(c, α) = plotly_colorscale(cgrad(alpha=α), α)
 # plotly_colorscale(c, alpha = nothing) = plotly_colorscale(cgrad(), alpha)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -768,6 +768,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             label = series[:label],
             zorder = series[:series_plotindex],
             cmap = py_fillcolormap(series),
+            alpha = series[:fillalpha],
             # edgecolors = (series[:linewidth] > 0 ? py_linecolor(series) : "face"),
             extrakw...
         )


### PR DESCRIPTION
With this the transparency in heatmap plots can be set via the fillalpha attribute on GR, PyPlot and PlotlyJS.