### PR TITLE
do not merge (discussion): gr defaults to png on IJulia

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -171,7 +171,8 @@ const _mimeformats = Dict(
 const _best_html_output_type = KW(
     :pyplot => :png,
     :unicodeplots => :txt,
-    :glvisualize => :png
+    :glvisualize => :png,
+    :gr => :png
 )
 
 # a backup for html... passes to svg or png depending on the html_output_format arg


### PR DESCRIPTION
In response to the discussion at #1380. However, please not that this solution is not ideal: the output in the notebook scales strangely due to dpi issues (I don't understand them very well, but I've mentioned them already in the [QML](https://github.com/barche/QML.jl/issues/53) repo). With png ,the image gets huge (compare standard output). If I reduce the size manually, the font stays huge. Here's a screenshot:

![grscale](https://user-images.githubusercontent.com/6333339/36202603-5f6531c4-117c-11e8-939c-a67a4c6e4943.png)

