### PR TITLE
Add GR to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -13,3 +13,4 @@ JSON
 NaNMath
 Requires
 Contour
+GR

--- a/test/travis_commands.jl
+++ b/test/travis_commands.jl
@@ -1,8 +1,8 @@
 Pkg.add("ImageMagick")
 Pkg.build("ImageMagick")
 
-Pkg.clone("GR")
-Pkg.build("GR")
+# Pkg.clone("GR")
+# Pkg.build("GR")
 
 Pkg.clone("https://github.com/JuliaPlots/PlotReferenceImages.jl.git")
 


### PR DESCRIPTION
With this, the out-of-the-box experience for Plots.jl should always be GR.

There are lots of things that could be improved, like: a) add a min bound on GR (@jheinen do you have a suggestion what I should put in here as the min GR version) and b) get rid of the conditional load code for the GR backend.

If @jheinen helps me with a) I will update this PR before we merge it. I'll leave b) to someone else.