### PR TITLE
add option to supress saved message

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -68,7 +68,8 @@ mp4(anim::Animation, fn = mp4fn(); kw...) = buildanimation(anim.dir, fn, false; 
 function buildanimation(animdir::AbstractString, fn::AbstractString,
                         is_animated_gif::Bool=true;
                         fps::Integer = 20, loop::Integer = 0,
-                        variable_palette::Bool=false)
+                        variable_palette::Bool=false,
+                        show_msg::Bool=true)
     fn = abspath(fn)
 
     if is_animated_gif
@@ -86,7 +87,7 @@ function buildanimation(animdir::AbstractString, fn::AbstractString,
         run(`ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -pix_fmt yuv420p -y $fn`)
     end
 
-    info("Saved animation to ", fn)
+    show_msg && info("Saved animation to ", fn)
     AnimatedGif(fn)
 end
 


### PR DESCRIPTION
Added option `show_msg::Bool` to `buildanimation` to show/suppress the "Saved animation to..." message.