### PR TITLE
ENH: provide "application/vnd.plotly.v1+json" for Plotly and PlotlyJS backends

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -14,6 +14,7 @@ using Base.Meta
 @reexport using PlotThemes
 import Showoff
 import StatsBase
+import JSON
 
 using Requires
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -86,8 +86,6 @@ const _plotly_js_path_remote = "https://cdn.plot.ly/plotly-latest.min.js"
 
 function _initialize_backend(::PlotlyBackend; kw...)
   @eval begin
-    import JSON
-
     _js_code = open(readstring, _plotly_js_path, "r")
 
     # borrowed from https://github.com/plotly/plotly.py/blob/2594076e29584ede2d09f2aa40a8a195b3f3fc66/plotly/offline/offline.py#L64-L71 c/o @spencerlyon2
@@ -740,14 +738,16 @@ function plotly_hover!(d_out::KW, hover)
 end
 
 # get a list of dictionaries, each representing the series params
-function plotly_series_json(plt::Plot)
+function plotly_series(plt::Plot)
     slist = []
     for series in plt.series_list
         append!(slist, plotly_series(plt, series))
     end
-    JSON.json(slist)
-    # JSON.json(map(series -> plotly_series(plt, series), plt.series_list))
+    slist
 end
+
+# get json string for a list of dictionaries, each representing the series params
+plotly_series_json(plt::Plot) = JSON.json(plotly_series(plt))
 
 # ----------------------------------------------------------------
 


### PR DESCRIPTION
For use in jupyterlab and nteract

closes #1418

closes #1386