### PR TITLE
fix grouping of series_annotations

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -548,9 +548,14 @@ end
 splittable_kw(key, val, lengthGroup) = false
 splittable_kw(key, val::AbstractArray, lengthGroup) = (key != :group) && size(val,1) == lengthGroup
 splittable_kw(key, val::Tuple, lengthGroup) = all(splittable_kw.(key, val, lengthGroup))
+splittable_kw(key, val::SeriesAnnotations, lengthGroup) = splittable_kw(key, val.strs, lengthGroup)
 
 split_kw(key, val::AbstractArray, indices) = val[indices, fill(Colon(), ndims(val)-1)...]
 split_kw(key, val::Tuple, indices) = Tuple(split_kw(key, v, indices) for v in val)
+function split_kw(key, val::SeriesAnnotations, indices)
+    split_strs = split_kw(key, val.strs, indices)
+    return SeriesAnnotations(split_strs, val.font, val.baseshape, val.scalefactor)
+end
 
 function groupedvec2mat(x_ind, x, y::AbstractArray, groupby, def_val = y[1])
     y_mat = Array{promote_type(eltype(y), typeof(def_val))}(length(keys(x_ind)), length(groupby.groupLabels))


### PR DESCRIPTION
Changes
```julia
cats = [:d, :c, :d, :c, :c, :c, :d, :a, :b, :d]
scatter(1:10, group=cats, series_annotations=String.(cats), ms = 13)
```
from
![group_annotations_old](https://user-images.githubusercontent.com/16589944/35092231-0aa0bb06-fc3f-11e7-999d-9cff14946497.png)

to
![group_annotations_new](https://user-images.githubusercontent.com/16589944/35092243-102d29f6-fc3f-11e7-8f73-2f36c1a9a166.png)

The issue was that series annotations are not treated as a `Vector` internally, but a `SeriesAnnotions` type is defined. Thus a `split_kw` Method for this type had to be defined in the `GroupBy` recipe.