### PR TITLE
Contour plots with x,y in grid (i.e. multi-dimensional array) form

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -638,6 +638,12 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
 
     if st in (:contour, :contour3d)
         z = transpose_z(series, z.surf)
+	if typeof(x)<:Plots.Surface
+            x = Plots.transpose_z(series, x.surf)
+        end
+        if typeof(y)<:Plots.Surface
+            y = Plots.transpose_z(series, y.surf)
+        end
 
         if st == :contour3d
             extrakw[:extend3d] = true

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -327,7 +327,7 @@ end
 
 function _override_seriestype_check(d::KW, st::Symbol)
     # do we want to override the series type?
-    if !is3d(st)
+    if !is3d(st) && !(st in (:contour,:contour3d))
         z = d[:z]
         if !isa(z, Void) && (size(d[:x]) == size(d[:y]) == size(z))
             st = (st == :scatter ? :scatter3d : :path3d)


### PR DESCRIPTION
These small changes allow for x, y in grid form, which is allowed by the PyPlot backend for making contour plots on deformed grids. (Might need some additional checks for other backends, which might not allow this.)