### PR TITLE
Infinite objects (fix #1422)

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -187,6 +187,8 @@ include("output.jl")
 @shorthands sticks
 @shorthands hline
 @shorthands vline
+@shorthands hspan
+@shorthands vspan
 @shorthands ohlc
 @shorthands contour
 @shorthands contourf

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -287,8 +287,8 @@ end
 
 
 function expand_extrema!(ex::Extrema, v::Number)
-    ex.emin = NaNMath.min(v, ex.emin)
-    ex.emax = NaNMath.max(v, ex.emax)
+    ex.emin = isfinite(v) ? min(v, ex.emin) : ex.emin
+    ex.emax = isfinite(v) ? max(v, ex.emax) : ex.emax
     ex
 end
 
@@ -303,8 +303,8 @@ expand_extrema!(axis::Axis, ::Bool) = axis[:extrema]
 
 function expand_extrema!(axis::Axis, v::Tuple{MIN,MAX}) where {MIN<:Number,MAX<:Number}
     ex = axis[:extrema]
-    ex.emin = NaNMath.min(v[1], ex.emin)
-    ex.emax = NaNMath.max(v[2], ex.emax)
+    ex.emin = isfinite(v[1]) ? min(v[1], ex.emin) : ex.emin
+    ex.emax = isfinite(v[2]) ? max(v[2], ex.emax) : ex.emax
     ex
 end
 function expand_extrema!(axis::Axis, v::AVec{N}) where N<:Number
@@ -326,6 +326,9 @@ function expand_extrema!(sp::Subplot, d::KW)
         else
             letter == :x ? :y : letter == :y ? :x : :z
         end]
+        if letter != :z && d[:seriestype] == :straightline && any(series[:seriestype] != :straightline for series in series_list(sp)) && data[1] != data[2]
+            data = [NaN]
+        end
         axis = sp[Symbol(letter, "axis")]
 
         if isa(data, Volume)

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -289,6 +289,8 @@ function extract_points(d)
     dim = is3d(d) ? 3 : 2
     array = if d[:seriestype] == :straightline
         straightline_data(d)
+    elseif d[:seriestype] == :shape
+        shape_data(series)
     else
         (d[:x], d[:y], d[:z])[1:dim]
     end

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -290,7 +290,7 @@ function extract_points(d)
     array = if d[:seriestype] == :straightline
         straightline_data(d)
     elseif d[:seriestype] == :shape
-        shape_data(series)
+        shape_data(d)
     else
         (d[:x], d[:y], d[:z])[1:dim]
     end

--- a/src/backends/glvisualize.jl
+++ b/src/backends/glvisualize.jl
@@ -287,12 +287,12 @@ function topoints(::Type{P}, array) where P
 end
 function extract_points(d)
     dim = is3d(d) ? 3 : 2
-    array = (d[:x], d[:y], d[:z])[1:dim]
+    array = if d[:seriestype] == :straightline
+        straightline_data(d)
+    else
+        (d[:x], d[:y], d[:z])[1:dim]
+    end
     topoints(Point{dim, Float32}, array)
-end
-function extract_straightline_points(sp::Subplot, series::Series)
-    x, y = straightline_data(sp, series)
-    topoints(Point{2, Float32}, (x, y))
 end
 function make_gradient(grad::Vector{C}) where C <: Colorant
     grad
@@ -1108,7 +1108,7 @@ function _display(plt::Plot{GLVisualizeBackend}, visible = true)
                 vis = GL.gl_surface(x, y, z, kw_args)
             elseif (st in (:path, :path3d, :straightline)) && d[:linewidth] > 0
                 kw = copy(kw_args)
-                points = st == :straightline ? extract_straightline_points(sp, series) : Plots.extract_points(d)
+                points = Plots.extract_points(d)
                 extract_linestyle(d, kw)
                 vis = GL.gl_lines(points, kw)
                 if d[:markershape] != :none

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -48,7 +48,7 @@ const _gr_attr = merge_with_base_supported([
     :contour_labels,
 ])
 const _gr_seriestype = [
-    :path, :scatter,
+    :path, :scatter, :straightline,
     :heatmap, :pie, :image,
     :contour, :path3d, :scatter3d, :surface, :wireframe,
     :shape
@@ -1014,7 +1014,11 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             x, y = convert_to_polar(x, y, (rmin, rmax))
         end
 
-        if st in (:path, :scatter)
+        if st == :straightline
+            x, y = straightline_data(sp, series)
+        end
+
+        if st in (:path, :scatter, :straightline)
             if length(x) > 1
                 lz = series[:line_z]
                 segments_iterator = if lz != nothing && length(lz) > 1
@@ -1036,7 +1040,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 end
 
                 # draw the line(s)
-                if st == :path
+                if st in (:path, :straightline)
                     for (i, rng) in enumerate(segments_iterator)
                         gr_set_line(series[:linewidth], series[:linestyle], get_linecolor(sp, series, i)) #, series[:linealpha])
                         arrowside = isa(series[:arrow], Arrow) ? series[:arrow].side : :none
@@ -1295,7 +1299,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     st == :shape && gr_polyline(x, y)
                 end
 
-                if st == :path
+                if st in (:path, :straightline)
                     GR.settransparency(gr_alpha(series[:linealpha]))
                     if series[:fillrange] == nothing || series[:ribbon] != nothing
                         GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1015,7 +1015,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         end
 
         if st == :straightline
-            x, y = straightline_data(sp, series)
+            x, y = straightline_data(series)
         end
 
         if st in (:path, :scatter, :straightline)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1186,6 +1186,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             GR.selntran(1)
 
         elseif st == :shape
+            x, y = shape_data(series)
             for (i,rng) in enumerate(iter_segments(x, y))
                 if length(rng) > 1
                     # connect to the beginning

--- a/src/backends/hdf5.jl
+++ b/src/backends/hdf5.jl
@@ -29,7 +29,7 @@ Read from .hdf5 file using:
 ==#
 
 @require Revise begin
-    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "hdf5.jl")) 
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "hdf5.jl"))
 end
 
 import FixedPointNumbers: N0f8 #In core Julia
@@ -97,7 +97,7 @@ const _hdf5_attr = merge_with_base_supported([
     :colorbar_title,
   ])
 const _hdf5_seriestype = [
-        :path, :steppre, :steppost, :shape,
+        :path, :steppre, :steppost, :shape, :straightline,
         :scatter, :hexbin, #:histogram2d, :histogram,
         # :bar,
         :heatmap, :pie, :image,

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -57,7 +57,7 @@ const _inspectdr_attr = merge_with_base_supported([
   ])
 const _inspectdr_style = [:auto, :solid, :dash, :dot, :dashdot]
 const _inspectdr_seriestype = [
-        :path, :scatter, :shape #, :steppre, :steppost
+        :path, :scatter, :shape, :straightline, #, :steppre, :steppost
     ]
 #see: _allMarkers, _shape_keys
 const _inspectdr_marker = Symbol[
@@ -243,7 +243,11 @@ function _series_added(plt::Plot{InspectDRBackend}, series::Series)
     if nothing == plot; return; end
 
     _vectorize(v) = isa(v, Vector) ? v : collect(v) #InspectDR only supports vectors
-    x = _vectorize(series[:x]); y = _vectorize(series[:y])
+    x, y = if st == :straightline
+        straightline_data(series)
+    else
+        _vectorize(series[:x]), _vectorize(series[:y])
+    end
 
     #No support for polar grid... but can still perform polar transformation:
     if ispolar(sp)
@@ -299,7 +303,7 @@ For st in :shape:
                 color = linecolor, fillcolor = fillcolor
             )
         end
-   elseif st in (:path, :scatter) #, :steppre, :steppost)
+   elseif st in (:path, :scatter, :straightline) #, :steppre, :steppost)
         #NOTE: In Plots.jl, :scatter plots have 0-linewidths (I think).
         linewidth = series[:linewidth]
         #More efficient & allows some support for markerstrokewidth:

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -272,6 +272,7 @@ For st in :shape:
 =#
 
     if st in (:shape,)
+        x, y = shape_data(series)
         nmax = 0
         for (i,rng) in enumerate(iter_segments(x, y))
             nmax = i

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -222,6 +222,8 @@ function pgf_series(sp::Subplot, series::Series)
         d[:x], d[:y], d[:z]
     elseif st == :straightline
         straightline_data(series)
+    elseif st == :shape
+        shape_data(series)
     elseif d[:marker_z] != nothing
         # If a marker_z is used pass it as third coordinate to a 2D plot.
         # See "Scatter Plots" in PGFPlots documentation

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -39,7 +39,7 @@ const _pgfplots_attr = merge_with_base_supported([
     :framestyle,
     :camera,
   ])
-const _pgfplots_seriestype = [:path, :path3d, :scatter, :steppre, :stepmid, :steppost, :histogram2d, :ysticks, :xsticks, :contour, :shape]
+const _pgfplots_seriestype = [:path, :path3d, :scatter, :steppre, :stepmid, :steppost, :histogram2d, :ysticks, :xsticks, :contour, :shape, :straightline,]
 const _pgfplots_style = [:auto, :solid, :dash, :dot, :dashdot, :dashdotdot]
 const _pgfplots_marker = [:none, :auto, :circle, :rect, :diamond, :utriangle, :dtriangle, :cross, :xcross, :star5, :pentagon, :hline] #vcat(_allMarkers, Shape)
 const _pgfplots_scale = [:identity, :ln, :log2, :log10]
@@ -220,6 +220,8 @@ function pgf_series(sp::Subplot, series::Series)
         d[:z].surf, d[:x], d[:y]
     elseif is3d(st)
         d[:x], d[:y], d[:z]
+    elseif st == :straightline
+        straightline_data(series)
     elseif d[:marker_z] != nothing
         # If a marker_z is used pass it as third coordinate to a 2D plot.
         # See "Scatter Plots" in PGFPlots documentation

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -704,7 +704,7 @@ function plotly_series_shapes(plt::Plot, series::Series)
     base_d[:name] = series[:label]
     # base_d[:legendgroup] = series[:label]
 
-    x, y = plotly_data(series[:x]), plotly_data(series[:y])
+    x, y = shape_data(series)
     for (i,rng) in enumerate(iter_segments(x,y))
         length(rng) < 2 && continue
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -51,6 +51,7 @@ const _plotly_attr = merge_with_base_supported([
 const _plotly_seriestype = [
     :path, :scatter, :bar, :pie, :heatmap,
     :contour, :surface, :wireframe, :path3d, :scatter3d, :shape, :scattergl,
+    :straightline
 ]
 const _plotly_style = [:auto, :solid, :dash, :dot, :dashdot]
 const _plotly_marker = [
@@ -510,12 +511,16 @@ function plotly_series(plt::Plot, series::Series)
             plotly_data(series[letter])
         end), (:x, :y, :z))
 
+    if st == :straightline
+        x, y = straightline_data(series)
+    end
+
     d_out[:name] = series[:label]
 
     isscatter = st in (:scatter, :scatter3d, :scattergl)
     hasmarker = isscatter || series[:markershape] != :none
-    hasline = st in (:path, :path3d)
-    hasfillrange = st in (:path, :scatter, :scattergl) &&
+    hasline = st in (:path, :path3d, :straightline)
+    hasfillrange = st in (:path, :scatter, :scattergl, :straightline) &&
         (isa(series[:fillrange], AbstractVector) || isa(series[:fillrange], Tuple))
 
     d_out[:colorbar] = KW(:title => sp[:colorbar_title])
@@ -526,7 +531,7 @@ function plotly_series(plt::Plot, series::Series)
     end
 
     # set the "type"
-    if st in (:path, :scatter, :scattergl)
+    if st in (:path, :scatter, :scattergl, :straightline)
         d_out[:type] = st==:scattergl ? "scattergl" : "scatter"
         d_out[:mode] = if hasmarker
             hasline ? "lines+markers" : "markers"

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -454,6 +454,8 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     x, y, z = series[:x], series[:y], series[:z]
     if st == :straightline
         x, y = straightline_data(series)
+    elseif st == :shape
+        x, y = shape_data(series)
     end
     xyargs = (st in _3dTypes ? (x,y,z) : (x,y))
 

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -45,7 +45,7 @@ const _pyplot_attr = merge_with_base_supported([
     :contour_labels,
   ])
 const _pyplot_seriestype = [
-        :path, :steppre, :steppost, :shape,
+        :path, :steppre, :steppost, :shape, :straightline,
         :scatter, :hexbin, #:histogram2d, :histogram,
         # :bar,
         :heatmap, :pie, :image,
@@ -452,6 +452,9 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
 
     # ax = getAxis(plt, series)
     x, y, z = series[:x], series[:y], series[:z]
+    if st == :straightline
+        x, y = straightline_data(series)
+    end
     xyargs = (st in _3dTypes ? (x,y,z) : (x,y))
 
     # handle zcolor and get c/cmap
@@ -485,7 +488,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     # for each plotting command, optionally build and add a series handle to the list
 
     # line plot
-    if st in (:path, :path3d, :steppre, :steppost)
+    if st in (:path, :path3d, :steppre, :steppost, :straightline)
         if series[:linewidth] > 0
             if series[:line_z] == nothing
                 handle = ax[:plot](xyargs...;
@@ -1244,7 +1247,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                         facecolor = py_color(_cycle(series[:fillcolor],1)),
                         linewidth = py_dpi_scale(plt, clamp(series[:linewidth], 0, 5)),
                     )
-                elseif series[:seriestype] == :path
+                elseif series[:seriestype] in (:path, :straightline)
                     PyPlot.plt[:Line2D]((0,1),(0,0),
                         color = py_color(_cycle(series[:linecolor],1)),
                         linewidth = py_dpi_scale(plt, clamp(series[:linewidth], 0, 5)),

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -2,7 +2,7 @@
 # https://github.com/Evizero/UnicodePlots.jl
 
 @require Revise begin
-    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "unicodeplots.jl")) 
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "unicodeplots.jl"))
 end
 
 const _unicodeplots_attr = merge_with_base_supported([
@@ -17,7 +17,7 @@ const _unicodeplots_attr = merge_with_base_supported([
     :guide, :lims,
   ])
 const _unicodeplots_seriestype = [
-    :path, :scatter,
+    :path, :scatter, :straightline,
     # :bar,
     :shape,
     :histogram2d,
@@ -142,7 +142,7 @@ function addUnicodeSeries!(o, d::KW, addlegend::Bool, xlim, ylim)
         return
     end
 
-    if st == :path
+    if st in (:path, :straightline)
         func = UnicodePlots.lineplot!
     elseif st == :scatter || d[:markershape] != :none
         func = UnicodePlots.scatterplot!
@@ -155,7 +155,11 @@ function addUnicodeSeries!(o, d::KW, addlegend::Bool, xlim, ylim)
     end
 
     # get the series data and label
-    x, y = [collect(float(d[s])) for s in (:x, :y)]
+    x, y = if st == :straightline
+        straightline_data(d)
+    else
+        [collect(float(d[s])) for s in (:x, :y)]
+    end
     label = addlegend ? d[:label] : ""
 
     # if we happen to pass in allowed color symbols, great... otherwise let UnicodePlots decide

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -157,6 +157,8 @@ function addUnicodeSeries!(o, d::KW, addlegend::Bool, xlim, ylim)
     # get the series data and label
     x, y = if st == :straightline
         straightline_data(d)
+    elseif st == :shape
+        shape_data(series)
     else
         [collect(float(d[s])) for s in (:x, :y)]
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -100,6 +100,30 @@ end
 end
 @deps vline straightline
 
+@recipe function f(::Type{Val{:hspan}}, x, y, z)
+    n = div(length(y), 2)
+    newx = repeat([-Inf, Inf, Inf, -Inf, NaN], outer = n)
+    newy = vcat([[y[2i-1], y[2i-1], y[2i], y[2i], NaN] for i in 1:n]...)
+    linewidth --> 0
+    x := newx
+    y := newy
+    seriestype := :shape
+    ()
+end
+@deps hspan shape
+
+@recipe function f(::Type{Val{:vspan}}, x, y, z)
+    n = div(length(y), 2)
+    newx = vcat([[y[2i-1], y[2i-1], y[2i], y[2i], NaN] for i in 1:n]...)
+    newy = repeat([-Inf, Inf, Inf, -Inf, NaN], outer = n)
+    linewidth --> 0
+    x := newx
+    y := newy
+    seriestype := :shape
+    ()
+end
+@deps vspan shape
+
 # ---------------------------------------------------------------------------
 # path and scatter
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -79,28 +79,26 @@ function hvline_limits(axis::Axis)
 end
 
 @recipe function f(::Type{Val{:hline}}, x, y, z)
-    xmin, xmax = hvline_limits(plotattributes[:subplot][:xaxis])
     n = length(y)
-    newx = repmat(Float64[xmin, xmax, NaN], n)
+    newx = repmat(Float64[-1, 1, NaN], n)
     newy = vec(Float64[yi for i=1:3,yi=y])
     x := newx
     y := newy
-    seriestype := :path
+    seriestype := :straightline
     ()
 end
-@deps hline path
+@deps hline straightline
 
 @recipe function f(::Type{Val{:vline}}, x, y, z)
-    ymin, ymax = hvline_limits(plotattributes[:subplot][:yaxis])
     n = length(y)
     newx = vec(Float64[yi for i=1:3,yi=y])
-    newy = repmat(Float64[ymin, ymax, NaN], n)
+    newy = repmat(Float64[-1, 1, NaN], n)
     x := newx
     y := newy
-    seriestype := :path
+    seriestype := :straightline
     ()
 end
-@deps vline path
+@deps vline straightline
 
 # ---------------------------------------------------------------------------
 # path and scatter
@@ -999,15 +997,7 @@ end
 # -------------------------------------------------
 
 "Adds a+bx... straight line over the current plot, without changing the axis limits"
-function abline!(plt::Plot, a, b; kw...)
-    xl, yl = xlims(plt), ylims(plt)
-    x1, x2 = max(xl[1], (yl[1] - b)/a), min(xl[2], (yl[2] - b)/a)
-    if x2 > x1
-        plot!(plt, x -> b + a*x, x1, x2; kw...)
-    else
-        nothing
-    end
-end
+abline!(plt::Plot, a, b; kw...) = plot!(plt, [0, 1], [b, b+a]; seriestype = :straightline, kw...)
 
 abline!(args...; kw...) = abline!(current(), args...; kw...)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1103,14 +1103,14 @@ function straightline_data(series)
 end
 
 function straightline_data(xl, yl, x, y)
-    if y[1] == y[2]
+    x_vals, y_vals = if y[1] == y[2]
         if x[1] == x[2]
             error("Two identical points cannot be used to describe a straight line.")
         else
-            return [xl[1], xl[2]], [y[1], y[2]]
+            [xl[1], xl[2]], [y[1], y[2]]
         end
     elseif x[1] == x[2]
-        return [x[1], x[2]], [yl[1], yl[2]]
+        [x[1], x[2]], [yl[1], yl[2]]
     else
         # get a and b from the line y = a * x + b through the points given by
         # the coordinates x and x
@@ -1118,8 +1118,15 @@ function straightline_data(xl, yl, x, y)
         a = (y[1] - y[2]) / (x[1] - x[2])
         # get the data values
         xdata = [clamp(x[1] + (x[1] - x[2]) * (ylim - y[1]) / (y[1] - y[2]), xl...) for ylim in yl]
-        return xdata, a .* xdata .+ b
+
+        xdata, a .* xdata .+ b
     end
+    # expand the data outside the axis limits, by a certain factor too improve
+    # plotly(js) and interactive behaviour
+    factor = 100
+    x_vals = x_vals .+ (x_vals[2] - x_vals[1]) .* factor .* [-1, 1]
+    y_vals = y_vals .+ (y_vals[2] - y_vals[1]) .* factor .* [-1, 1]
+    return x_vals, y_vals
 end
 
 function shape_data(series)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1080,8 +1080,9 @@ function convert_sci_unicode(label::AbstractString)
     label
 end
 
-function straightline_data(sp::Subplot, series::Series)
-    xl, yl = isvertical(series.d) ? (xlims(sp), ylims(sp)) : (ylims(sp), xlims(sp))
+function straightline_data(series)
+    sp = series[:subplot]
+    xl, yl = isvertical(series) ? (xlims(sp), ylims(sp)) : (ylims(sp), xlims(sp))
     x, y = series[:x], series[:y]
     n = length(x)
     if n == 2

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1121,3 +1121,25 @@ function straightline_data(xl, yl, x, y)
         return xdata, a .* xdata .+ b
     end
 end
+
+function shape_data(series)
+    sp = series[:subplot]
+    xl, yl = isvertical(series) ? (xlims(sp), ylims(sp)) : (ylims(sp), xlims(sp))
+    x, y = series[:x], series[:y]
+    factor = 100
+    for i in eachindex(x)
+        if x[i] == -Inf
+            x[i] = xl[1] - factor * (xl[2] - xl[1])
+        elseif x[i] == Inf
+            x[i] = xl[2] + factor * (xl[2] - xl[1])
+        end
+    end
+    for i in eachindex(y)
+        if y[i] == -Inf
+            y[i] = yl[1] - factor * (yl[2] - yl[1])
+        elseif y[i] == Inf
+            y[i] = yl[2] + factor * (yl[2] - yl[1])
+        end
+    end
+    return x, y
+end


### PR DESCRIPTION
This supercedes #1316 and implements `hline`, `vline` and `Plots.abline` that update automatically with changing axis limits. This is done via a new seriestype `:straightline` which is characterized by two points. The final points to be connected by the `:straightline` are calculated by the new `Plots.straightline_data(series)` in the backend code based on the axes limits of all series.
Similarly, the function `Plots.shape_data(series)` is introduced and called in the backend code to replace infinite values with values far outside the axes limits.
Below you find all the plots produced by executing the following code snippet:
```julia
using Plots
plot(Shape([-Inf, Inf, Inf, -Inf, -Inf], [-Inf, -Inf, 0, 0, -Inf]))
scatter!(randn(10), randn(10))
hline!([0.5])
Plots.abline!(-0.3, 1)
vline!(-5:2.5:5)
ylims!((-5, 5))
```
![infinte_1](https://user-images.githubusercontent.com/16589944/37621126-5c69b68c-2bbe-11e8-8f7f-160b0f649c99.png)
![infinte_2](https://user-images.githubusercontent.com/16589944/37621134-61b0310c-2bbe-11e8-8dec-1644f534091c.png)
![infinte_3](https://user-images.githubusercontent.com/16589944/37621145-667ca9ae-2bbe-11e8-82b0-8322a39a6595.png)
![infinte_4](https://user-images.githubusercontent.com/16589944/37621153-69bcbcda-2bbe-11e8-9b5f-7082eda71a94.png)
![infinte_5](https://user-images.githubusercontent.com/16589944/37621164-6d4806de-2bbe-11e8-9325-750275a67b4e.png)
![infinte_6](https://user-images.githubusercontent.com/16589944/37621173-700754ba-2bbe-11e8-8e4f-e4aa8afa4f63.png)

**NOTE** that these are not really infinite objects: When zooming out the plot area e.g. in Plotly, these objects do not get updated. Maybe it would make sense to have the lines go 10 or 100 times the axes lenghts beyond the axes limits, so people could zoom for a while before reaching the lines' limits?