### PR TITLE
restructure some show methods

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -922,8 +922,7 @@ end
 # ----------------------------------------------------------------
 
 
-function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyBackend})
-    prepare_output(plt)
+function _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyBackend})
     write(io, html_head(plt) * html_body(plt))
 end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -922,15 +922,6 @@ end
 # ----------------------------------------------------------------
 
 
-function _show(io::IO, ::MIME"image/png", plt::Plot{PlotlyBackend})
-    # show_png_from_html(io, plt)
-    error("png output from the plotly backend is not supported.  Please use plotlyjs instead.")
-end
-
-function _show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyBackend})
-    error("svg output from the plotly backend is not supported.  Please use plotlyjs instead.")
-end
-
 function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyBackend})
     prepare_output(plt)
     write(io, html_head(plt) * html_body(plt))

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -1,5 +1,5 @@
 @require Revise begin
-    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "plotlyjs.jl")) 
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "plotlyjs.jl"))
 end
 
 # https://github.com/spencerlyon2/PlotlyJS.jl
@@ -88,8 +88,7 @@ end
 
 # ----------------------------------------------------------------
 
-function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend})
-    prepare_output(plt)
+function _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend})
     if isijulia() && !_use_remote[]
         write(io, PlotlyJS.html_body(PlotlyJS.JupyterPlot(plt.o)))
     else

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -212,7 +212,7 @@ end
 
 function _show(io::IO, ::MIME"text/plain", plt::Plot{UnicodePlotsBackend})
     unicodeplots_rebuild(plt)
-    map(show, plt.o)
+    foreach(x -> show(io, x), plt.o)
     nothing
 end
 

--- a/src/output.jl
+++ b/src/output.jl
@@ -195,10 +195,11 @@ function Base.show(io::IO, ::MIME"text/html", plt::Plot)
     end
 end
 
-function _show(io::IO, m, plt::Plot{B}) where B
-    # Base.show_backtrace(STDOUT, backtrace())
-    warn("_show is not defined for this backend. m=", string(m))
+# delegate mimewritable (showable on julia 0.7) to _show instead
+function Base.mimewritable(m::M, plt::P) where {M<:MIME, P<:Plot}
+    return method_exists(_show, Tuple{IO, M, P})
 end
+
 function _display(plt::Plot)
     warn("_display is not defined for this backend.")
 end

--- a/src/output.jl
+++ b/src/output.jl
@@ -157,17 +157,6 @@ end
 
 # ---------------------------------------------------------
 
-const _mimeformats = Dict(
-    "application/eps"         => "eps",
-    "image/eps"               => "eps",
-    "application/pdf"         => "pdf",
-    "image/png"               => "png",
-    "application/postscript"  => "ps",
-    "image/svg+xml"           => "svg",
-    "text/plain"              => "txt",
-    "application/x-tex"       => "tex",
-)
-
 const _best_html_output_type = KW(
     :pyplot => :png,
     :unicodeplots => :txt,
@@ -205,8 +194,10 @@ function _display(plt::Plot)
 end
 
 # for writing to io streams... first prepare, then callback
-for mime in keys(_mimeformats)
-    @eval function Base.show(io::IO, m::MIME{Symbol($mime)}, plt::Plot{B}) where B
+for mime in ("text/plain", "text/html", "image/png", "image/eps", "image/svg+xml",
+             "application/eps", "application/pdf", "application/postscript",
+             "application/x-tex")
+    @eval function Base.show(io::IO, m::MIME{Symbol($mime)}, plt::Plot)
         prepare_output(plt)
         _show(io, m, plt)
     end

--- a/src/output.jl
+++ b/src/output.jl
@@ -177,7 +177,7 @@ const _best_html_output_type = KW(
 )
 
 # a backup for html... passes to svg or png depending on the html_output_format arg
-function Base.show(io::IO, ::MIME"text/html", plt::Plot)
+function _show(io::IO, ::MIME"text/html", plt::Plot)
     output_type = Symbol(plt.attr[:html_output_format])
     if output_type == :auto
         output_type = get(_best_html_output_type, backend_name(plt.backend), :svg)
@@ -191,7 +191,7 @@ function Base.show(io::IO, ::MIME"text/html", plt::Plot)
     elseif output_type == :txt
         show(io, MIME("text/plain"), plt)
     else
-        error("only png or svg allowed. got: $output_type")
+        error("only png or svg allowed. got: $(repr(output_type))")
     end
 end
 
@@ -307,11 +307,6 @@ end
             end
             _extra_mime_info!(plt, out)
             out
-        end
-
-        # default text/plain passes to html... handles Interact issues
-        function Base.show(io::IO, m::MIME"text/plain", plt::Plot)
-            show(io, MIME("text/html"), plt)
         end
 
         ENV["MPLBACKEND"] = "Agg"

--- a/src/output.jl
+++ b/src/output.jl
@@ -284,7 +284,10 @@ end
                 output_type = get(_best_html_output_type, backend_name(plt.backend), :svg)
             end
             out = Dict()
-            if output_type == :png
+            if output_type == :txt
+                mime = "text/plain"
+                out[mime] = sprint(show, MIME(mime), plt)
+            elseif output_type == :png
                 mime = "image/png"
                 out[mime] = base64encode(show, MIME(mime), plt)
             elseif output_type == :svg


### PR DESCRIPTION
First commit forwards `Base.showable` to `_show` instead, since that is what Plots uses.
Second commit removes some `show` method that don't return data in the requested mime type (fix #1529).
Third commit remove `Base.show` methods for plotly and plotlyjs and thus unifies all Plot types show by going through the same `Base.show` -> `prepare_output` -> `Plots._show`. path.