### PR TITLE
Enable the output shortcuts 'svg', 'pdf', 'ps', 'eps'.

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -62,8 +62,13 @@ export
     ylims,
     zlims,
 
+    # output.jl
     savefig,
     png,
+    svg,
+    pdf,
+    ps,
+    eps,
     gui,
     inline,
     closeall,


### PR DESCRIPTION
Hello,
to solve issue #1502 , I extended the export list of Plots.
With
```
using Plots; gr()
x=rand(101); y=rand(101)+10; z=rand(101)+100;
bar=plot3d(x,y,z)
svg("3D_test_shortcut_svg")
pdf("3D_test_shortcut_pdf")
ps("3D_test_shortcut_ps")
```
I tested 3 of them, assuming eps works with another backend as it is similar.
Verified with 'xpdf' and 'display'.

Cheers,
Thomas
