### PR TITLE
allow ticks = :all and ticks = n::Int for categorical axes

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -238,10 +238,18 @@ function get_ticks(axis::Axis)
     ticks = ticks == :native ? :auto : ticks
 
     dvals = axis[:discrete_values]
-    cv, dv = if !isempty(dvals) && ticks == :auto
+    cv, dv = if !isempty(dvals)
         # discrete ticks...
-        axis[:continuous_values], dvals
-    elseif ticks == :auto
+        n = length(dvals)
+        rng = if ticks == :auto
+            Int[round(Int,i) for i in linspace(1, n, 15)]
+        elseif ticks == :all
+            1:n
+        elseif typeof(ticks) <: Int
+            Int[round(Int,i) for i in linspace(1, n, ticks)]
+        end
+        axis[:continuous_values][rng], dvals[rng]
+    elseif typeof(ticks) <: Symbol
         if ispolar(axis.sps[1]) && axis[:letter] == :x
             #force theta axis to be full circle
             (collect(0:pi/4:7pi/4), string.(0:45:315))
@@ -260,13 +268,7 @@ function get_ticks(axis::Axis)
     end
     # @show ticks dvals cv dv
 
-    # TODO: better/smarter cutoff values for sampling ticks
-    if length(cv) > 30 && ticks == :auto
-        rng = Int[round(Int,i) for i in linspace(1, length(cv), 15)]
-        cv[rng], dv[rng]
-    else
-        cv, dv
-    end
+    return cv, dv
 end
 
 _transform_ticks(ticks) = ticks


### PR DESCRIPTION
```julia
using Plots

x = ["x$i" for i in 1:50]
y = rand(50)

plot(
    plot(x, y), # xticks = :auto
    plot(x, y, xticks = :all),
    plot(x, y, xticks = 9),
    layout = (3, 1), legend = false
)
```
![categorical_ticks](https://user-images.githubusercontent.com/16589944/37516399-40e9a302-290e-11e8-9270-d61c3e12aef6.png)
