### PR TITLE
make get_*color functions return plot_color (markercolor in series recipes in GR)

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -624,7 +624,7 @@ function get_linecolor(series, i::Int = 1)
     lc = series[:linecolor]
     lz = series[:line_z]
     if lz == nothing
-        isa(lc, ColorGradient) ? lc : _cycle(lc, i)
+        isa(lc, ColorGradient) ? lc : plot_color(_cycle(lc, i))
     else
         cmin, cmax = get_clims(series[:subplot])
         grad = isa(lc, ColorGradient) ? lc : cgrad()
@@ -648,7 +648,7 @@ function get_fillcolor(series, i::Int = 1)
     fc = series[:fillcolor]
     fz = series[:fill_z]
     if fz == nothing
-        isa(fc, ColorGradient) ? fc : _cycle(fc, i)
+        isa(fc, ColorGradient) ? fc : plot_color(_cycle(fc, i))
     else
         cmin, cmax = get_clims(series[:subplot])
         grad = isa(fc, ColorGradient) ? fc : cgrad()
@@ -664,7 +664,7 @@ function get_markercolor(series, i::Int = 1)
     mc = series[:markercolor]
     mz = series[:marker_z]
     if mz == nothing
-        isa(mc, ColorGradient) ? mc : _cycle(mc, i)
+        isa(mc, ColorGradient) ? mc : plot_color(_cycle(mc, i))
     else
         cmin, cmax = get_clims(series[:subplot])
         grad = isa(mc, ColorGradient) ? mc : cgrad()


### PR DESCRIPTION
Doing
```julia
using Plots
gr()
@recipe function f(::Type{Val{:test}}, x,y,z)
       markercolor := :red
       seriestype := :scatter
       x,y,z
end
plot(1:5, st = :test)
```
used to return
```julia
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: MethodError: no method matching alpha(::Symbol)
Closest candidates are:
  alpha(::ColorTypes.AGray32) at /home/dani/.julia/v0.6/ColorTypes/src/traits.jl:11
  alpha(::ColorTypes.ARGB32) at /home/dani/.julia/v0.6/ColorTypes/src/traits.jl:10
  alpha(::ColorTypes.RGB24) at /home/dani/.julia/v0.6/ColorTypes/src/traits.jl:9
  ...
Stacktrace:
 [1] gr_getcolorind at /home/dani/.julia/v0.6/Plots/src/backends/gr.jl:138 [inlined]
 [2] gr_set_markercolor(::Symbol) at /home/dani/.julia/v0.6/Plots/src/backends/gr.jl:144
 [3] gr_draw_markers(::Plots.Series, ::UnitRange{Int64}, ::UnitRange{Int64}, ::Int64, ::Void) at /home/dani/.julia/v0.6/Plots/src/backends/gr.jl:366
 [4] gr_draw_markers(::Plots.Series, ::UnitRange{Int64}, ::UnitRange{Int64}, ::Tuple{Float64,Float64}) at /home/dani/.julia/v0.6/Plots/src/backends/gr.jl:378
 [5] gr_display(::Plots.Subplot{Plots.GRBackend}, ::Measures.Length{:mm,Float64}, ::Measures.Length{:mm,Float64}, ::Array{Float64,1}) at /home/dani/.julia/v0.6/Plots/src/backends/gr.jl:1042
 [6] gr_display(::Plots.Plot{Plots.GRBackend}, ::String) at /home/dani/.julia/v0.6/Plots/src/backends/gr.jl:587
 [7] _show(::IOContext{Base.AbstractIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.GRBackend}) at /home/dani/.julia/v0.6/Plots/src/backends/gr.jl:1370
 [8] show(::IOContext{Base.AbstractIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.GRBackend}) at /home/dani/.julia/v0.6/Plots/src/output.jl:210
 [9] show(::IOContext{Base.AbstractIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("text/html")}, ::Plots.Plot{Plots.GRBackend}) at /home/dani/.julia/v0.6/Plots/src/output.jl:190
 [10] verbose_show(::Base.AbstractIOBuffer{Array{UInt8,1}}, ::MIME{Symbol("text/html")}, ::Plots.Plot{Plots.GRBackend}) at ./multimedia.jl:42
 [11] #sprint#228(::Void, ::Function, ::Int64, ::Function, ::MIME{Symbol("text/html")}, ::Vararg{Any,N} where N) at ./strings/io.jl:66
 [12] reprmime(::MIME{Symbol("text/html")}, ::Plots.Plot{Plots.GRBackend}) at ./multimedia.jl:61
 [13] stringmime at ./multimedia.jl:83 [inlined]
 [14] render(::Juno.PlotPane, ::Plots.Plot{Plots.GRBackend}) at /home/dani/.julia/v0.6/Plots/src/output.jl:341
 [15] display(::Media.DisplayHook, ::Plots.Plot{Plots.GRBackend}) at /home/dani/.julia/v0.6/Media/src/compat.jl:9
 [16] display(::Plots.Plot{Plots.GRBackend}) at ./multimedia.jl:218
 [17] print_response(::Base.Terminals.TTYTerminal, ::Any, ::Void, ::Bool, ::Bool, ::Void) at ./REPL.jl:144
 [18] print_response(::Base.REPL.LineEditREPL, ::Any, ::Void, ::Bool, ::Bool) at ./REPL.jl:129
 [19] (::Base.REPL.#do_respond#16{Bool,Atom.##150#151,Base.REPL.LineEditREPL,Base.LineEdit.Prompt})(::Base.LineEdit.MIState, ::Base.AbstractIOBuffer{Array{UInt8,1}}, ::Bool) at ./REPL.jl:646
 [20] (::OhMyREPL.Prompt.##25#52)(::Base.LineEdit.MIState, ::Base.REPL.LineEditREPL, ::String) at /home/dani/.julia/v0.6/OhMyREPL/src/repl.jl:227
 [21] (::Base.LineEdit.##13#14{OhMyREPL.Prompt.##25#52,String})(::Base.LineEdit.MIState, ::Base.REPL.LineEditREPL) at ./LineEdit.jl:740
 [22] (::Base.LineEdit.##165#171)(::Base.LineEdit.MIState, ::Base.LineEdit.PrefixSearchState, ::String) at ./LineEdit.jl:1463
 [23] (::Base.LineEdit.##13#14{Base.LineEdit.##165#171,String})(::Base.LineEdit.MIState, ::Base.LineEdit.PrefixSearchState) at ./LineEdit.jl:740
 [24] run_repl(::Base.REPL.LineEditREPL, ::Base.##510#511) at ./REPL.jl:180
```
This fixes this issue.
However, this is only a small workaround for a special case of the bigger issue reported in https://github.com/JuliaPlots/Plots.jl/issues/1520.