### PR TITLE
Partial attempt to fix labeling to atomatically scientific notation

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -212,7 +212,7 @@ function optimal_ticks_and_labels(axis::Axis, ticks = nothing)
         formatter = axis[:formatter]
         if formatter == :auto
             # the default behavior is to make strings of the scaled values and then apply the labelfunc
-            map(labelfunc(scale, backend()), Showoff.showoff(scaled_ticks, :plain))
+            map(labelfunc(scale, backend()), Showoff.showoff(scaled_ticks, :auto))
         elseif formatter == :scientific
             Showoff.showoff(unscaled_ticks, :scientific)
         else

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -213,11 +213,19 @@ function optimal_ticks_and_labels(axis::Axis, ticks = nothing)
         if formatter == :auto
             # the default behavior is to make strings of the scaled values and then apply the labelfunc
             map(labelfunc(scale, backend()), Showoff.showoff(scaled_ticks, :auto))
+        elseif formatter == :plain
+            # Leave the numbers in plain format
+            map(labelfunc(scale, backend()), Showoff.showoff(scaled_ticks, :plain))
         elseif formatter == :scientific
             Showoff.showoff(unscaled_ticks, :scientific)
         else
             # there was an override for the formatter... use that on the unscaled ticks
             map(formatter, unscaled_ticks)
+            # if the formatter left us with numbers, still apply the default formatter
+            # However it leave us with the problem of unicode number decoding by the backend
+            # if eltype(unscaled_ticks) <: Number
+            #     Showoff.showoff(unscaled_ticks, :auto)
+            # end
         end
     else
         # no finite ticks to show...

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -223,7 +223,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     sinf = sind.(a)
     cosf = cosd.(a)
     rtick_values, rtick_labels = get_ticks(yaxis)
-    if (yaxis[:formatter] == :scientific || contains(rtick_labels,"×10") )&& yaxis[:ticks] in (:auto, :native)
+    if (yaxis[:formatter] == :scientific || any(contains.(rtick_labels,"×10"))) && yaxis[:ticks] in (:auto, :native)
         rtick_labels = convert_sci_unicode(rtick_labels)
     end
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -223,8 +223,8 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     sinf = sind.(a)
     cosf = cosd.(a)
     rtick_values, rtick_labels = get_ticks(yaxis)
-    if (yaxis[:formatter] == :scientific || any(contains.(rtick_labels,"×10"))) && yaxis[:ticks] in (:auto, :native)
-        rtick_labels = convert_sci_unicode(rtick_labels)
+    if yaxis[:formatter] in (:scientific, :auto) && yaxis[:ticks] in (:auto, :native)
+        rtick_labels = convert_sci_unicode.(rtick_labels)
     end
 
     #draw angular grid
@@ -889,7 +889,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     # ensure correct dispatch in gr_text for automatic log ticks
                     if xaxis[:scale] in _logScales
                         dv = string(dv, "\\ ")
-                    elseif xaxis[:formatter] == :scientific || contains(dv,"×10")
+                    elseif xaxis[:formatter] in (:scientific, :auto)
                         dv = convert_sci_unicode(dv)
                     end
                 end
@@ -908,7 +908,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     # ensure correct dispatch in gr_text for automatic log ticks
                     if yaxis[:scale] in _logScales
                         dv = string(dv, "\\ ")
-                    elseif yaxis[:formatter] == :scientific || contains(dv,"×10")
+                    elseif yaxis[:formatter] in (:scientific, :auto)
                         dv = convert_sci_unicode(dv)
                     end
                 end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -223,7 +223,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     sinf = sind.(a)
     cosf = cosd.(a)
     rtick_values, rtick_labels = get_ticks(yaxis)
-    if yaxis[:formatter] == :scientific && yaxis[:ticks] in (:auto, :native)
+    if (yaxis[:formatter] == :scientific || contains(rtick_labels,"×10") )&& yaxis[:ticks] in (:auto, :native)
         rtick_labels = convert_sci_unicode(rtick_labels)
     end
 
@@ -889,7 +889,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     # ensure correct dispatch in gr_text for automatic log ticks
                     if xaxis[:scale] in _logScales
                         dv = string(dv, "\\ ")
-                    elseif xaxis[:formatter] == :scientific
+                    elseif xaxis[:formatter] == :scientific || contains(dv,"×10")
                         dv = convert_sci_unicode(dv)
                     end
                 end
@@ -908,7 +908,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     # ensure correct dispatch in gr_text for automatic log ticks
                     if yaxis[:scale] in _logScales
                         dv = string(dv, "\\ ")
-                    elseif yaxis[:formatter] == :scientific
+                    elseif yaxis[:formatter] == :scientific || contains(dv,"×10")
                         dv = convert_sci_unicode(dv)
                     end
                 end

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -329,7 +329,8 @@ function pgf_axis(sp::Subplot, letter)
             push!(style, string(letter, "ticklabels = {\$", join(tick_labels,"\$,\$"), "\$}"))
         elseif axis[:showaxis]
             tick_labels = ispolar(sp) && letter == :x ? [ticks[2][3:end]..., "0", "45"] : ticks[2]
-            tick_labels = axis[:formatter] == :scientific ? string.("\$", convert_sci_unicode.(tick_labels), "\$") : tick_labels
+            tick_labels = ( axis[:formatter] in (:scientific, :auto) ?
+                            string.("\$", convert_sci_unicode.(tick_labels), "\$") : tick_labels )
             push!(style, string(letter, "ticklabels = {", join(tick_labels,","), "}"))
         else
             push!(style, string(letter, "ticklabels = {}"))

--- a/src/backends/web.jl
+++ b/src/backends/web.jl
@@ -12,6 +12,7 @@ function standalone_html(plt::AbstractPlot; title::AbstractString = get(plt.attr
     <html>
         <head>
             <title>$title</title>
+            <meta http-equiv="content-type" content="text/html; charset=UTF-8">
             $(html_head(plt))
         </head>
         <body>


### PR DESCRIPTION
At present unless you specify explicitly `:scientific` formatting for the labels (hmm, have yet to find how to do this...), you are going to get fixed notation for any numbers - really inconvenient!  A the same time, `Showoff.jl` provides `:auto` formatter, which guesses properly the style to use.

Here is a simple fix that selects :auto label formatter instead of :plain, making default behaviour as expected from a well behaved plotter in the following situation:

```
x=1e-12:1e-13:1e-10;Plots.plot(x,1./x)
```

Note, that I had to fix in a crude way the unicode translator for the GR backend -- definitely a better approach is possible.