### PR TITLE
Add support for Surface plots.

### DIFF
--- a/src/backends/hdf5.jl
+++ b/src/backends/hdf5.jl
@@ -167,6 +167,7 @@ function _initialize_backend(::HDF5Backend)
 #                "PLOTTEXT" => PlotText,
                 "COLORGRADIENT" => ColorGradient,
                 "AXIS" => Axis,
+                "SURFACE" => Surface,
                 "SUBPLOT" => Subplot,
                 "NULLABLE" => Nullable,
             )
@@ -407,6 +408,11 @@ function _hdf5plot_gwrite(grp, k::String, v::Axis)
     _hdf5plot_writetype(grp, Axis)
     return
 end
+function _hdf5plot_gwrite(grp, k::String, v::Surface)
+	grp = HDF5.g_create(grp, k)
+	_hdf5plot_gwrite(grp, "data2d", v.surf)
+	_hdf5plot_writetype(grp, Surface)
+end
 #TODO: "Properly" support Nullable using _hdf5plot_writetype?
 function _hdf5plot_gwrite(grp, k::String, v::Nullable)
     if isnull(v)
@@ -576,6 +582,11 @@ function _hdf5plot_read(grp, k::String, T::Type{Axis}, dtid)
     kwlist = KW()
     _hdf5plot_read(grp, kwlist)
     return Axis([], kwlist)
+end
+function _hdf5plot_read(grp, k::String, T::Type{Surface}, dtid)
+    grp = HDF5.g_open(grp, k)
+    data2d = _hdf5plot_read(grp, "data2d")
+    return Surface(data2d)
 end
 function _hdf5plot_read(grp, k::String, T::Type{Subplot}, dtid)
     grp = HDF5.g_open(grp, k)


### PR DESCRIPTION
Should work... but unable to verify.

The example provided in https://github.com/JuliaPlots/Plots.jl/issues/1470 does not run with the current version of GR.  I also cannot get PyPlot to work at the moment.

I have confirmed that I can re-load the plot by using:
```
#[...] Code from Issue 1470
Plots.hdf5plot_write(p, "temp.hdf5");

#"Replay" saved .hdf5 file
inspectdr() #Does not actually support Surface plots, but...
#gr() #Current version does not appear to plot provided surface example.
pread = Plots.hdf5plot_read("temp.hdf5") #Seems to return valid object
```
The added functions are very unlikely to break any current code.

@goldnd: Do you mind testing out the solution with your configuration?