### PR TITLE
default bar width for plots with only one bar (fix #1413)

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -317,7 +317,11 @@ end
     # compute half-width of bars
     bw = plotattributes[:bar_width]
     hw = if bw == nothing
-        0.5*_bar_width*ignorenan_minimum(filter(x->x>0, diff(procx)))
+        if nx > 1
+            0.5*_bar_width*ignorenan_minimum(filter(x->x>0, diff(procx)))
+        else
+            0.5 * _bar_width
+        end
     else
         Float64[0.5_cycle(bw,i) for i=1:length(procx)]
     end


### PR DESCRIPTION
This allows to do e.g.:
```julia
bar([1], [1])

bar([1 2 3], [1 2 3])

bar(
    ["a" "b" "c"],
    [1 2 3],
    labels = ["a" "b" "c"]
)
```