### PR TITLE
RFC: use bar recipe in plotly

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -49,7 +49,7 @@ const _plotly_attr = merge_with_base_supported([
   ])
 
 const _plotly_seriestype = [
-    :path, :scatter, :bar, :pie, :heatmap,
+    :path, :scatter, :pie, :heatmap,
     :contour, :surface, :wireframe, :path3d, :scatter3d, :shape, :scattergl,
 ]
 const _plotly_style = [:auto, :solid, :dash, :dot, :dashdot]
@@ -543,17 +543,6 @@ function plotly_series(plt::Plot, series::Series)
             warn("fillrange ignored... plotly only supports filling to zero and to a vector of values. fillrange: $(series[:fillrange])")
         end
         d_out[:x], d_out[:y] = x, y
-
-    elseif st == :bar
-        d_out[:type] = "bar"
-        d_out[:x], d_out[:y], d_out[:orientation] = if isvertical(series)
-            x, y, "v"
-        else
-            y, x, "h"
-        end
-        d_out[:width] = series[:bar_width]
-        d_out[:marker] = KW(:color => _cycle(rgba_string.(series[:fillcolor]),eachindex(series[:x])),
-                            :line => KW(:width => series[:linewidth]))
 
     elseif st == :heatmap
         d_out[:type] = "heatmap"


### PR DESCRIPTION
As reported in https://github.com/JuliaPlots/StatPlots.jl/issues/133 `groupedbar` does not work properly with Plotly(JS). The reason for this is that fillrange is not working with Plotly's native bar implementation. Using the bar recipe of Plots instead would fix this issue and allow stacked `groupedbar` plots:

![plotly_bar_recipe](https://user-images.githubusercontent.com/16589944/37511429-1552eaf0-28ff-11e8-9a8f-5ab8aaec182f.png)

However, as you can see, this would be a regression in terms of the values shown when hovering (`x` values at the border of the bar) and maybe also legend entry symbols. Here's the current behaviour for comparison:

![plotly_bar_native](https://user-images.githubusercontent.com/16589944/37511524-64344222-28ff-11e8-8899-14480a6e1e09.png)

Personally, I think having `fillrange` and `groupedbar` work is preferable, but maybe the majority has a different opinion (I guess the plotly(js) backends are often chosen because of the interactivity and all this hovering stuff). Any thoughts?