### PR TITLE
reduce pyplot colorbar size for z values with very small or big abs vals

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1295,7 +1295,8 @@ function _update_plot_object(plt::Plot{PyPlotBackend})
         if haskey(sp.attr, :cbar_ax)
             cbw = sp.attr[:cbar_width]
             # this is the bounding box of just the colors of the colorbar (not labels)
-            has_toplabel = sp[:zaxis][:extrema].emax >= 1e7
+            ex = sp[:zaxis][:extrema]
+            has_toplabel = !(1e-7 < max(abs(ex.emax), abs(ex.emin)) < 1e7)
             cb_bbox = BoundingBox(right(sp.bbox)-cbw+1mm, top(sp.bbox) +  (has_toplabel ? 4mm : 2mm), _cbar_width-1mm, height(sp.bbox) - (has_toplabel ? 6mm : 4mm))
             pcts = bbox_to_pcts(cb_bbox, figw, figh)
             sp.attr[:cbar_ax][:set_position](pcts)


### PR DESCRIPTION
#926 fixed the colorbar size for very big z values, e.g.
```julia
heatmap(1e8 * rand(10, 10))
```
However, it did not consider very small or negative values like:
```julia
heatmap(-1e8 * rand(10, 10))
heatmap(1e-7 * rand(10, 10))
heatmap(-1e-7 * rand(10, 10))
```
This fixes these cases as well.