### PR TITLE
PyPlot: fix bg_legend = invisible()

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1287,8 +1287,6 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                 loc = get(_pyplot_legend_pos, leg, "best"),
                 scatterpoints = 1,
                 fontsize = py_dpi_scale(plt, sp[:legendfontsize]),
-                # family = sp[:legendfont].family,
-                # framealpha = 0.6,
                 facecolor = py_color(sp[:background_color_legend]),
                 edgecolor = py_color(sp[:foreground_color_legend]),
                 framealpha = alpha(plot_color(sp[:background_color_legend])),
@@ -1296,16 +1294,9 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
             leg[:set_zorder](1000)
             sp[:legendtitle] != nothing && leg[:set_title](sp[:legendtitle])
 
-            # fgcolor = py_color(sp[:foreground_color_legend])
-            lfcolor = py_color(sp[:legendfontcolor])
             for txt in leg[:get_texts]()
-                PyPlot.plt[:setp](txt, color = lfcolor, family = sp[:legendfontfamily])
+                PyPlot.plt[:setp](txt, color = py_color(sp[:legendfontcolor]), family = sp[:legendfontfamily])
             end
-
-            # set some legend properties
-            # frame = leg[:get_frame]()
-            # frame[set_facecolor_sym](py_color(sp[:background_color_legend]))
-            # frame[:set_edgecolor](fgcolor)
         end
     end
 end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1291,7 +1291,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                 # framealpha = 0.6,
                 facecolor = py_color(sp[:background_color_legend]),
                 edgecolor = py_color(sp[:foreground_color_legend]),
-                framealpha = alpha(sp[:background_color_legend]),
+                framealpha = alpha(plot_color(sp[:background_color_legend])),
             )
             leg[:set_zorder](1000)
             sp[:legendtitle] != nothing && leg[:set_title](sp[:legendtitle])

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1282,7 +1282,6 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
 
         # if anything was added, call ax.legend and set the colors
         if !isempty(handles)
-            fgcolor = py_color(sp[:foreground_color_legend])
             leg = ax[:legend](handles,
                 labels,
                 loc = get(_pyplot_legend_pos, leg, "best"),
@@ -1297,6 +1296,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
             leg[:set_zorder](1000)
             sp[:legendtitle] != nothing && leg[:set_title](sp[:legendtitle])
 
+            # fgcolor = py_color(sp[:foreground_color_legend])
             lfcolor = py_color(sp[:legendfontcolor])
             for txt in leg[:get_texts]()
                 PyPlot.plt[:setp](txt, color = lfcolor, family = sp[:legendfontfamily])

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1282,27 +1282,30 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
 
         # if anything was added, call ax.legend and set the colors
         if !isempty(handles)
+            fgcolor = py_color(sp[:foreground_color_legend])
             leg = ax[:legend](handles,
                 labels,
                 loc = get(_pyplot_legend_pos, leg, "best"),
                 scatterpoints = 1,
-                fontsize = py_dpi_scale(plt, sp[:legendfontsize])
-                # family = sp[:legendfont].family
-                # framealpha = 0.6
+                fontsize = py_dpi_scale(plt, sp[:legendfontsize]),
+                # family = sp[:legendfont].family,
+                # framealpha = 0.6,
+                facecolor = py_color(sp[:background_color_legend]),
+                edgecolor = py_color(sp[:foreground_color_legend]),
+                framealpha = alpha(sp[:background_color_legend]),
             )
             leg[:set_zorder](1000)
             sp[:legendtitle] != nothing && leg[:set_title](sp[:legendtitle])
 
-            fgcolor = py_color(sp[:foreground_color_legend])
             lfcolor = py_color(sp[:legendfontcolor])
             for txt in leg[:get_texts]()
                 PyPlot.plt[:setp](txt, color = lfcolor, family = sp[:legendfontfamily])
             end
 
             # set some legend properties
-            frame = leg[:get_frame]()
-            frame[set_facecolor_sym](py_color(sp[:background_color_legend]))
-            frame[:set_edgecolor](fgcolor)
+            # frame = leg[:get_frame]()
+            # frame[set_facecolor_sym](py_color(sp[:background_color_legend]))
+            # frame[:set_edgecolor](fgcolor)
         end
     end
 end


### PR DESCRIPTION
Setting `bg_legend = invisible()` on pyplot did not inherit the subplots background color but set the color of the legend frame to be really `invisible()`. When using a dark theme in Atom for example this shows a dark legend box with the default Plots theme, which is not expected.

This PR fixes the issue by explicitly setting the framealpha of the legend frame in matplotlib as the alpha of the legend background color. This inherits the subplots background color. The downside, however, is that you cannot set the facealpha and the edgealpha separately in matplotlib. Thus, setting `bg_legend = invisible()` also removes the legend frame.

I still think this is an improvement to the current behaviour, but other opinions are very welcome.

Thanks to @davidzentlermunro for reporting on Gitter!