### PR TITLE
fix marker arguments (fix #1503 fix #1505)

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1532,7 +1532,7 @@ function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
     elseif d[:markerstrokecolor] == :auto
         getSeriesRGBColor(plot_color(d[:markercolor], d[:markeralpha]), sp, plotIndex)
     else
-        getSeriesRGBColor(plot_color(d[:markerstrokecolor], d[:markerstrokealpha]), sp, plotIndex)
+        getSeriesRGBColor.(d[:markerstrokecolor], sp, plotIndex)
     end
 
     # if marker_z, fill_z or line_z are set, ensure we have a gradient

--- a/src/args.jl
+++ b/src/args.jl
@@ -1528,9 +1528,9 @@ function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
 
     # update markerstrokecolor
     d[:markerstrokecolor] = if d[:markerstrokecolor] == :match
-        plot_color(sp[:foreground_color_subplot], d[:markerstrokealpha])
+        plot_color(sp[:foreground_color_subplot])
     elseif d[:markerstrokecolor] == :auto
-        getSeriesRGBColor(plot_color(d[:markercolor], d[:markeralpha]), sp, plotIndex)
+        getSeriesRGBColor.(d[:markercolor], sp, plotIndex)
     else
         getSeriesRGBColor.(d[:markerstrokecolor], sp, plotIndex)
     end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -357,21 +357,15 @@ function gr_draw_markers(series::Series, x, y, msize, mz)
 
             # draw a filled in shape, slightly bigger, to estimate a stroke
             if series[:markerstrokewidth] > 0
-                cfunc(_cycle(series[:markerstrokecolor], i)) #, series[:markerstrokealpha])
+                cfunc(get_markerstrokecolor(series, i))
+                gr_set_transparency(get_markerstrokealpha(series, i))
                 gr_draw_marker(x[i], y[i], msi + series[:markerstrokewidth], shape)
             end
 
-            # draw the shape
-            if mz == nothing
-                cfunc(_cycle(series[:markercolor], i)) #, series[:markeralpha])
-            else
-                # pick a color from the pre-loaded gradient
-                ci = round(Int, 1000 + _cycle(mz, i) * 255)
-                cfuncind(ci)
-                gr_set_transparency(_gr_gradient_alpha[ci-999])
-            end
-            # don't draw filled area if marker shape is 1D
+            # draw the shape - don't draw filled area if marker shape is 1D
             if !(shape in (:hline, :vline, :+, :x))
+                cfunc(get_markercolor(series, i))
+                gr_set_transparency(get_markeralpha(series, i))
                 gr_draw_marker(x[i], y[i], msi, shape)
             end
         end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -353,7 +353,6 @@ function gr_draw_markers(series::Series, x, y, msize, mz)
             msi = _cycle(msize, i)
             shape = _cycle(shapes, i)
             cfunc = isa(shape, Shape) ? gr_set_fillcolor : gr_set_markercolor
-            cfuncind = isa(shape, Shape) ? GR.setfillcolorind : GR.setmarkercolorind
 
             # draw a filled in shape, slightly bigger, to estimate a stroke
             if series[:markerstrokewidth] > 0
@@ -1040,10 +1039,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             end
 
             if series[:markershape] != :none
-                if series[:marker_z] != nothing
-                    zmin, zmax = extrema(series[:marker_z])
-                    GR.setspace(zmin, zmax, 0, 90)
-                end
                 gr_draw_markers(series, x, y, clims)
             end
 

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -175,9 +175,6 @@ function pgf_marker(d, i = 1)
     shape = _cycle(d[:markershape], i)
     cstr, a = pgf_color(plot_color(get_markercolor(d, i), get_markeralpha(d, i)))
     cstr_stroke, a_stroke = pgf_color(plot_color(get_markerstrokecolor(d, i), get_markerstrokealpha(d, i)))
-    if d[:markerstrokealpha] != nothing
-        a_stroke = _cycle(d[:markerstrokealpha], i)
-    end
     """
     mark = $(get(_pgfplots_markers, shape, "*")),
     mark size = $(0.5 * _cycle(d[:markersize], i)),
@@ -219,10 +216,6 @@ function pgf_series(sp::Subplot, series::Series)
         straightline_data(series)
     elseif st == :shape
         shape_data(series)
-    elseif d[:marker_z] != nothing
-        # If a marker_z is used pass it as third coordinate to a 2D plot.
-        # See "Scatter Plots" in PGFPlots documentation
-        d[:x], d[:y], d[:marker_z]
     elseif ispolar(sp)
         theta, r = filter_radial_data(d[:x], d[:y], axis_limits(sp[:yaxis]))
         rad2deg.(theta), r

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -173,11 +173,8 @@ end
 
 function pgf_marker(d, i = 1)
     shape = _cycle(d[:markershape], i)
-    cstr, a = pgf_color(_cycle(d[:markercolor], i))
-    if d[:markeralpha] != nothing
-        a = _cycle(d[:markeralpha], i)
-    end
-    cstr_stroke, a_stroke = pgf_color(_cycle(d[:markerstrokecolor], i))
+    cstr, a = pgf_color(plot_color(get_markercolor(d, i), get_markeralpha(d, i)))
+    cstr_stroke, a_stroke = pgf_color(plot_color(get_markerstrokecolor(d, i), get_markerstrokealpha(d, i)))
     if d[:markerstrokealpha] != nothing
         a_stroke = _cycle(d[:markerstrokealpha], i)
     end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -580,8 +580,18 @@ function plotly_series(plt::Plot, series::Series)
     end
 
     # set the "type"
-    if st in (:path, :scatter, :scattergl, :straightline, :path3d, :scatter3d)
+    if st in (:path, :straightline, :path3d)
         return plotly_series_segments(series, d_out, x, y, z)
+
+    elseif st in (:scatter, :scattergl)
+        d_out[:type] = string(st)
+        d_out[:mode] = hasline ? "lines+markers" : "markers"
+        d_out[:x], d_out[:y] = x, y
+
+    elseif st == :scatter3d
+        d_out[:mode] = string(st)
+        d_out[:mode] = hasline ? "lines+markers" : "markers"
+        d_out[:x], d_out[:y], d_out[:z] = x, y, z
 
     elseif st == :heatmap
         d_out[:type] = "heatmap"
@@ -753,15 +763,14 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z)
 
         # add "marker"
         if hasmarker
-            inds = eachindex(x)
             d_out[:marker] = KW(
-                :symbol => get(_plotly_markers, series[:markershape], string(series[:markershape])),
+                :symbol => get(_plotly_markers, _cycle(series[:markershape], i), string(_cycle(series[:markershape], i))),
                 # :opacity => series[:markeralpha],
-                :size => 2 * series[:markersize],
-                :color => rgba_string.(plot_color.(get_markercolor.(series, inds), get_markeralpha.(series, inds))),
+                :size => 2 * _cycle(series[:markersize], i),
+                :color => rgba_string.(plot_color.(get_markercolor.(series, i), get_markeralpha.(series, i))),
                 :line => KW(
-                    :color => rgba_string.(plot_color.(get_markerstrokecolor.(series, inds), get_markerstrokealpha.(series, inds))),
-                    :width => series[:markerstrokewidth],
+                    :color => rgba_string.(plot_color.(get_markerstrokecolor.(series, i), get_markerstrokealpha.(series, i))),
+                    :width => _cycle(series[:markerstrokewidth], i),
                 ),
             )
         end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -658,7 +658,17 @@ function plotly_series(plt::Plot, series::Series)
     plotly_polar!(d_out, series)
     plotly_hover!(d_out, series[:hover])
 
-    return [d_out]
+    d_outs = [d_out]
+    if series[:marker_z] != nothing
+        d_base = KW(
+            :xaxis => "x$(x_idx)",
+            :yaxis => "y$(y_idx)",
+            :name => series[:label],
+        )
+        push!(d_outs, plotly_colorbar_hack(series, d_base, :marker))
+    end
+
+    return d_outs
 end
 
 function plotly_series_shapes(plt::Plot, series::Series)
@@ -670,11 +680,12 @@ function plotly_series_shapes(plt::Plot, series::Series)
 
     # these are the axes that the series should be mapped to
     x_idx, y_idx = plotly_link_indicies(plt, series[:subplot])
-    base_d = KW()
-    base_d[:xaxis] = "x$(x_idx)"
-    base_d[:yaxis] = "y$(y_idx)"
-    base_d[:name] = series[:label]
-    # base_d[:legendgroup] = series[:label]
+    d_base = KW(
+        :xaxis => "x$(x_idx)",
+        :yaxis => "y$(y_idx)",
+        :name => series[:label],
+    )
+    # d_base[:legendgroup] = series[:label]
 
     x, y = (plotly_data(series, letter, data)
         for (letter, data) in zip((:x, :y), shape_data(series))
@@ -684,7 +695,7 @@ function plotly_series_shapes(plt::Plot, series::Series)
         length(rng) < 2 && continue
 
         # to draw polygons, we actually draw lines with fill
-        d_out = merge(base_d, KW(
+        d_out = merge(d_base, KW(
             :type => "scatter",
             :mode => "lines",
             :x => vcat(x[rng], x[rng[1]]),
@@ -705,11 +716,11 @@ function plotly_series_shapes(plt::Plot, series::Series)
         d_outs[i] = d_out
     end
     if series[:fill_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, base_d, :fill))
+        push!(d_outs, plotly_colorbar_hack(series, d_base, :fill))
     elseif series[:line_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, base_d, :line))
+        push!(d_outs, plotly_colorbar_hack(series, d_base, :line))
     elseif series[:marker_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, base_d, :marker))
+        push!(d_outs, plotly_colorbar_hack(series, d_base, :marker))
     end
     d_outs
 end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -646,11 +646,11 @@ function plotly_series(plt::Plot, series::Series)
         d_out[:marker] = KW(
             :symbol => get(_plotly_markers, series[:markershape], string(series[:markershape])),
             # :opacity => series[:markeralpha],
-            :size => 2 * series[:markersize],
+            :size => 2 * _cycle(series[:markersize], inds),
             :color => rgba_string.(plot_color.(get_markercolor.(series, inds), get_markeralpha.(series, inds))),
             :line => KW(
                 :color => rgba_string.(plot_color.(get_markerstrokecolor.(series, inds), get_markerstrokealpha.(series, inds))),
-                :width => series[:markerstrokewidth],
+                :width => _cycle(series[:markerstrokewidth], inds),
             ),
         )
     end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -580,18 +580,8 @@ function plotly_series(plt::Plot, series::Series)
     end
 
     # set the "type"
-    if st in (:path, :straightline, :path3d)
+    if st in (:path, :scatter, :scattergl, :straightline, :path3d, :scatter3d)
         return plotly_series_segments(series, d_out, x, y, z)
-
-    elseif st in (:scatter, :scattergl)
-        d_out[:type] = string(st)
-        d_out[:mode] = hasline ? "lines+markers" : "markers"
-        d_out[:x], d_out[:y] = x, y
-
-    elseif st == :scatter3d
-        d_out[:mode] = string(st)
-        d_out[:mode] = hasline ? "lines+markers" : "markers"
-        d_out[:x], d_out[:y], d_out[:z] = x, y, z
 
     elseif st == :heatmap
         d_out[:type] = "heatmap"
@@ -658,17 +648,7 @@ function plotly_series(plt::Plot, series::Series)
     plotly_polar!(d_out, series)
     plotly_hover!(d_out, series[:hover])
 
-    d_outs = [d_out]
-    if series[:marker_z] != nothing
-        d_base = KW(
-            :xaxis => "x$(x_idx)",
-            :yaxis => "y$(y_idx)",
-            :name => series[:label],
-        )
-        push!(d_outs, plotly_colorbar_hack(series, d_base, :marker))
-    end
-
-    return d_outs
+    return [d_out]
 end
 
 function plotly_series_shapes(plt::Plot, series::Series)
@@ -738,7 +718,7 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z)
     d_outs = Vector{KW}((hasfillrange ? 2 : 1 ) * length(segments))
 
     for (i,rng) in enumerate(segments)
-        length(rng) < 2 && continue
+        !isscatter && length(rng) < 2 && continue
 
         d_out = deepcopy(d_base)
         d_out[:showlegend] = i==1 ? should_add_to_legend(series) : false
@@ -778,9 +758,9 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z)
                 :symbol => get(_plotly_markers, _cycle(series[:markershape], i), string(_cycle(series[:markershape], i))),
                 # :opacity => series[:markeralpha],
                 :size => 2 * _cycle(series[:markersize], i),
-                :color => rgba_string.(plot_color.(get_markercolor.(series, i), get_markeralpha.(series, i))),
+                :color => rgba_string(plot_color(get_markercolor(series, i), get_markeralpha(series, i))),
                 :line => KW(
-                    :color => rgba_string.(plot_color.(get_markerstrokecolor.(series, i), get_markerstrokealpha.(series, i))),
+                    :color => rgba_string(plot_color(get_markerstrokecolor(series, i), get_markerstrokealpha(series, i))),
                     :width => _cycle(series[:markerstrokewidth], i),
                 ),
             )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -691,7 +691,7 @@ function has_attribute_segments(series::Series)
     end
     series[:seriestype] == :shape && return false
     # ... else we check relevant attributes if they have multiple inputs
-    return any((typeof(series[attr]) <: AbstractVector && length(series[attr]) > 1) for attr in [:seriescolor, :seriesalpha, :linecolor, :linealpha, :linewidth, :fillcolor, :fillalpha]) || any(typeof(series[attr]) <: AbstractArray{<:Real} for attr in (:line_z, :fill_z))
+    return any((typeof(series[attr]) <: AbstractVector && length(series[attr]) > 1) for attr in [:seriescolor, :seriesalpha, :linecolor, :linealpha, :linewidth, :fillcolor, :fillalpha, :markercolor, :markeralpha, :markerstrokecolor, :markerstrokealpha]) || any(typeof(series[attr]) <: AbstractArray{<:Real} for attr in (:line_z, :fill_z, :marker_z))
 end
 
 # ---------------------------------------------------------------

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -195,7 +195,11 @@ end
 function iter_segments(series::Series)
     x, y, z = series[:x], series[:y], series[:z]
     if has_attribute_segments(series)
-        return [i:(i + 1) for i in 1:(length(y) - 1)]
+        if series[:seriestype] in (:scatter, :scatter3d)
+            return [[i] for i in 1:length(y)]
+        else
+            return [i:(i + 1) for i in 1:(length(y) - 1)]
+        end
     else
         segs = UnitRange{Int64}[]
         args = is3d(series) ? (x, y, z) : (x, y)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -656,6 +656,31 @@ function get_fillalpha(series, i::Int = 1)
     _cycle(series[:fillalpha], i)
 end
 
+function get_markercolor(series, i::Int = 1)
+    mc = series[:markercolor]
+    mz = series[:marker_z]
+    if mz == nothing
+        isa(mc, ColorGradient) ? mc : _cycle(mc, i)
+    else
+        cmin, cmax = get_clims(series[:subplot])
+        grad = isa(mc, ColorGradient) ? mc : cgrad()
+        grad[clamp((_cycle(mz, i) - cmin) / (cmax - cmin), 0, 1)]
+    end
+end
+
+function get_markeralpha(series, i::Int = 1)
+    _cycle(series[:markeralpha], i)
+end
+
+function get_markerstrokecolor(series, i::Int = 1)
+    msc = series[:markerstrokecolor]
+    isa(msc, ColorGradient) ? msc : _cycle(msc, i)
+end
+
+function get_markerstrokealpha(series, i::Int = 1)
+    _cycle(series[:markerstrokealpha], i)
+end
+
 function has_attribute_segments(series::Series)
     # we want to check if a series needs to be split into segments just because
     # of its attributes


### PR DESCRIPTION
#1467 Introduced some issues with marker arguments (cf. #1503, #1505). Thank you @dpsanders and @cstjean for reporting!

```julia
plotly() # or plotlyjs()
scatter([1], [2])
```
![marker_plotly](https://user-images.githubusercontent.com/16589944/39667158-2448ec8e-50b0-11e8-81ad-6eaa7f2be019.png)


```julia
gr()
scatter([1,2,3], alpha=0.1)
```
![markeralpha_gr](https://user-images.githubusercontent.com/16589944/39667176-64e20d0c-50b0-11e8-8793-23853424668d.png)

Furthermore, other marker arguments should also work fine on GR, Plotly(JS), PyPlot and PGFPlots:
```julia
n = 20; x = 1:n
plot(
    scatter(x.^2, markeralpha = [0.8, 0.2], markercolor = [:orange, :red, :purple], markersize = [5, 8]),
    scatter(x.^2, markeralpha = linspace(1, 0, n), marker_z = sqrt.(x), markersize = 8),
    markerstrokewidth = 0,
    markershape = [:circle, :diamond, :dtriangle, :star5, :square]
    )
```
![marker_arguments](https://user-images.githubusercontent.com/16589944/39667186-9dc678d8-50b0-11e8-89da-4e9bfa20c067.png)
