### PR TITLE
fix single subplot in plotly (fix #1485)

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -328,9 +328,11 @@ function plotly_layout(plt::Plot)
 
     d_out[:annotations] = KW[]
 
+    multiple_subplots = length(plt.subplots) > 1
+
     for sp in plt.subplots
-        spidx = sp[:subplot_index]
-        x_idx, y_idx = plotly_link_indicies(plt, sp)
+        spidx = multiple_subplots ? sp[:subplot_index] : ""
+        x_idx, y_idx = multiple_subplots ? plotly_link_indicies(plt, sp) : ("", "") 
         # add an annotation for the title... positioned horizontally relative to plotarea,
         # but vertically just below the top of the subplot bounding box
         if sp[:title] != ""


### PR DESCRIPTION
See #1485. Also tested with
```julia
using Plots
plotly()

p1 = scatter(rand(10), xlims = (0, 5))
p2 = scatter(rand(10), ylims = (0, 0.5))
plot(p1, p2)
```
polar plots, annotations and series annotations, which also use `spidx`.