### PR TITLE
Log-scale heatmap edge computation

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -718,6 +718,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         end
         if st == :heatmap
             outside_ticks = true
+            for ax in (sp[:xaxis], sp[:yaxis])
+                ax[:scale] != :identity && warn("GR: heatmap with $(ax[:scale]) scale not supported.")
+            end
             x, y = heatmap_edges(series[:x], sp[:xaxis][:scale]), heatmap_edges(series[:y], sp[:yaxis][:scale])
             xy_lims = x[1], x[end], y[1], y[end]
             expand_extrema!(sp[:xaxis], x)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -587,6 +587,8 @@ function plotly_series(plt::Plot, series::Series)
         return plotly_series_segments(series, d_out, x, y, z)
 
     elseif st == :heatmap
+        x = heatmap_edges(x, sp[:xaxis][:scale])
+        y = heatmap_edges(y, sp[:yaxis][:scale])
         d_out[:type] = "heatmap"
         d_out[:x], d_out[:y], d_out[:z] = x, y, z
         d_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -358,19 +358,17 @@ const _scale_base = Dict{Symbol, Real}(
     :ln => e,
 )
 
-"create an (n+1) list of the outsides of heatmap rectangles"
-function heatmap_edges(v::AVec, scale::Symbol = :identity)
+function _heatmap_edges(v::AVec)
   vmin, vmax = ignorenan_extrema(v)
   extra_min = extra_max = 0.5 * (vmax-vmin) / (length(v)-1)
-  if scale in _logScales
-      vmin > 0 || error("The axis values must be positive for a $scale scale")
-      while vmin - extra_min <= 0
-          extra_min /= _scale_base[scale]
-      end
-  end
   vcat(vmin-extra_min, 0.5 * (v[1:end-1] + v[2:end]), vmax+extra_max)
 end
 
+"create an (n+1) list of the outsides of heatmap rectangles"
+function heatmap_edges(v::AVec, scale::Symbol = :identity)
+  f, invf = scalefunc(scale), invscalefunc(scale)
+  map(invf, _heatmap_edges(map(f,v)))
+end
 
 function calc_r_extrema(x, y)
     xmin, xmax = ignorenan_extrema(x)


### PR DESCRIPTION
Heat map edge computation in log scale.
Fixes #920 for PyPlot and Plotly{,JS}.
GR seems not to support it natively as far as I can tell (or any heatmap where edges are not equally spaced in linear scale), so I added a warning instead.

```
x = logspace(-1,4,6)
y = logspace(-1,1,5)
z = log10.(x.*y')
p1 = heatmap(log10.(x),log10.(y),z',
             title="(log.(x),log.(y),z) :identity")
p2 = heatmap(x,y,z',
             xscale=:log10,yscale=:log10,
             title="(x,y,z) :log10")
x, y = [0.001,1,5,100], 1:2:10
z = log10.(x.*y')
p3 = heatmap(log10.(x),log10.(y),z')
p4 = heatmap(x,y,z',
             xscale=:log10,yscale=:log10)
plot(p1,p2,p3,p4,colorbar=false)

```

![heatmap-log](https://user-images.githubusercontent.com/4170948/41386721-95b3d8ee-6f8b-11e8-9859-0762e0704e2e.png)
