### PR TITLE
Make series of shapes and segments toggle together in plotly[js] (fixes #1488)

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -388,6 +388,7 @@ function plotly_layout(plt::Plot)
                 :bgcolor  => rgba_string(sp[:background_color_legend]),
                 :bordercolor => rgba_string(sp[:foreground_color_legend]),
                 :font     => plotly_font(legendfont(sp)),
+                :tracegroupgap => 0,
                 :x => xpos,
                 :y => ypos
             )
@@ -678,7 +679,7 @@ function plotly_series_shapes(plt::Plot, series::Series)
     base_d[:xaxis] = "x$(x_idx)"
     base_d[:yaxis] = "y$(y_idx)"
     base_d[:name] = series[:label]
-    # base_d[:legendgroup] = series[:label]
+    base_d[:legendgroup] = series[:label]
 
     x, y = (plotly_data(series, letter, data) 
         for (letter, data) in zip((:x, :y), shape_data(series))
@@ -733,6 +734,7 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z)
 
         d_out = deepcopy(d_base)
         d_out[:showlegend] = i==1 ? should_add_to_legend(series) : false
+        d_out[:legendgroup] = series[:label]
 
         # set the type
         if st in (:path, :scatter, :scattergl, :straightline)


### PR DESCRIPTION
As series of segments or shapes generate one trace per segment/shape in the plotly (and plotlyjs) backend, only the first trace is shown in the legend to avoid duplicate entries. As a result, the visibility of only the first trace is toggled when the corresponding entry in the legend is clicked.

This can be fixed by adding all traces to the same `legendgroup`. This attribute is otherwise unused by Plots.jl and AFAIK cannot be used manually by the user. However, plotly.js adds a gap between legend groups by default, which can be avoided by setting `layout.legend.tracegroupgap` to 0 by default (this attribute is similarly unused).

I ran the plotlyjs backend tests once for master (to update the reference images) and once for this fix, and there seem to be no differences (after setting `tracegroupgap` to 0).