### PR TITLE
PyPlot: fix markercolor in legend for marker_z with st = :path

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1255,7 +1255,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                         linestyle = py_linestyle(:path,series[:linestyle]),
                         marker = py_marker(series[:markershape]),
                         markeredgecolor = py_markerstrokecolor(series),
-                        markerfacecolor = py_markercolor(series)
+                        markerfacecolor = series[:marker_z] == nothing ? py_markercolor(series) : py_color(series[:markercolor][0.5])
                     )
                 else
                     series[:serieshandle][1]


### PR DESCRIPTION
The following lines should return more or less the same plot:
```julia
scatter(xm, ym, marker_z = 1:100)
plot(xm, ym, markershape = :circle, linecolor = false, marker_z = 1:100)
```
The second line however errors on PyPlot:
```julia
plot(xm, ym, markershape = :circle, linecolor = invisible(), marker_z = 1:100)
Error showing value of type Plots.Plot{Plots.PyPlotBackend}:
ERROR: PyError (ccall(@pysym(:PyObject_Call), PyPtr, (PyPtr, PyPtr, PyPtr), o, arg, C_NULL)) <class
'ValueError'>
ValueError('Invalid RGBA argument: [(0.001462, 0.000466, 0.013866, 1.0), (0.016561, 0.013136, 0.0802
82, 1.0), (0.051644, 0.032474, 0.159254, 1.0), (0.09299, 0.045583, 0.234358, 1.0), (0.149073, 0.0454
68, 0.317085, 1.0), (0.211095, 0.03703, 0.378563, 1.0), (0.271347, 0.040922, 0.411976, 1.0), (0.3289
21, 0.057827, 0.427511, 1.0), (0.379001, 0.076253, 0.432719, 1.0), (0.434987, 0.097069, 0.432039, 1.
0), (0.491022, 0.117179, 0.425552, 1.0), (0.547157, 0.136929, 0.413511, 1.0), (0.603139, 0.157151, 0
.395891, 1.0), (0.652369, 0.176421, 0.375586, 1.0), (0.7065, 0.200728, 0.347777, 1.0), (0.758422, 0.
229097, 0.315266, 1.0), (0.807082, 0.262692, 0.278898, 1.0), (0.846709, 0.297559, 0.244113, 1.0), (0
.886302, 0.342586, 0.202968, 1.0), (0.919879, 0.393389, 0.16007, 1.0), (0.946965, 0.449191, 0.115272
, 1.0), (0.967322, 0.509078, 0.068659, 1.0), (0.979666, 0.565057, 0.031409, 1.0), (0.986964, 0.63048
5, 0.030908, 1.0), (0.987124, 0.697944, 0.087731, 1.0), (0.980032, 0.766837, 0.166353, 1.0), (0.9662
43, 0.836191, 0.261534, 1.0), (0.951546, 0.896226, 0.365627, 1.0), (0.949545, 0.955063, 0.50786, 1.0
), (0.988362, 0.998364, 0.644924, 1.0)]',)
...
```
because it tries to access all gradient colors when adding the marker to the legend. This is fixed here by adding only the "mean" gradient color to the legend.