### PR TITLE
add Dates.Time recipe (fix #1391)

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1000,13 +1000,15 @@ abline!(args...; kw...) = abline!(current(), args...; kw...)
 
 
 # -------------------------------------------------
-# Dates
+# Dates & Times
 
 dateformatter(dt) = string(Date(Dates.UTD(dt)))
 datetimeformatter(dt) = string(DateTime(Dates.UTM(dt)))
+timeformatter(t) = string(Dates.Time(Dates.Nanosecond(t)))
 
 @recipe f(::Type{Date}, dt::Date) = (dt -> Dates.value(dt), dateformatter)
 @recipe f(::Type{DateTime}, dt::DateTime) = (dt -> Dates.value(dt), datetimeformatter)
+@recipe f(::Type{Dates.Time}, t::Dates.Time) = (t -> Dates.value(t), timeformatter)
 
 # -------------------------------------------------
 # Complex Numbers


### PR DESCRIPTION
This allows to plot arrays of `Dates.Time`:
```julia
plot(Dates.Time.(1:10), rand(10))
```
![time](https://user-images.githubusercontent.com/16589944/36346276-b80f69ea-143b-11e8-98bb-ec289aacfd4d.png)

It would be nice to choose better ticks as well similar to https://github.com/JuliaPlots/Plots.jl/pull/720