### PR TITLE
WIP: Add :native option to ticks attribute (Fixes #1382)

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -234,6 +234,9 @@ function get_ticks(axis::Axis)
     ticks = _transform_ticks(axis[:ticks])
     ticks in (nothing, false) && return nothing
 
+    # treat :native ticks as :auto
+    ticks = ticks == :native ? :auto : ticks
+
     dvals = axis[:discrete_values]
     cv, dv = if !isempty(dvals) && ticks == :auto
         # discrete ticks...

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -649,7 +649,7 @@ function _update_min_padding!(sp::Subplot{GRBackend})
     end
     # Add margin for x and y ticks
     xticks, yticks = axis_drawing_info(sp)[1:2]
-    if !(xticks in (nothing, false))
+    if !(xticks in (nothing, false, :none))
         flip, mirror = gr_set_xticks_font(sp)
         l = gr_get_ticks_size(xticks, 2)
         if mirror
@@ -658,7 +658,7 @@ function _update_min_padding!(sp::Subplot{GRBackend})
             bottompad += 1mm + gr_plot_size[2] * l * px
         end
     end
-    if !(yticks in (nothing, false))
+    if !(yticks in (nothing, false, :none))
         flip, mirror = gr_set_yticks_font(sp)
         l = gr_get_ticks_size(yticks, 1)
         if mirror

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -222,7 +222,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     sinf = sind.(a)
     cosf = cosd.(a)
     rtick_values, rtick_labels = get_ticks(yaxis)
-    if yaxis[:formatter] == :scientific && yaxis[:ticks] == :auto
+    if yaxis[:formatter] == :scientific && yaxis[:ticks] in (:auto, :native)
         rtick_labels = convert_sci_unicode(rtick_labels)
     end
 
@@ -884,7 +884,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 # use xor ($) to get the right y coords
                 xi, yi = GR.wctondc(cv, sp[:framestyle] == :origin ? 0 : xor(flip, mirror) ? ymax : ymin)
                 # @show cv dv ymin xi yi flip mirror (flip $ mirror)
-                if xaxis[:ticks] == :auto
+                if xaxis[:ticks] in (:auto, :native)
                     # ensure correct dispatch in gr_text for automatic log ticks
                     if xaxis[:scale] in _logScales
                         dv = string(dv, "\\ ")
@@ -903,7 +903,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 # use xor ($) to get the right y coords
                 xi, yi = GR.wctondc(sp[:framestyle] == :origin ? 0 : xor(flip, mirror) ? xmax : xmin, cv)
                 # @show cv dv xmin xi yi
-                if yaxis[:ticks] == :auto
+                if yaxis[:ticks] in (:auto, :native)
                     # ensure correct dispatch in gr_text for automatic log ticks
                     if yaxis[:scale] in _logScales
                         dv = string(dv, "\\ ")

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -295,7 +295,7 @@ function pgf_axis(sp::Subplot, letter)
     end
 
     # ticks on or off
-    if axis[:ticks] in (nothing, false) || framestyle == :none
+    if axis[:ticks] in (nothing, false, :none) || framestyle == :none
         push!(style, "$(letter)majorticks=false")
     end
 

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -314,7 +314,7 @@ function pgf_axis(sp::Subplot, letter)
         kw[Symbol(letter,:max)] = lims[2]
     end
 
-    if !(axis[:ticks] in (nothing, false, :none)) && framestyle != :none
+    if !(axis[:ticks] in (nothing, false, :none, :native)) && framestyle != :none
         ticks = get_ticks(axis)
         #pgf plot ignores ticks with angle below 90 when xmin = 90 so shift values
         tick_values = ispolar(sp) && letter == :x ? [rad2deg.(ticks[1])[3:end]..., 360, 405] : ticks[1]

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -260,7 +260,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
     lims = axis_limits(axis)
     ax[:range] = map(scalefunc(axis[:scale]), lims)
 
-    if !(axis[:ticks] in (nothing, :none))
+    if !(axis[:ticks] in (nothing, :none, false))
         ax[:titlefont] = plotly_font(guidefont(axis))
         ax[:type] = plotly_scale(axis[:scale])
         ax[:tickfont] = plotly_font(tickfont(axis))

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -273,8 +273,8 @@ function plotly_axis(axis::Axis, sp::Subplot)
         end
 
         # ticks
-        ticks = get_ticks(axis)
-        if ticks != :auto
+        if axis[:ticks] != :native
+            ticks = get_ticks(axis)
             ttype = ticksType(ticks)
             if ttype == :ticks
                 ax[:tickmode] = "array"

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -258,7 +258,7 @@ function plotly_axis(axis::Axis, sp::Subplot)
 
     ax[:tickangle] = -axis[:rotation]
     lims = axis_limits(axis)
-    ax[:range] = map(scalefunc(axis[:scale]), lims)
+    axis[:ticks] != :native ? ax[:range] = map(scalefunc(axis[:scale]), lims) : nothing
 
     if !(axis[:ticks] in (nothing, :none, false))
         ax[:titlefont] = plotly_font(guidefont(axis))
@@ -465,7 +465,7 @@ function plotly_close_shapes(x, y)
     nanvcat(xs), nanvcat(ys)
 end
 
-plotly_data(v) = collect(v)
+plotly_data(v) = v != nothing ? collect(v) : v
 plotly_data(surf::Surface) = surf.surf
 plotly_data(v::AbstractArray{R}) where {R<:Rational} = float(v)
 
@@ -493,7 +493,16 @@ function plotly_series(plt::Plot, series::Series)
     d_out[:yaxis] = "y$spidx"
     d_out[:showlegend] = should_add_to_legend(series)
 
-    x, y = plotly_data(series[:x]), plotly_data(series[:y])
+
+    x, y, z = map(letter -> (axis = sp[Symbol(letter, :axis)];
+        if axis[:ticks] == :native && !isempty(axis[:discrete_values])
+            axis[:discrete_values]
+        elseif st in (:heatmap, :contour, :surface, :wireframe)
+            plotly_surface_data(series, series[letter])
+        else
+            plotly_data(series[letter])
+        end), (:x, :y, :z))
+
     d_out[:name] = series[:label]
 
     isscatter = st in (:scatter, :scatter3d, :scattergl)
@@ -501,13 +510,6 @@ function plotly_series(plt::Plot, series::Series)
     hasline = st in (:path, :path3d)
     hasfillrange = st in (:path, :scatter, :scattergl) &&
         (isa(series[:fillrange], AbstractVector) || isa(series[:fillrange], Tuple))
-
-    # for surface types, set the data
-    if st in (:heatmap, :contour, :surface, :wireframe)
-        for letter in [:x,:y,:z]
-            d_out[letter] = plotly_surface_data(series, series[letter])
-        end
-    end
 
     d_out[:colorbar] = KW(:title => sp[:colorbar_title])
 
@@ -548,13 +550,13 @@ function plotly_series(plt::Plot, series::Series)
 
     elseif st == :heatmap
         d_out[:type] = "heatmap"
-        # d_out[:x], d_out[:y], d_out[:z] = series[:x], series[:y], transpose_z(series, series[:z].surf, false)
+        d_out[:x], d_out[:y], d_out[:z] = x, y, z
         d_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
         d_out[:showscale] = hascolorbar(sp)
 
     elseif st == :contour
         d_out[:type] = "contour"
-        # d_out[:x], d_out[:y], d_out[:z] = series[:x], series[:y], transpose_z(series, series[:z].surf, false)
+        d_out[:x], d_out[:y], d_out[:z] = x, y, z
         # d_out[:showscale] = series[:colorbar] != :none
         d_out[:ncontours] = series[:levels]
         d_out[:contours] = KW(:coloring => series[:fillrange] != nothing ? "fill" : "lines")
@@ -563,7 +565,7 @@ function plotly_series(plt::Plot, series::Series)
 
     elseif st in (:surface, :wireframe)
         d_out[:type] = "surface"
-        # d_out[:x], d_out[:y], d_out[:z] = series[:x], series[:y], transpose_z(series, series[:z].surf, false)
+        d_out[:x], d_out[:y], d_out[:z] = x, y, z
         if st == :wireframe
             d_out[:hidesurface] = true
             wirelines = KW(
@@ -595,8 +597,7 @@ function plotly_series(plt::Plot, series::Series)
         else
             hasline ? "lines" : "none"
         end
-        d_out[:x], d_out[:y] = x, y
-        d_out[:z] = plotly_data(series[:z])
+        d_out[:x], d_out[:y], d_out[:z] = x, y, z
 
     else
         warn("Plotly: seriestype $st isn't supported.")

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1060,7 +1060,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 pyaxis[Symbol(:tick_, pos)]()        # the tick labels
             end
             py_set_scale(ax, axis)
-            py_set_lims(ax, axis)
+            axis[:ticks] != :native ? py_set_lims(ax, axis) : nothing
             if ispolar(sp) && letter == :y
                 ax[:set_rlabel_position](90)
             end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1069,7 +1069,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             if sp[:framestyle] == :origin && length(ticks) > 1
                 ticks[2][ticks[1] .== 0] = ""
             end
-            py_set_ticks(ax, ticks, letter)
+            axis[:ticks] != :native ? py_set_ticks(ax, ticks, letter) : nothing
             pyaxis[:set_tick_params](direction = axis[:tick_direction] == :out ? "out" : "in")
             ax[Symbol("set_", letter, "label")](axis[:guide])
             if get(axis.d, :flip, false)


### PR DESCRIPTION
#1382 

Proof of concept at this stage.

```
using Plots; plotly()
plot(rand(10), ticks = :native)
```
![native_ticks](https://user-images.githubusercontent.com/22132297/36276588-5d4d952e-1286-11e8-83a9-f818e5e69a77.gif)

```
using Plots; plotly()
xs = [ "x$i" for i in 1:10 ]
ys = [ "y$i" for i in 1:4 ]
z = rand(4, 10)
plot(heatmap(xs, ys, z), heatmap(xs, ys, z, ticks=:native))
```
![discrete-native-ticks](https://user-images.githubusercontent.com/22132297/36486863-7be62146-1717-11e8-8865-b0ce2a402b55.gif)

 