### PR TITLE
Fix UnicodePlots in IJulia, reuse IJulia.display_dict

### DIFF
--- a/src/backends/hdf5.jl
+++ b/src/backends/hdf5.jl
@@ -240,10 +240,6 @@ end
 
 # ----------------------------------------------------------------
 
-_show(io::IO, mime::MIME"text/plain", plt::Plot{HDF5Backend}) = nothing #Don't show
-
-# ----------------------------------------------------------------
-
 # Display/show the plot (open a GUI window, or browser page, for example).
 function _display(plt::Plot{HDF5Backend})
     msg = "HDF5 interface does not support `display()` function."

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -523,7 +523,6 @@ for (mime, fmt) in _inspectdr_mimeformats_nodpi
         _inspectdr_show(io, mime, _inspectdr_getmplot(plt.o), plt[:size]...)
     end
 end
-_show(io::IO, mime::MIME"text/plain", plt::Plot{InspectDRBackend}) = nothing #Don't show
 
 # ----------------------------------------------------------------
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -922,8 +922,7 @@ end
 # ----------------------------------------------------------------
 
 
-function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyBackend})
-    prepare_output(plt)
+function _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyBackend})
     write(io, html_head(plt) * html_body(plt))
 end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -922,15 +922,6 @@ end
 # ----------------------------------------------------------------
 
 
-function _show(io::IO, ::MIME"image/png", plt::Plot{PlotlyBackend})
-    # show_png_from_html(io, plt)
-    error("png output from the plotly backend is not supported.  Please use plotlyjs instead.")
-end
-
-function _show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyBackend})
-    error("svg output from the plotly backend is not supported.  Please use plotlyjs instead.")
-end
-
 function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyBackend})
     prepare_output(plt)
     write(io, html_head(plt) * html_body(plt))

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -1,5 +1,5 @@
 @require Revise begin
-    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "plotlyjs.jl")) 
+    Revise.track(Plots, joinpath(Pkg.dir("Plots"), "src", "backends", "plotlyjs.jl"))
 end
 
 # https://github.com/spencerlyon2/PlotlyJS.jl
@@ -88,8 +88,7 @@ end
 
 # ----------------------------------------------------------------
 
-function Base.show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend})
-    prepare_output(plt)
+function _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend})
     if isijulia() && !_use_remote[]
         write(io, PlotlyJS.html_body(PlotlyJS.JupyterPlot(plt.o)))
     else

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -212,7 +212,7 @@ end
 
 function _show(io::IO, ::MIME"text/plain", plt::Plot{UnicodePlotsBackend})
     unicodeplots_rebuild(plt)
-    map(show, plt.o)
+    foreach(x -> show(io, x), plt.o)
     nothing
 end
 

--- a/src/output.jl
+++ b/src/output.jl
@@ -195,10 +195,11 @@ function Base.show(io::IO, ::MIME"text/html", plt::Plot)
     end
 end
 
-function _show(io::IO, m, plt::Plot{B}) where B
-    # Base.show_backtrace(STDOUT, backtrace())
-    warn("_show is not defined for this backend. m=", string(m))
+# delegate mimewritable (showable on julia 0.7) to _show instead
+function Base.mimewritable(m::M, plt::P) where {M<:MIME, P<:Plot}
+    return method_exists(_show, Tuple{IO, M, P})
 end
+
 function _display(plt::Plot)
     warn("_display is not defined for this backend.")
 end

--- a/src/output.jl
+++ b/src/output.jl
@@ -218,9 +218,10 @@ closeall() = closeall(backend())
 # ---------------------------------------------------------
 # A backup, if no PNG generation is defined, is to try to make a PDF and use FileIO to convert
 
+const PDFBackends = Union{PGFPlotsBackend,PlotlyJSBackend,PyPlotBackend,InspectDRBackend,GRBackend}
 if is_installed("FileIO")
     @eval import FileIO
-    function _show(io::IO, ::MIME"image/png", plt::Plot)
+    function _show(io::IO, ::MIME"image/png", plt::Plot{<:PDFBackends})
         fn = tempname()
 
         # first save a pdf file

--- a/src/output.jl
+++ b/src/output.jl
@@ -176,25 +176,6 @@ const _best_html_output_type = KW(
     :plotly => :html
 )
 
-# a backup for html... passes to svg or png depending on the html_output_format arg
-function Base.show(io::IO, ::MIME"text/html", plt::Plot)
-    output_type = Symbol(plt.attr[:html_output_format])
-    if output_type == :auto
-        output_type = get(_best_html_output_type, backend_name(plt.backend), :svg)
-    end
-    if output_type == :png
-        # info("writing png to html output")
-        print(io, "<img src=\"data:image/png;base64,", base64encode(show, MIME("image/png"), plt), "\" />")
-    elseif output_type == :svg
-        # info("writing svg to html output")
-        show(io, MIME("image/svg+xml"), plt)
-    elseif output_type == :txt
-        show(io, MIME("text/plain"), plt)
-    else
-        error("only png or svg allowed. got: $output_type")
-    end
-end
-
 # delegate mimewritable (showable on julia 0.7) to _show instead
 function Base.mimewritable(m::M, plt::P) where {M<:MIME, P<:Plot}
     return method_exists(_show, Tuple{IO, M, P})
@@ -307,11 +288,6 @@ end
             end
             _extra_mime_info!(plt, out)
             out
-        end
-
-        # default text/plain passes to html... handles Interact issues
-        function Base.show(io::IO, m::MIME"text/plain", plt::Plot)
-            show(io, MIME("text/html"), plt)
         end
 
         ENV["MPLBACKEND"] = "Agg"

--- a/src/output.jl
+++ b/src/output.jl
@@ -211,6 +211,9 @@ for mime in keys(_mimeformats)
     end
 end
 
+# default text/plain for all backends
+_show(io::IO, ::MIME{Symbol("text/plain")}, plt::Plot) = show(io, plt)
+
 "Close all open gui windows of the current backend"
 closeall() = closeall(backend())
 
@@ -322,9 +325,6 @@ end
 
     if Juno.isactive()
         Media.media(Plot, Media.Plot)
-
-
-        _show(io::IO, m::MIME"text/plain", plt::Plot{B}) where {B} = print(io, "Plot{$B}()")
 
         function Juno.render(e::Juno.Editor, plt::Plot)
             Juno.render(e, nothing)


### PR DESCRIPTION
First commit makes UnicodePlots print to the given `IO`.
The second commit reuses IJulia's implementation of display_dict instead of Plots rolling its own. We instead use `Base.mimewritable` to "trick" IJulia.

fix #1514

Only the two last commits are relevant for the PR, includes #1535, #1536 and #1537 also.

