### PR TITLE
fix fill magic argument

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -751,6 +751,10 @@ function processFillArg(d::KW, arg)
     elseif allAlphas(arg)
         d[:fillalpha] = arg
 
+    # fillrange provided as vector or number
+    elseif typeof(arg) <: Union{AbstractArray{<:Real}, Real}
+        d[:fillrange] = arg
+
     elseif !handleColors!(d, arg, :fillcolor)
 
         d[:fillrange] = arg

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -536,7 +536,7 @@ function plotly_series(plt::Plot, series::Series)
         if series[:fillrange] == true || series[:fillrange] == 0 || isa(series[:fillrange], Tuple)
             d_out[:fill] = "tozeroy"
             d_out[:fillcolor] = rgba_string(series[:fillcolor])
-        elseif isa(series[:fillrange], AbstractVector)
+        elseif typeof(series[:fillrange]) <: Union{AbstractVector{<:Real}, Real}
             d_out[:fill] = "tonexty"
             d_out[:fillcolor] = rgba_string(series[:fillcolor])
         elseif !(series[:fillrange] in (false, nothing))
@@ -665,6 +665,14 @@ function plotly_series(plt::Plot, series::Series)
         # series, one for series being filled to) instead of one
         d_out_fillrange = deepcopy(d_out)
         d_out_fillrange[:showlegend] = false
+        # if fillrange is provided as real or tuple of real, expand to array
+        if typeof(series[:fillrange]) <: Real
+            series[:fillrange] = fill(series[:fillrange], length(series[:x]))
+        elseif typeof(series[:fillrange]) <: Tuple
+            f1 = typeof(series[:fillrange][1]) <: Real ? fill(series[:fillrange][1], length(series[:x])) : series[:fillrange][1]
+            f2 = typeof(series[:fillrange][2]) <: Real ? fill(series[:fillrange][2], length(series[:x])) : series[:fillrange][2]
+            series[:fillrange] = (f1, f2)
+        end
         if isa(series[:fillrange], AbstractVector)
             d_out_fillrange[:y] = series[:fillrange]
             delete!(d_out_fillrange, :fill)


### PR DESCRIPTION
`fill = ([-1, -1], 0.4, :red)` now works correctly. (Originally `[-1, -1]` was interpreted as vector of colors.)

Furthermore, it's now possible to on Plotly(JS) to do
```julia
plot(rand(10), fillrange = -1)
plot(rand(10), fillrange = (-1, 1))
plot(rand(10), fillrange = (-1, 1 + rand(10))
```
(Originally only `AbstractArray`s, `0`, or `Tuple`s of `AbstractArray`s were supported.)