### PR TITLE
Fix image axis limits and add image movement and resizing.

### DIFF
--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -1215,7 +1215,7 @@ end
 
 function gl_image(img, kw_args)
     rect = kw_args[:primitive]
-    kw_args[:primitive] = GeometryTypes.SimpleRectangle{Float32}(rect.x, rect.y, rect.h, rect.w) # seems to be flipped
+    kw_args[:primitive] = GeometryTypes.SimpleRectangle{Float32}(rect.x, rect.y, rect.w, rect.h)
     visualize(img, Style(:default), kw_args)
 end
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1199,6 +1199,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         elseif st == :image
             z = transpose_z(series, series[:z].surf, true)'
             w, h = size(z)
+            xmin, xmax = ignorenan_extrema(series[:x]); ymin, ymax = ignorenan_extrema(series[:y])
             if eltype(z) <: Colors.AbstractGray
                 grey = round.(UInt8, float(z) * 255)
                 rgba = map(c -> UInt32( 0xff000000 + Int(c)<<16 + Int(c)<<8 + Int(c) ), grey)
@@ -1208,7 +1209,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                                         round(Int, green(c) * 255) << 8  +
                                         round(Int,   red(c) * 255) ), z)
             end
-            GR.drawimage(0, w, h, 0, w, h, rgba)
+            GR.drawimage(xmin, xmax, ymax, ymin, w, h, rgba)
         end
 
         # this is all we need to add the series_annotations text

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -731,6 +731,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
 
     if st == :image
         # @show typeof(z)
+        xmin, xmax = ignorenan_extrema(series[:x]); ymin, ymax = ignorenan_extrema(series[:y])
         img = Array(transpose_z(series, z.surf))
         z = if eltype(img) <: Colors.AbstractGray
             float(img)
@@ -743,7 +744,8 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             zorder = series[:series_plotindex],
             cmap = py_colormap([:black, :white]),
             vmin = 0.0,
-            vmax = 1.0
+            vmax = 1.0,
+            extent = (xmin, xmax, ymax, ymin)
         )
         push!(handles, handle)
 

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -360,7 +360,6 @@ function _expand_subplot_extrema(sp::Subplot, d::KW, st::Symbol)
         xmin, xmax = ignorenan_extrema(d[:x]); ymin, ymax = ignorenan_extrema(d[:y])
         expand_extrema!(sp[:xaxis], (xmin, xmax))
         expand_extrema!(sp[:yaxis], (ymin, ymax))
-        sp[:yaxis].d[:flip] = true
     elseif !(st in (:pie, :histogram, :bins2d, :histogram2d))
         expand_extrema!(sp, d)
     end

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -357,9 +357,9 @@ end
 function _expand_subplot_extrema(sp::Subplot, d::KW, st::Symbol)
     # adjust extrema and discrete info
     if st == :image
-        w, h = size(d[:z])
-        expand_extrema!(sp[:xaxis], (0,w))
-        expand_extrema!(sp[:yaxis], (0,h))
+        xmin, xmax = ignorenan_extrema(d[:x]); ymin, ymax = ignorenan_extrema(d[:y])
+        expand_extrema!(sp[:xaxis], (xmin, xmax))
+        expand_extrema!(sp[:yaxis], (ymin, ymax))
         sp[:yaxis].d[:flip] = true
     elseif !(st in (:pie, :histogram, :bins2d, :histogram2d))
         expand_extrema!(sp, d)

--- a/src/series.jl
+++ b/src/series.jl
@@ -325,6 +325,7 @@ end
     else
         seriestype := :heatmap
         yflip --> true
+        cbar --> false
         fillcolor --> ColorGradient([:black, :white])
         SliceIt, 1:m, 1:n, Surface(convert(Matrix{Float64}, mat))
     end
@@ -341,6 +342,7 @@ end
     else
         seriestype := :heatmap
         yflip --> true
+        cbar --> false
         z, plotattributes[:fillcolor] = replace_image_with_heatmap(mat)
         SliceIt, 1:m, 1:n, Surface(z)
     end
@@ -463,6 +465,36 @@ end
     end
     wrap_surfaces(plotattributes)
     SliceIt, x, y, Surface(z)
+end
+
+# # images - grays
+
+@recipe function f(x::AVec, y::AVec, mat::AMat{T}) where T<:Gray
+    if is_seriestype_supported(:image)
+        seriestype := :image
+        SliceIt, x, y, Surface(mat)
+    else
+        seriestype := :heatmap
+        yflip --> true
+        cbar --> false
+        fillcolor --> ColorGradient([:black, :white])
+        SliceIt, x, y, Surface(convert(Matrix{Float64}, mat))
+    end
+end
+
+# # images - colors
+
+@recipe function f(x::AVec, y::AVec, mat::AMat{T}) where T<:Colorant
+    if is_seriestype_supported(:image)
+        seriestype := :image
+        SliceIt, x, y, Surface(mat)
+    else
+        seriestype := :heatmap
+        yflip --> true
+        cbar --> false
+        z, plotattributes[:fillcolor] = replace_image_with_heatmap(mat)
+        SliceIt, x, y, Surface(z)
+    end
 end
 
 #

--- a/src/series.jl
+++ b/src/series.jl
@@ -321,6 +321,7 @@ end
     n, m = size(mat)
     if is_seriestype_supported(:image)
         seriestype := :image
+        yflip --> true
         SliceIt, 1:m, 1:n, Surface(mat)
     else
         seriestype := :heatmap
@@ -338,6 +339,7 @@ end
 
     if is_seriestype_supported(:image)
         seriestype := :image
+        yflip --> true
         SliceIt, 1:m, 1:n, Surface(mat)
     else
         seriestype := :heatmap
@@ -472,6 +474,7 @@ end
 @recipe function f(x::AVec, y::AVec, mat::AMat{T}) where T<:Gray
     if is_seriestype_supported(:image)
         seriestype := :image
+        yflip --> true
         SliceIt, x, y, Surface(mat)
     else
         seriestype := :heatmap
@@ -487,6 +490,7 @@ end
 @recipe function f(x::AVec, y::AVec, mat::AMat{T}) where T<:Colorant
     if is_seriestype_supported(:image)
         seriestype := :image
+        yflip --> true
         SliceIt, x, y, Surface(mat)
     else
         seriestype := :heatmap


### PR DESCRIPTION
This should fix the incorrect image limits mentioned in #1354.
I've also added some functionality for moving and resizing the image by specifying x,y coordinate vectors. You can now manually unflip the yaxis and along with the move/resize functionality it should be easier to achieve the use case discussed in #1196. 

I'm not particularly happy with the two recipes I added for (x,y,img) as they are basically copies of the recipe that gets used when just the image is given, but I couldn't think of a neat way to make those work when x,y data is also given.

```
using Plots, TestImages
img = testimage("lighthouse")
plot(img)
```
![img](https://user-images.githubusercontent.com/22132297/35114065-6efa6ae8-fc7b-11e7-8d89-d23026262fad.png)

```
plot(linspace(0,10,768), linspace(0,5,512), img)
```
![imgresize](https://user-images.githubusercontent.com/22132297/35114070-729246b2-fc7b-11e7-8798-049f63f41f0d.png)

```
plot(linspace(0,10,768), linspace(0,5,512), img, xlims = (0,5))
```
![imgresizecrop](https://user-images.githubusercontent.com/22132297/35114076-765ec7e8-fc7b-11e7-83ee-9a2e9a108593.png)
```
plot(linspace(0,10,768), linspace(0,5,512), img[end:-1:1,:], yflip = false)
plot!(x -> sin(x)+2, linewidth = 10)
```
![imgoverlay](https://user-images.githubusercontent.com/22132297/35114652-61692d90-fc7d-11e7-9036-53280fa4c805.png)

Issues:
- I've experienced no issue with GR and GLVisualize.
- Resizing with PyPlot as in the second command changes the aspect ratio, this can be fixed by setting aspect ratio manually.
- Plotly is slow with plotting images.

