### PR TITLE
Prevent addition of curly braces around style string. (Fixes #1396)

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -450,7 +450,7 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
         end
         @label colorbar_end
 
-        o = axisf(; style = style, kw...)
+        o = axisf(; style = join(style, ","), kw...)
 
         # add the series object to the PGFPlots.Axis
         for series in series_list(sp)


### PR DESCRIPTION
#1396
```
using Plots
pgfplots()  
using LaTeXStrings  
plt = plot()  
xticks!([0.1,0.2],[L"\alpha", L"\beta"])   
``` 
This seems to fix the annoying '\endcsname' issue that PGFPlots had.