### PR TITLE
Contour improvements

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -43,6 +43,7 @@ const _arg_desc = KW(
 :normalize         	=> "Bool or Symbol. Histogram normalization mode. Possible values are: false/:none (no normalization, default), true/:pdf (normalize to a discrete Probability Density Function, where the total area of the bins is 1), :probability (bin heights sum to 1) and :density (the area of each bin, rather than the height, is equal to the counts - useful for uneven bin sizes).",
 :weights           	=> "AbstractVector. Used in histogram types for weighted counts.",
 :contours          	=> "Bool. Add contours to the side-grids of 3D plots?  Used in surface/wireframe.",
+:contour_labels     => "Bool. Show labels at the contour lines?",
 :match_dimensions  	=> "Bool. For heatmap types... should the first dimension of a matrix (rows) correspond to the first dimension of the plot (x-axis)?  The default is false, which matches the behavior of Matplotlib, Plotly, and others.  Note: when passing a function for z, the function should still map `(x,y) -> z`.",
 :subplot           	=> "Integer (subplot index) or Subplot object.  The subplot that this series belongs to.",
 :series_annotations => "AbstractVector of String or PlotText.  These are annotations which are mapped to data points/positions.",

--- a/src/args.jl
+++ b/src/args.jl
@@ -272,6 +272,7 @@ const _series_defaults = KW(
     :normalize         => false,     # do we want a normalized histogram?
     :weights           => nothing,   # optional weights for histograms (1D and 2D)
     :contours          => false,     # add contours to 3d surface and wireframe plots
+    :contour_labels    => false,
     :match_dimensions  => false,     # do rows match x (true) or y (false) for heatmap/image/spy? see issue 196
                                      # this ONLY effects whether or not the z-matrix is transposed for a heatmap display!
     :subplot           => :auto,     # which subplot(s) does this series belong to?
@@ -574,6 +575,7 @@ add_aliases(:gridstyle, :grid_style, :gridlinestyle, :grid_linestyle, :grid_ls, 
 add_aliases(:framestyle, :frame_style, :frame, :axesstyle, :axes_style, :boxstyle, :box_style, :box, :borderstyle, :border_style, :border)
 add_aliases(:tick_direction, :tickdirection, :tick_dir, :tickdir, :tick_orientation, :tickorientation, :tick_or, :tickor)
 add_aliases(:camera, :cam, :viewangle, :view_angle)
+add_aliases(:contour_labels, :contourlabels, :clabels, :clabs)
 
 # add all pluralized forms to the _keyAliases dict
 for arg in keys(_series_defaults)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1066,7 +1066,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             else
                 GR.setlinetype(gr_linetype[series[:linestyle]])
                 GR.setlinewidth(max(0, series[:linewidth] / (sum(gr_plot_size) * 0.001)))
-                if plot_color(series[:linecolor]) == plot_color(:black)
+                if plot_color(series[:linecolor]) == [plot_color(:black)]
                     GR.contour(x, y, h, z, 0 + (series[:contour_labels] == true ? 1 : 0))
                 else
                     GR.contour(x, y, h, z, 1000 + (series[:contour_labels] == true ? 1 : 0))

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1076,7 +1076,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             if cmap
                 gr_set_line(1, :solid, yaxis[:foreground_color_axis])
                 gr_set_viewport_cmap(sp)
-                l = (length(h) > 1) ? round.(Int32, 1000 + (h - ignorenan_minimum(h)) / (ignorenan_maximum(h) - ignorenan_minimum(h)) * 255) : 1000
+                l = (length(h) > 1) ? round.(Int32, 1000 + (h - ignorenan_minimum(h)) / (ignorenan_maximum(h) - ignorenan_minimum(h)) * 255) : Int32[1000, 1255]
                 GR.setwindow(xmin, xmax, zmin, zmax)
                 GR.cellarray(xmin, xmax, zmax, zmin, 1, length(l), l)
                 ztick = 0.5 * GR.tick(zmin, zmax)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -45,6 +45,7 @@ const _gr_attr = merge_with_base_supported([
     :framestyle,
     :tick_direction,
     :camera,
+    :contour_labels,
 ])
 const _gr_seriestype = [
     :path, :scatter,

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -45,6 +45,7 @@ const _plotly_attr = merge_with_base_supported([
     :framestyle,
     :tick_direction,
     :camera,
+    :contour_labels,
   ])
 
 const _plotly_seriestype = [
@@ -434,6 +435,14 @@ function plotly_colorscale(grad::ColorGradient, α)
     [[grad.values[i], rgba_string(plot_color(grad.colors[i], α))] for i in 1:length(grad.colors)]
 end
 plotly_colorscale(c, α) = plotly_colorscale(cgrad(alpha=α), α)
+function plotly_colorscale(c::AbstractVector{<:RGBA}, α)
+    if length(c) == 1
+        return [[0.0, rgba_string(plot_color(c[1], α))]]
+    else
+        vals = linspace(0.0, 1.0, length(c))
+        return [[vals[i], rgba_string(plot_color(c[i], α))] for i in eachindex(c)]
+    end
+end
 # plotly_colorscale(c, alpha = nothing) = plotly_colorscale(cgrad(), alpha)
 
 
@@ -559,7 +568,7 @@ function plotly_series(plt::Plot, series::Series)
         d_out[:x], d_out[:y], d_out[:z] = x, y, z
         # d_out[:showscale] = series[:colorbar] != :none
         d_out[:ncontours] = series[:levels]
-        d_out[:contours] = KW(:coloring => series[:fillrange] != nothing ? "fill" : "lines")
+        d_out[:contours] = KW(:coloring => series[:fillrange] != nothing ? "fill" : "lines", :showlabels => series[:contour_labels] == true)
         d_out[:colorscale] = plotly_colorscale(series[:linecolor], series[:linealpha])
         d_out[:showscale] = hascolorbar(sp)
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -437,7 +437,7 @@ end
 plotly_colorscale(c, α) = plotly_colorscale(cgrad(alpha=α), α)
 function plotly_colorscale(c::AbstractVector{<:RGBA}, α)
     if length(c) == 1
-        return [[0.0, rgba_string(plot_color(c[1], α))]]
+        return [[0.0, rgba_string(plot_color(c[1], α))], [1.0, rgba_string(plot_color(c[1], α))]]
     else
         vals = linspace(0.0, 1.0, length(c))
         return [[vals[i], rgba_string(plot_color(c[i], α))] for i in eachindex(c)]

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -646,13 +646,18 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             extrakw[:extend3d] = true
         end
 
+        if typeof(series[:linecolor]) <: AbstractArray
+            extrakw[:colors] = py_color.(series[:linecolor])
+        else
+            extrakw[:cmap] = py_linecolormap(series)
+        end
+
         # contour lines
         handle = ax[:contour](x, y, z, levelargs...;
             label = series[:label],
             zorder = series[:series_plotindex],
             linewidths = py_dpi_scale(plt, series[:linewidth]),
             linestyles = py_linestyle(st, series[:linestyle]),
-            cmap = py_linecolormap(series),
             extrakw...
         )
         if series[:contour_labels] == true
@@ -665,7 +670,6 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             handle = ax[:contourf](x, y, z, levelargs...;
                 label = series[:label],
                 zorder = series[:series_plotindex] + 0.5,
-                cmap = py_fillcolormap(series),
                 extrakw...
             )
             push!(handles, handle)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -42,6 +42,7 @@ const _pyplot_attr = merge_with_base_supported([
     :framestyle,
     :tick_direction,
     :camera,
+    :contour_labels,
   ])
 const _pyplot_seriestype = [
         :path, :steppre, :steppost, :shape,
@@ -654,6 +655,9 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             cmap = py_linecolormap(series),
             extrakw...
         )
+        if series[:contour_labels] == true
+            PyPlot.clabel(handle, handle[:levels])
+        end
         push!(handles, handle)
 
         # contour fills

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -575,7 +575,10 @@ _update_clims(zmin, zmax, emin, emax) = min(zmin, emin), max(zmax, emax)
 
 function hascolorbar(series::Series)
     st = series[:seriestype]
-    hascbar = st in (:heatmap, :contour)
+    hascbar = st == :heatmap
+    if st == :contour
+        hascbar = (isscalar(series[:levels]) ? (series[:levels] > 1) : (length(series[:levels]) > 1)) && (length(unique(Array(series[:z]))) > 1)
+    end
     if series[:marker_z] != nothing || series[:line_z] != nothing || series[:fill_z] != nothing
         hascbar = true
     end


### PR DESCRIPTION
This implements the `contour_labels` keyword for GR, PyPlot, and Plotly(JS):
```julia
contour(data, contour_labels = true, levels = 0.2:0.2:1)
```
![contour_labels](https://user-images.githubusercontent.com/16589944/36816375-cea9b322-1cdd-11e8-83aa-63ddeafb5960.png)

Furthermore it is now possible to pass `levels = 1` or `levels = [0.5]`, which errored on GR and PyPlot before. I removed the colorbar in these single level cases. This fixes #431.

For PyPlot and Plotly it is now possible to pass a Vector of colors (also of length 1) for the contour line colors (although Plotly support is not perfect):
```julia
contour(data, levels = 3, color = [:red, :green, :blue])
```
![contour_colors](https://user-images.githubusercontent.com/16589944/36816735-03a8620c-1cdf-11e8-8ce4-f2884a2cb64c.png)
This addresses #1111 

GR can only handle `color = [:black]`

There's still a lot of room for improvement but it's better than the status quo.


