### PR TITLE
only try the pdf -> png convert sometimes

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -218,9 +218,10 @@ closeall() = closeall(backend())
 # ---------------------------------------------------------
 # A backup, if no PNG generation is defined, is to try to make a PDF and use FileIO to convert
 
+const PDFBackends = Union{PGFPlotsBackend,PlotlyJSBackend,PyPlotBackend,InspectDRBackend,GRBackend}
 if is_installed("FileIO")
     @eval import FileIO
-    function _show(io::IO, ::MIME"image/png", plt::Plot)
+    function _show(io::IO, ::MIME"image/png", plt::Plot{<:PDFBackends})
         fn = tempname()
 
         # first save a pdf file


### PR DESCRIPTION
Only try to convert `pdf` -> `png` if the backend supports writing to pdf in the first place.