### PR TITLE
update series attributes after processing series recipes fix (#1520)

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1473,26 +1473,19 @@ function _replace_linewidth(d::KW)
 end
 
 function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
-    pkg = plt.backend
-    globalIndex = d[:series_plotindex]
-
     # add default values to our dictionary, being careful not to delete what we just added!
     for (k,v) in _series_defaults
         slice_arg!(d, d, k, v, commandIndex, false)
     end
 
-    # this is how many series belong to this subplot
-    # plotIndex = count(series -> series.d[:subplot] === sp && series.d[:primary], plt.series_list)
-    plotIndex = 0
-    for series in sp.series_list
-        if series[:primary]
-            plotIndex += 1
-        end
-    end
-    # plotIndex = count(series -> series[:primary], sp.series_list)
-    if get(d, :primary, true)
-        plotIndex += 1
-    end
+    return d
+end
+
+
+function _update_series_attributes!(d::KW, plt::Plot, sp::Subplot)
+    pkg = plt.backend
+    globalIndex = d[:series_plotindex]
+    plotIndex = _series_index(d, sp)
 
     aliasesAndAutopick(d, :linestyle, _styleAliases, supported_styles(pkg), plotIndex)
     aliasesAndAutopick(d, :markershape, _markerAliases, supported_markers(pkg), plotIndex)
@@ -1561,4 +1554,20 @@ function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
 
     _replace_linewidth(d)
     d
+end
+
+function _series_index(d, sp)
+    idx = 0
+    for series in series_list(sp)
+        if series[:primary]
+            idx += 1
+        end
+        if series == d
+            return idx
+        end
+    end
+    if get(d, :primary, true)
+        idx += 1
+    end
+    return idx
 end

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -398,6 +398,7 @@ function _process_seriesrecipe(plt::Plot, d::KW)
         sp = _prepare_subplot(plt, d)
         _prepare_annotations(sp, d)
         _expand_subplot_extrema(sp, d, st)
+        _update_series_attributes!(d, plt, sp)
         _add_the_series(plt, sp, d)
 
     else


### PR DESCRIPTION
see discussion in #1520.
This reverses the order in the pipeline: first series recipe processing, then updating of markercolor etc. via seriescolor.
I really hope this does not mess anything else up. It would be great if someone could test or review this.