### PR TITLE
Filled legend marker for filled areas in PGFPlots

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -269,9 +269,14 @@ function pgf_series(sp::Subplot, series::Series)
 
             # add to legend?
             if i == 1 && sp[:legend] != :none && should_add_to_legend(series)
-                kw[:legendentry] = d[:label]
-                if st == :shape # || d[:fillrange] != nothing
-                    push!(style, "area legend")
+                if d[:fillrange] != nothing
+                    # we add a series
+                    push!(series_collection, pgf_fill_legend_hack(d, args))
+                else
+                    kw[:legendentry] = d[:label]
+                    if st == :shape # || d[:fillrange] != nothing
+                        push!(style, "area legend")
+                    end
                 end
             else
                 push!(style, "forget plot")
@@ -336,6 +341,25 @@ function pgf_fillrange_args(fillrange, x, y, z)
     return x_fill, y_fill, z_fill
 end
 
+function pgf_fill_legend_hack(d, args)
+    style = []
+    kw = KW()
+    push!(style, pgf_linestyle(d, 1))
+    push!(style, pgf_marker(d, 1))
+    push!(style, pgf_fillstyle(d, 1))
+    push!(style, "area legend")
+    kw[:legendentry] = d[:label]
+    kw[:style] = join(style, ',')
+    st = d[:seriestype]
+    func = if st == :path3d
+        PGFPlots.Linear3
+    elseif st == :scatter
+        PGFPlots.Scatter
+    else
+        PGFPlots.Linear
+    end
+    return func(([arg[1]] for arg in args)...; kw...)
+end
 
 # ----------------------------------------------------------------
 

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -270,7 +270,7 @@ function pgf_series(sp::Subplot, series::Series)
             # add to legend?
             if i == 1 && sp[:legend] != :none && should_add_to_legend(series)
                 if d[:fillrange] != nothing
-                    # we add a series
+                    push!(style, "forget plot")
                     push!(series_collection, pgf_fill_legend_hack(d, args))
                 else
                     kw[:legendentry] = d[:label]


### PR DESCRIPTION
Changes
```julia
using Plots; pgfplots()
x = linspace(0, 2π, 100)
plot(x, [sin.(x) cos.(x)], fill=(0, 0.5))
```
from
![pgf_marker_old](https://user-images.githubusercontent.com/16589944/38433219-587cee3a-39ca-11e8-875b-1bb467af9625.png)

to
![pgf_marker_new](https://user-images.githubusercontent.com/16589944/38433226-607438fa-39ca-11e8-9ba5-2110056ab028.png)
