### PR TITLE
Partially address #1409: group with named tuples

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1024,7 +1024,7 @@ end
 # allow passing NamedTuples for a named legend entry
 @require NamedTuples begin
     legendEntryFromTuple(ns::NamedTuples.NamedTuple) =
-        join(["$k = $v" for (k, v) in zip(keys(ns), values(ns))], ' ')
+        join(["$k = $v" for (k, v) in zip(keys(ns), values(ns))], ", ")
 
     function extractGroupArgs(vs::NamedTuples.NamedTuple, args...)
         isempty(vs) && return GroupBy([""], [1:size(args[1],1)])

--- a/src/args.jl
+++ b/src/args.jl
@@ -1012,13 +1012,26 @@ function extractGroupArgs(v::AVec, args...; legendEntry = string)
     GroupBy(map(legendEntry, groupLabels), groupIds)
 end
 
-legendEntryFromTuple(ns::Tuple) = string(("$n " for n in ns)...)
+legendEntryFromTuple(ns::Tuple) = join(ns, ' ')
 
 # this is when given a tuple of vectors of values to group by
 function extractGroupArgs(vs::Tuple, args...)
-    (vs == ()) && return GroupBy([""], [1:size(args[1],1)])
-    v = collect(zip(vs...))
+    isempty(vs) && return GroupBy([""], [1:size(args[1],1)])
+    v = map(tuple, vs...)
     extractGroupArgs(v, args...; legendEntry = legendEntryFromTuple)
+end
+
+# allow passing NamedTuples for a named legend entry
+@require NamedTuples begin
+    legendEntryFromTuple(ns::NamedTuples.NamedTuple) =
+        join(["$k = $v" for (k, v) in zip(keys(ns), values(ns))], ' ')
+
+    function extractGroupArgs(vs::NamedTuples.NamedTuple, args...)
+        isempty(vs) && return GroupBy([""], [1:size(args[1],1)])
+        NT = eval(:(NamedTuples.@NT($(keys(vs)...)))){map(eltype, vs)...}
+        v = map(NT, vs...)
+        extractGroupArgs(v, args...; legendEntry = legendEntryFromTuple)
+    end
 end
 
 # expecting a mapping of "group label" to "group indices"


### PR DESCRIPTION
This allows grouping with NamedTuples to give a name to the entries in the legend. For example:

```julia
julia> using Plots

julia> using NamedTuples

julia> plot(rand(10), group = @NT(a = rand(Bool,10), b = rand(Bool, 10)))
```
![test](https://user-images.githubusercontent.com/6333339/37295723-cc46d768-2610-11e8-8b84-ab97d5b259bf.png)

In #1409 this would allow:

`@df df plot(:R, :F, group = @NT(L = :L, T = :T), legend=:topleft, marker=:circle, frame=:box, grid=false)`