### PR TITLE
RFC: WIP: Heatmap recipe

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -183,6 +183,7 @@ include("output.jl")
 @shorthands histogram2d
 @shorthands density
 @shorthands heatmap
+@shorthands plots_heatmap
 @shorthands hexbin
 @shorthands sticks
 @shorthands hline

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -669,6 +669,8 @@ function plotly_series_shapes(plt::Plot, series::Series)
         d_outs[i] = d_out
     end
     if series[:fill_z] != nothing
+        push!(d_outs, plotly_colorbar_hack(series, base_d, :fill))
+    elseif series[:line_z] != nothing
         push!(d_outs, plotly_colorbar_hack(series, base_d, :line))
     end
     d_outs

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -390,8 +390,8 @@ end
 @deps bar shape
 
 # ---------------------------------------------------------------------------
-# Heatmap
-@recipe function f(::Type{Val{:heatmapr}}, x, y, z)
+# Plots Heatmap
+@recipe function f(::Type{Val{:plots_heatmap}}, x, y, z)
     xe, ye = heatmap_edges(x), heatmap_edges(y)
     m, n = size(z.surf)
     x_pts, y_pts = fill(NaN, 6 * m * n), fill(NaN, 6 * m * n)
@@ -415,7 +415,7 @@ end
     label := ""
     ()
 end
-@deps heatmapr shape
+@deps plots_heatmap shape
 
 # ---------------------------------------------------------------------------
 # Histograms

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -407,8 +407,7 @@ end
     end
     ensure_gradient!(plotattributes, :fillcolor, :fillalpha)
     fill_z := fz
-    linewidth := 0
-    linecolor := invisible()
+    line_z --> fz
     x := x_pts
     y := y_pts
     z := nothing

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -407,7 +407,7 @@ end
     end
     ensure_gradient!(plotattributes, :fillcolor, :fillalpha)
     fill_z := fz
-    line_z --> fz
+    line_z := fz
     x := x_pts
     y := y_pts
     z := nothing

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -389,6 +389,34 @@ end
 end
 @deps bar shape
 
+# ---------------------------------------------------------------------------
+# Heatmap
+@recipe function f(::Type{Val{:heatmapr}}, x, y, z)
+    xe, ye = heatmap_edges(x), heatmap_edges(y)
+    m, n = size(z.surf)
+    x_pts, y_pts = fill(NaN, 6 * m * n), fill(NaN, 6 * m * n)
+    fz = zeros(m * n)
+    for i in 1:m # y
+        for j in 1:n # x
+            k = (j - 1) * m + i
+            inds = (6 * (k - 1) + 1):(6 * k - 1)
+            x_pts[inds] .= [xe[j], xe[j + 1], xe[j + 1], xe[j], xe[j]]
+            y_pts[inds] .= [ye[i], ye[i], ye[i + 1], ye[i + 1], ye[i]]
+            fz[k] = z.surf[i, j]
+        end
+    end
+    ensure_gradient!(plotattributes, :fillcolor, :fillalpha)
+    fill_z := fz
+    linewidth := 0
+    linecolor := invisible()
+    x := x_pts
+    y := y_pts
+    z := nothing
+    seriestype := :shape
+    label := ""
+    ()
+end
+@deps heatmapr shape
 
 # ---------------------------------------------------------------------------
 # Histograms

--- a/src/series.jl
+++ b/src/series.jl
@@ -8,7 +8,7 @@
 
 const FuncOrFuncs{F} = Union{F, Vector{F}, Matrix{F}}
 
-all3D(d::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image, :heatmapr), get(d, :seriestype, :none))
+all3D(d::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image, :plots_heatmap), get(d, :seriestype, :none))
 
 # unknown
 convertToAnyVector(x, d::KW) = error("No user recipe defined for $(typeof(x))")

--- a/src/series.jl
+++ b/src/series.jl
@@ -8,7 +8,7 @@
 
 const FuncOrFuncs{F} = Union{F, Vector{F}, Matrix{F}}
 
-all3D(d::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image), get(d, :seriestype, :none))
+all3D(d::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image, :heatmapr), get(d, :seriestype, :none))
 
 # unknown
 convertToAnyVector(x, d::KW) = error("No user recipe defined for $(typeof(x))")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -643,17 +643,12 @@ end
 function get_fillcolor(series, i::Int = 1)
     fc = series[:fillcolor]
     fz = series[:fill_z]
-    lz = series[:line_z]
-    if fz == nothing && lz == nothing
+    if fz == nothing
         isa(fc, ColorGradient) ? fc : _cycle(fc, i)
     else
         cmin, cmax = get_clims(series[:subplot])
         grad = isa(fc, ColorGradient) ? fc : cgrad()
-        if fz != nothing
-            grad[clamp((_cycle(fz, i) - cmin) / (cmax - cmin), 0, 1)]
-        elseif lz != nothing
-            grad[clamp((_cycle(lz, i) - cmin) / (cmax - cmin), 0, 1)]
-        end
+        grad[clamp((_cycle(fz, i) - cmin) / (cmax - cmin), 0, 1)]
     end
 end
 


### PR DESCRIPTION
This is a follow-up on #1467 and implements a heatmap recipe.
For now I've kept the native heatmap implementation in the backends and created a new `:heatmapr` seriestype to compare the results and decide on which backend we want to choose which implementation.

### Comparison

Here's the output of
```julia
using Plots
y = (1:21) .* (1:21)'
plot(
    plot(y, seriestype = :heatmap, title = "Native Heatmap"),
    plot(y, seriestype = :heatmapr, title = "Heatmap Recipe"),
    plot(y, seriestype = :heatmap, scale = :log10),
    plot(y, seriestype = :heatmapr, scale = :log10),
    lw = 1,
    layout = (2, 2),
    )
```
for several backends:

**GR**
![heatmap_recipe_gr](https://user-images.githubusercontent.com/16589944/38456060-6a886378-3a80-11e8-831d-1c58fa1d0467.png)

This would fix the logscale problem for heatmaps on GR.

**PyPlot**
![heatmap_recipe_pyplot](https://user-images.githubusercontent.com/16589944/38456061-70cc6630-3a80-11e8-887c-c5e1e1d37ffa.png)

Almost identical output

**PGFPlots**
![heatmap_recipe_pgfplots](https://user-images.githubusercontent.com/16589944/38456062-75d875f6-3a80-11e8-96e0-ba969087b7f4.png)

Finally, a heatmap implementation

**Plotly(JS)**
![heatmap_recipe_plotly](https://user-images.githubusercontent.com/16589944/38456063-7ec0e6d0-3a80-11e8-9a28-58b15233f78b.png)

There's a regression for Plotl(JS) in the interactive view:
Native:
![heatmap_plotly_interactive_old](https://user-images.githubusercontent.com/16589944/38456064-83c89c36-3a80-11e8-8d0f-56fcfd72145c.png)

Recipe:
![heatmap_plotly_interactive_new](https://user-images.githubusercontent.com/16589944/38456070-8780f620-3a80-11e8-8a8d-a6b5a426f282.png)

### More control

Furthermore, this would allow us something like (#1287):
```julia
plot(y, seriestype = :heatmapr,  fα = 0.2:0.2:0.8)
```
(I'm still thinking about allowing to pass a matrix as `fillalpha`, if that's possible)
Here's the output on different backends:

**GR**
![heatmap_advanced_gr](https://user-images.githubusercontent.com/16589944/38456074-906cc39a-3a80-11e8-95b2-c728d9c7f482.png)

**PyPlot**
![heatmap_advanced_pyplot](https://user-images.githubusercontent.com/16589944/38456078-9b1c7aa6-3a80-11e8-8247-42b010d5ca65.png)

**PGFPlots**
![heatmap_advanced_pgfplots](https://user-images.githubusercontent.com/16589944/38456080-9e911430-3a80-11e8-9e1f-58bab3a5f83e.png)

**Plotly(JS)**
![heatmap_advanced_plotly](https://user-images.githubusercontent.com/16589944/38456083-a3a87738-3a80-11e8-8608-0e83ccd93640.png)

### Benchmarks

There comes the downside:
Here's the output of
```julia
using BenchmarkTools
@benchmark display(plot(y, seriestype = :heatmap))
@benchmark display(plot(y, seriestype = :heatmapr))
```
for several backends:

**GR**
Native:
```julia
BenchmarkTools.Trial:
  memory estimate:  5.55 MiB
  allocs estimate:  221728
  --------------
  minimum time:     72.282 ms (0.00% GC)
  median time:      142.958 ms (0.00% GC)
  mean time:        150.112 ms (1.54% GC)
  maximum time:     217.139 ms (0.00% GC)
  --------------
  samples:          34
  evals/sample:     1
```
Recipe:
```julia
BenchmarkTools.Trial:
  memory estimate:  8.26 MiB
  allocs estimate:  306245
  --------------
  minimum time:     61.424 ms (0.00% GC)
  median time:      82.728 ms (0.00% GC)
  mean time:        89.293 ms (3.18% GC)
  maximum time:     214.373 ms (2.98% GC)
  --------------
  samples:          56
  evals/sample:     1
```

**PyPlot**
Native:
```julia
BenchmarkTools.Trial:
  memory estimate:  2.44 MiB
  allocs estimate:  88155
  --------------
  minimum time:     407.102 ms (0.00% GC)
  median time:      503.468 ms (0.00% GC)
  mean time:        517.391 ms (0.17% GC)
  maximum time:     694.881 ms (0.00% GC)
  --------------
  samples:          10
  evals/sample:     1
```
Recipe:
```julia
BenchmarkTools.Trial:
  memory estimate:  8.46 MiB
  allocs estimate:  268626
  --------------
  minimum time:     1.318 s (0.00% GC)
  median time:      1.376 s (0.00% GC)
  mean time:        1.377 s (0.25% GC)
  maximum time:     1.439 s (0.95% GC)
  --------------
  samples:          4
  evals/sample:     1
```

**PGFPlots**
Recipe:
```julia
BenchmarkTools.Trial:
  memory estimate:  14.83 MiB
  allocs estimate:  307429
  --------------
  minimum time:     10.571 s (0.00% GC)
  median time:      10.571 s (0.00% GC)
  mean time:        10.571 s (0.00% GC)
  maximum time:     10.571 s (0.00% GC)
  --------------
  samples:          1
  evals/sample:     1
```

**PlotlyJS**
Native:
```julia
BenchmarkTools.Trial:
  memory estimate:  4.43 MiB
  allocs estimate:  162473
  --------------
  minimum time:     145.293 ms (0.00% GC)
  median time:      194.977 ms (0.00% GC)
  mean time:        195.806 ms (1.22% GC)
  maximum time:     225.369 ms (5.02% GC)
  --------------
  samples:          26
  evals/sample:     1
```
Recipe:
```julia
BenchmarkTools.Trial:
  memory estimate:  105.84 MiB
  allocs estimate:  2623521
  --------------
  minimum time:     8.184 s (0.49% GC)
  median time:      8.184 s (0.49% GC)
  mean time:        8.184 s (0.49% GC)
  maximum time:     8.184 s (0.49% GC)
  --------------
  samples:          1
  evals/sample:     1
```

**Plotly**
Native:
```julia
BenchmarkTools.Trial:
  memory estimate:  3.76 MiB
  allocs estimate:  148744
  --------------
  minimum time:     222.058 ms (0.00% GC)
  median time:      318.871 ms (0.00% GC)
  mean time:        317.100 ms (0.93% GC)
  maximum time:     384.451 ms (0.00% GC)
  --------------
  samples:          16
  evals/sample:     1
```
Recipe:
```julia
BenchmarkTools.Trial:
  memory estimate:  8.97 MiB
  allocs estimate:  277455
  --------------
  minimum time:     256.525 ms (0.00% GC)
  median time:      393.302 ms (0.00% GC)
  mean time:        382.719 ms (1.61% GC)
  maximum time:     425.111 ms (0.00% GC)
  --------------
  samples:          14
  evals/sample:     1
```
### Conclusion

The recipe is really slow for PGFPlots and PlotlyJS. For all other backends there's still a regression.

I'd vote for implementing the recipe for GR (quite fast) and PGFPlots (no alternative implementation) and keeping the native implementation for Plotly(JS) (regression in interactivity and extremly slow for PlotlyJS). I'm not sure about PyPlot, but I think having control about individual alphas is not as desirable as being almost three times as fast in general. Furthermore, for bigger matrices this regression in speed might be more significant.
An alternative would be to keep the native implementation and the `:heatmapr` recipe (maybe with a better name) and let the user decide. This would give more control, but may be to confusing.

I'm really excited to hear about your opinions!