### PR TITLE
Make contourf work with uniform data

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -568,7 +568,7 @@ function get_clims(sp::Subplot)
         isfinite(clims[1]) && (zmin = clims[1])
         isfinite(clims[2]) && (zmax = clims[2])
     end
-    return zmin < zmax ? (zmin, zmax) : (0.0, 0.0)
+    return zmin < zmax ? (zmin, zmax) : (-0.1, 0.1)
 end
 
 _update_clims(zmin, zmax, emin, emax) = min(zmin, emin), max(zmax, emax)


### PR DESCRIPTION
cf. #1091
This makes `contourf` work with uniform data work for GR and PyPlot, and `contour` on GR. Unfortunately, `contour` with uniform data still fails for PyPlot.