### PR TITLE
Fix misplaced Plotly annotations. (Fixes #1356)

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -147,7 +147,7 @@ function plotly_annotation_dict(x, y, val; xref="paper", yref="paper")
         :text => val,
         :xref => xref,
         :x => x,
-        :yref => xref,
+        :yref => yref,
         :y => y,
         :showarrow => false,
     )


### PR DESCRIPTION
#1356 
```
using Plots; plotly()
plot(rand(10,8), ann = (:bottom_left, :auto), layout = grid(2,2))
```

<img width="597" alt="plotly-anns" src="https://user-images.githubusercontent.com/22132297/36072432-8beeb5ec-0f17-11e8-8284-7547b6b8654e.png">
