### PR TITLE
WIP: add experimental backend for PlotlyWebIO

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -276,6 +276,7 @@ end
 # @init_backend Bokeh
 @init_backend Plotly
 @init_backend PlotlyJS
+@init_backend PlotlyWebIO
 @init_backend GR
 @init_backend GLVisualize
 @init_backend PGFPlots

--- a/src/backends/plotlywebio.jl
+++ b/src/backends/plotlywebio.jl
@@ -32,11 +32,6 @@ function _initialize_backend(::PlotlyWebIOBackend; kw...)
         import PlotlyWebIO
         export PlotlyWebIO
     end
-
-    # # override IJulia inline display
-    # if isijulia()
-    #     IJulia.display_dict(plt::AbstractPlot{PlotlyWebIOBackend}) = IJulia.display_dict(plt.o)
-    # end
 end
 
 # ---------------------------------------------------------------------------
@@ -44,8 +39,8 @@ end
 
 function _create_backend_figure(plt::Plot{PlotlyWebIOBackend})
     if !isplotnull() && plt[:overwrite_figure] && isa(current().o, PlotlyWebIO.WebIOPlot)
-        #PlotlyWebIO.WebIOPlot(PlotlyWebIO.Plot(), current().o.view)
-        current().o
+        # FIXME: Not sure what we're supposed to do here.
+        PlotlyWebIO.WebIOPlot()#PlotlyWebIO.WebIOPlot(), current().o.scope)
     else
         PlotlyWebIO.WebIOPlot()
     end
@@ -92,13 +87,14 @@ end
 function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyWebIOBackend})
     prepare_output(plt)
     if isijulia() && !_use_remote[]
-        write(io, PlotlyWebIO.html_body(PlotlyWebIO.JupyterPlot(plt.o)))
+        write(io, PlotlyWebIO.html_body(PlotlyWebIO.JupyterPlot(plt.o.scope)))
     else
-        show(io, MIME("text/html"), plt.o)
+        show(io, MIME("text/html"), plt.o.scope)
     end
 end
 
 function plotlywebio_save_hack(io::IO, plt::Plot{PlotlyWebIOBackend}, ext::String)
+    # Temporarily disabled. FIXME
     # tmpfn = tempname() * "." * ext
     # PlotlyWebIO.savefig(plt.o, tmpfn)
     # write(io, read(open(tmpfn)))

--- a/src/backends/plotlywebio.jl
+++ b/src/backends/plotlywebio.jl
@@ -1,0 +1,130 @@
+@require Revise begin
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "plotlywebio.jl")) 
+end
+
+# https://github.com/spencerlyon2/PlotlyWebIO.jl
+
+const _plotlywebio_attr        = _plotly_attr
+const _plotlywebio_seriestype  = _plotly_seriestype
+const _plotlywebio_style       = _plotly_style
+const _plotlywebio_marker      = _plotly_marker
+const _plotlywebio_scale       = _plotly_scale
+
+# --------------------------------------------------------------------------------------
+
+
+function add_backend_string(::PlotlyWebIOBackend)
+    """
+    if !Plots.is_installed("PlotlyWebIO")
+        Pkg.add("PlotlyWebIO")
+    end
+    if !Plots.is_installed("Rsvg")
+        Pkg.add("Rsvg")
+    end
+    import Blink
+    Blink.AtomShell.install()
+    """
+end
+
+
+function _initialize_backend(::PlotlyWebIOBackend; kw...)
+    @eval begin
+        import PlotlyWebIO
+        export PlotlyWebIO
+    end
+
+    # # override IJulia inline display
+    # if isijulia()
+    #     IJulia.display_dict(plt::AbstractPlot{PlotlyWebIOBackend}) = IJulia.display_dict(plt.o)
+    # end
+end
+
+# ---------------------------------------------------------------------------
+
+
+function _create_backend_figure(plt::Plot{PlotlyWebIOBackend})
+    if !isplotnull() && plt[:overwrite_figure] && isa(current().o, PlotlyWebIO.WebIOPlot)
+        #PlotlyWebIO.WebIOPlot(PlotlyWebIO.Plot(), current().o.view)
+        current().o
+    else
+        PlotlyWebIO.WebIOPlot()
+    end
+end
+
+
+function _series_added(plt::Plot{PlotlyWebIOBackend}, series::Series)
+    syncplot = plt.o
+    pdicts = plotly_series(plt, series)
+    for pdict in pdicts
+        typ = pop!(pdict, :type)
+        gt = PlotlyWebIO.GenericTrace(typ; pdict...)
+        #PlotlyWebIO.addtraces!(syncplot, gt)
+    end
+end
+
+function _series_updated(plt::Plot{PlotlyWebIOBackend}, series::Series)
+    xsym, ysym = (ispolar(series) ? (:t,:r) : (:x,:y))
+    kw = KW(xsym => (series.d[:x],), ysym => (series.d[:y],))
+    z = series[:z]
+    if z != nothing
+        kw[:z] = (isa(z,Surface) ? transpose_z(series, series[:z].surf, false) : z,)
+    end
+    PlotlyWebIO.restyle!(
+        plt.o,
+        findfirst(plt.series_list, series),
+        kw
+    )
+end
+
+
+# ----------------------------------------------------------------
+
+function _update_plot_object(plt::Plot{PlotlyWebIOBackend})
+    pdict = plotly_layout(plt)
+    syncplot = plt.o
+    w,h = plt[:size]
+    PlotlyWebIO.relayout!(syncplot, pdict, width = w, height = h)
+end
+
+
+# ----------------------------------------------------------------
+
+function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyWebIOBackend})
+    prepare_output(plt)
+    if isijulia() && !_use_remote[]
+        write(io, PlotlyWebIO.html_body(PlotlyWebIO.JupyterPlot(plt.o)))
+    else
+        show(io, MIME("text/html"), plt.o)
+    end
+end
+
+function plotlywebio_save_hack(io::IO, plt::Plot{PlotlyWebIOBackend}, ext::String)
+    # tmpfn = tempname() * "." * ext
+    # PlotlyWebIO.savefig(plt.o, tmpfn)
+    # write(io, read(open(tmpfn)))
+end
+_show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyWebIOBackend}) = plotlywebio_save_hack(io, plt, "svg")
+_show(io::IO, ::MIME"image/png", plt::Plot{PlotlyWebIOBackend}) = plotlywebio_save_hack(io, plt, "png")
+_show(io::IO, ::MIME"application/pdf", plt::Plot{PlotlyWebIOBackend}) = plotlywebio_save_hack(io, plt, "pdf")
+_show(io::IO, ::MIME"image/eps", plt::Plot{PlotlyWebIOBackend}) = plotlywebio_save_hack(io, plt, "eps")
+
+function write_temp_html(plt::Plot{PlotlyWebIOBackend})
+    filename = string(tempname(), ".html")
+    savefig(plt, filename)
+    filename
+end
+
+function _display(plt::Plot{PlotlyWebIOBackend})
+    if get(ENV, "PLOTS_USE_ATOM_PLOTPANE", true) in (true, 1, "1", "true", "yes")
+        display(plt.o)
+    else
+        standalone_html_window(plt)
+    end
+end
+
+
+function closeall(::PlotlyWebIOBackend)
+    if !isplotnull() && isa(current().o, PlotlyWebIO.WebIOPlot)
+        close(current().o)
+    end
+end

--- a/src/backends/plotlywebio.jl
+++ b/src/backends/plotlywebio.jl
@@ -53,12 +53,12 @@ end
 
 
 function _series_added(plt::Plot{PlotlyWebIOBackend}, series::Series)
-    syncplot = plt.o
+    webioplot = plt.o
     pdicts = plotly_series(plt, series)
     for pdict in pdicts
         typ = pop!(pdict, :type)
         gt = PlotlyWebIO.GenericTrace(typ; pdict...)
-        #PlotlyWebIO.addtraces!(syncplot, gt)
+        PlotlyWebIO.addtraces!(webioplot, gt)
     end
 end
 
@@ -81,9 +81,9 @@ end
 
 function _update_plot_object(plt::Plot{PlotlyWebIOBackend})
     pdict = plotly_layout(plt)
-    syncplot = plt.o
+    webioplot = plt.o
     w,h = plt[:size]
-    PlotlyWebIO.relayout!(syncplot, pdict, width = w, height = h)
+    PlotlyWebIO.relayout!(webioplot, pdict, width = w, height = h)
 end
 
 


### PR DESCRIPTION
[PlotlyWebIO.jl](https://github.com/sglyon/PlotlyWebIO.jl) is a branch/rewrite of PlotlyJS.jl that uses [WebIO.jl](https://github.com/JuliaGizmos/WebIO.jl) for two-way communication with Plotly. Among other benefits, it enables callbacks from Plotly to Julia (eg. we can now tell [which points are selected](https://github.com/sglyon/PlotlyWebIO.jl/issues/4)). This is interesting to me, but it's quite a mouthful for a first Plots.jl PR. Any help is very appreciated. 

I've been working exclusively in IJulia for now. The sister PR, required for this to work (along with the `master` of JSExpr) is https://github.com/sglyon/PlotlyWebIO.jl/pull/5

```julia
plotlywebio()
plot([1, -1, 2]).o.scope
```

![image](https://user-images.githubusercontent.com/8622776/37661568-80b8cccc-2c2b-11e8-897e-0a59c7d8b39e.png)

Current issues:

- [ ] We currently need `plot([1, -1, 2]).o.scope` to display the plot. Which Plots.jl function is called for display in IJulia? I thought it would be `Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyWebIOBackend})`, but that's not called.
- [ ] DateTime axes show up as numbers
- [ ] `p.o.event_obs["selected"][]` should show the selected points, but it doesn't work. Potentially because `_create_backend_figure` creates a new object.
- [ ] The figure is displayed too early, then updated.

cc @sglyon 