### PR TITLE
Fixes for :native axes. (Fixes #1435 and partly #1425)

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -264,7 +264,10 @@ function plotly_axis(plt::Plot, axis::Axis, sp::Subplot)
 
     ax[:tickangle] = -axis[:rotation]
     lims = axis_limits(axis)
-    axis[:ticks] != :native ? ax[:range] = map(scalefunc(axis[:scale]), lims) : nothing
+
+    if axis[:ticks] != :native || axis[:lims] != :auto 
+        ax[:range] = map(scalefunc(axis[:scale]), lims)
+    end
 
     if !(axis[:ticks] in (nothing, :none, false))
         ax[:titlefont] = plotly_font(guidefont(axis))

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1077,7 +1077,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 pyaxis[Symbol(:tick_, pos)]()        # the tick labels
             end
             py_set_scale(ax, axis)
-            axis[:ticks] != :native ? py_set_lims(ax, axis) : nothing
+            axis[:ticks] != :native || axis[:lims] != :auto ? py_set_lims(ax, axis) : nothing
             if ispolar(sp) && letter == :y
                 ax[:set_rlabel_position](90)
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -207,7 +207,7 @@ function iter_segments(series::Series)
 end
 
 # helpers to figure out if there are NaN values in a list of array types
-anynan(i::Int, args::Tuple) = any(a -> !isfinite(_cycle(a,i)), args)
+anynan(i::Int, args::Tuple) = any(a -> try isnan(_cycle(a,i)) catch MethodError false end, args)
 anynan(istart::Int, iend::Int, args::Tuple) = any(i -> anynan(i, args), istart:iend)
 allnan(istart::Int, iend::Int, args::Tuple) = all(i -> anynan(i, args), istart:iend)
 
@@ -1192,4 +1192,8 @@ function shape_data(series)
         end
     end
     return x, y
+end
+
+function construct_categorical_data(x::AbstractArray, axis::Axis)
+    map(xi -> axis[:discrete_values][searchsortedfirst(axis[:continuous_values], xi)], x)
 end


### PR DESCRIPTION
#1435 #1425 
Fixes for categorical and DateTime data. Limits can now be manually set for ticks = :native. 
```
plotlyjs()
scatter([1,2,3,1.5,4], ["a", "B", "a", "b", "b"], ticks=:native)
````
<img width="591" alt="categorical" src="https://user-images.githubusercontent.com/22132297/37559816-56993c5a-2a24-11e8-9169-e737650f41c0.png">

```
plotlyjs()
plot([DateTime(2017, 1, 1), DateTime(2017, 2, 1)], [1, 3]; ticks = :native)
```
<img width="588" alt="datetime" src="https://user-images.githubusercontent.com/22132297/37559818-5c05e49a-2a24-11e8-9a2e-9a0f9fe30fcd.png">

For Plotly native `DateTime` ticks you need to specify the date so for `Time` data the current date is used.

DateTime Surfaces don't seem to work for Plotly so I didn't add a method for converting those. Not sure maybe the method should be there so Plots doesn't error, but then Plotly could output something weird?