### PR TITLE
replace hline and vline marker shapes with _ and | on pyplot (fix #1188)

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -214,6 +214,8 @@ function py_marker(marker::Symbol)
     marker == :hexagon && return "h"
     marker == :octagon && return "8"
     marker == :pixel && return ","
+    marker == :hline && return "_"
+    marker == :vline && return "|"
     haskey(_shapes, marker) && return py_marker(_shapes[marker])
 
     warn("Unknown marker $marker")
@@ -571,7 +573,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                                           :scatter3d, :steppre, :steppost,
                                           :bar)
         if series[:marker_z] == nothing
-            extrakw[:c] = py_color_fix(py_markercolor(series), x)
+            extrakw[:c] = series[:markershape] in (:+, :x, :hline, :vline) ? py_markerstrokecolor(series) : py_color_fix(py_markercolor(series), x)
         else
             extrakw[:c] = convert(Vector{Float64}, series[:marker_z])
             extrakw[:cmap] = py_markercolormap(series)


### PR DESCRIPTION
cf. #1188
Apparently matplotlib 2.1.2 has problems with Shapes consisting of less than 4 points as markers. Thus I replaced the shapes passed for `:hline` and `:vline` markers with matplotlib's native `"_"` and `"|"` markers.
Furthermore, markers consisting only of strokes (`:+`, `:x`, `:hline`, `vline`) where using the series color instead of markerstrokecolor. That's also fixed here.
This works for me now with both, Conda.jl's and archlinux' native python.