### PR TITLE
Fix size and dpi for GR and PyPlot

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -65,6 +65,7 @@ const _arg_desc = KW(
 :html_output_format       => "Symbol.  When writing html output, what is the format?  `:png` and `:svg` are currently supported.",
 :inset_subplots 		  => "nothing or vector of 2-tuple (parent,bbox).  optionally pass a vector of (parent,bbox) tuples which are the parent layout and the relative bounding box of inset subplots",
 :dpi 					  => "Number.  Dots Per Inch of output figures",
+:thickness_scaling        => "Number. Scale for the thickness of all line elements like lines, borders, axes, grid lines, ... defaults to 1.",
 :display_type 			  => "Symbol (`:auto`, `:gui`, or `:inline`).  When supported, `display` will either open a GUI window or plot inline.",
 :extra_kwargs 			  => "KW (Dict{Symbol,Any}).  Pass a map of extra keyword args which may be specific to a backend.",
 :fontfamily               => "String or Symbol.  Default font family for title, legend entries, tick labels and guides",

--- a/src/args.jl
+++ b/src/args.jl
@@ -301,6 +301,7 @@ const _plot_defaults = KW(
     :inset_subplots              => nothing,   # optionally pass a vector of (parent,bbox) tuples which are
                                                # the parent layout and the relative bounding box of inset subplots
     :dpi                         => DPI,        # dots per inch for images, etc
+    :thickness_scaling           => 1,
     :display_type                => :auto,
     :extra_kwargs                => KW(),
 )

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -544,7 +544,7 @@ function gr_display(plt::Plot, fmt="")
     GR.clearws()
 
     _gr_thickness_scaling[1] = plt[:thickness_scaling]
-    dpi_factor = plt[:dpi] ./ Plots.DPI
+    dpi_factor = plt[:dpi] / Plots.DPI
 
     # collect some monitor/display sizes in meters and pixels
     display_width_meters, display_height_meters, display_width_px, display_height_px = GR.inqdspsize()

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -383,7 +383,7 @@ end
 function gr_set_line(lw, style, c) #, a)
     GR.setlinetype(gr_linetype[style])
     w, h = gr_plot_size
-    GR.setlinewidth(_gr_dpi_factor[1] * max(0, lw / ((w + h) * 0.001)))
+    GR.setlinewidth(_gr_thickness_scaling[1] * max(0, lw / ((w + h) * 0.001)))
     gr_set_linecolor(c) #, a)
 end
 
@@ -396,7 +396,7 @@ end
 
 # this stores the conversion from a font pointsize to "percentage of window height" (which is what GR uses)
 const _gr_point_mult = 0.0018 * ones(1)
-const _gr_dpi_factor = ones(1)
+const _gr_thickness_scaling = ones(1)
 
 # set the font attributes... assumes _gr_point_mult has been populated already
 function gr_set_font(f::Font; halign = f.halign, valign = f.valign,
@@ -543,7 +543,7 @@ end
 function gr_display(plt::Plot, fmt="")
     GR.clearws()
 
-    _gr_dpi_factor[1] = plt[:thickness_scaling]
+    _gr_thickness_scaling[1] = plt[:thickness_scaling]
     dpi_factor = plt[:dpi] ./ Plots.DPI
 
     # collect some monitor/display sizes in meters and pixels
@@ -576,7 +576,7 @@ function gr_display(plt::Plot, fmt="")
 
     # update point mult
     px_per_pt = px / pt
-    _gr_point_mult[1] = 1.5 * _gr_dpi_factor[1] * px_per_pt / max(h,w)
+    _gr_point_mult[1] = 1.5 * _gr_thickness_scaling[1] * px_per_pt / max(h,w)
 
     # subplots:
     for sp in plt.subplots

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -395,7 +395,7 @@ function py_bbox_title(ax)
 end
 
 function py_dpi_scale(plt::Plot{PyPlotBackend}, ptsz)
-    ptsz * plt[:dpi] / DPI
+    ptsz * plt[:thickness_scaling]
 end
 
 # ---------------------------------------------------------------------------
@@ -955,7 +955,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
     w, h = plt[:size]
     fig = plt.o
     fig[:clear]()
-    dpi = plt[:dpi]
+    dpi = 100 * plt[:dpi] / DPI
     fig[:set_size_inches](w/dpi, h/dpi, forward = true)
     fig[set_facecolor_sym](py_color(plt[:background_color_outside]))
     fig[:set_dpi](dpi)
@@ -1358,7 +1358,7 @@ for (mime, fmt) in _pyplot_mimeformats
             # figsize = map(px2inch, plt[:size]),
             facecolor = fig[:get_facecolor](),
             edgecolor = "none",
-            dpi = plt[:dpi]
+            dpi = 100 * plt[:dpi] / DPI
         )
     end
 end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -402,7 +402,7 @@ end
 
 # Create the window/figure for this backend.
 function _create_backend_figure(plt::Plot{PyPlotBackend})
-    w,h = map(px2inch, plt[:size])
+    w,h = map(px2inch, Tuple(s * plt[:dpi] / Plots.DPI for s in plt[:size]))
 
     # # reuse the current figure?
     fig = if plt[:overwrite_figure]
@@ -955,10 +955,10 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
     w, h = plt[:size]
     fig = plt.o
     fig[:clear]()
-    dpi = 100 * plt[:thickness_scaling] * plt[:dpi] / DPI
-    fig[:set_size_inches](w/dpi, h/dpi, forward = true)
+    dpi = plt[:thickness_scaling] * plt[:dpi]
+    fig[:set_size_inches](w/DPI/plt[:thickness_scaling], h/DPI/plt[:thickness_scaling], forward = true)
     fig[set_facecolor_sym](py_color(plt[:background_color_outside]))
-    fig[:set_dpi](dpi)
+    fig[:set_dpi](plt[:dpi])
 
     # resize the window
     PyPlot.plt[:get_current_fig_manager]()[:resize](w, h)
@@ -1209,7 +1209,9 @@ function _update_min_padding!(sp::Subplot{PyPlotBackend})
     rightpad  += sp[:right_margin]
     bottompad += sp[:bottom_margin]
 
-    sp.minpad = (leftpad, toppad, rightpad, bottompad)
+    dpi_factor = sp.plt[:thickness_scaling] * Plots.DPI / sp.plt[:dpi]
+
+    sp.minpad = Tuple(dpi_factor .* [leftpad, toppad, rightpad, bottompad])
 end
 
 
@@ -1358,7 +1360,7 @@ for (mime, fmt) in _pyplot_mimeformats
             # figsize = map(px2inch, plt[:size]),
             facecolor = fig[:get_facecolor](),
             edgecolor = "none",
-            dpi = 100 * plt[:thickness_scaling] * plt[:dpi] / DPI
+            dpi = plt[:dpi] * plt[:thickness_scaling]
         )
     end
 end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -395,7 +395,7 @@ function py_bbox_title(ax)
 end
 
 function py_dpi_scale(plt::Plot{PyPlotBackend}, ptsz)
-    ptsz * plt[:thickness_scaling]
+    ptsz
 end
 
 # ---------------------------------------------------------------------------
@@ -955,7 +955,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
     w, h = plt[:size]
     fig = plt.o
     fig[:clear]()
-    dpi = 100 * plt[:dpi] / DPI
+    dpi = 100 * plt[:thickness_scaling] * plt[:dpi] / DPI
     fig[:set_size_inches](w/dpi, h/dpi, forward = true)
     fig[set_facecolor_sym](py_color(plt[:background_color_outside]))
     fig[:set_dpi](dpi)
@@ -1358,7 +1358,7 @@ for (mime, fmt) in _pyplot_mimeformats
             # figsize = map(px2inch, plt[:size]),
             facecolor = fig[:get_facecolor](),
             edgecolor = "none",
-            dpi = 100 * plt[:dpi] / DPI
+            dpi = 100 * plt[:thickness_scaling] * plt[:dpi] / DPI
         )
     end
 end

--- a/src/output.jl
+++ b/src/output.jl
@@ -325,16 +325,19 @@ end
                 # temporarily overwrite size to be Atom.plotsize
                 sz = plt[:size]
                 dpi = plt[:dpi]
+                thickness_scaling = plt[:thickness_scaling]
                 jsize = Juno.plotsize()
                 jsize[1] == 0 && (jsize[1] = 400)
                 jsize[2] == 0 && (jsize[2] = 500)
 
                 scale = minimum(jsize[i] / sz[i] for i in 1:2)
                 plt[:size] = (s * scale for s in sz)
-                plt[:dpi] *= scale
+                plt[:dpi] = 100
+                plt[:thickness_scaling] *= scale
                 Juno.render(pane, HTML(stringmime(MIME("text/html"), plt)))
                 plt[:size] = sz
                 plt[:dpi] = dpi
+                plt[:thickness_scaling] = thickness_scaling
             end
             # special handling for PlotlyJS
             function Juno.render(pane::Juno.PlotPane, plt::Plot{PlotlyJSBackend})

--- a/src/output.jl
+++ b/src/output.jl
@@ -324,13 +324,17 @@ end
             function Juno.render(pane::Juno.PlotPane, plt::Plot)
                 # temporarily overwrite size to be Atom.plotsize
                 sz = plt[:size]
+                dpi = plt[:dpi]
                 jsize = Juno.plotsize()
                 jsize[1] == 0 && (jsize[1] = 400)
                 jsize[2] == 0 && (jsize[2] = 500)
 
-                plt[:size] = jsize
+                scale = minimum(jsize[i] / sz[i] for i in 1:2)
+                plt[:size] = (s * scale for s in sz)
+                plt[:dpi] *= scale
                 Juno.render(pane, HTML(stringmime(MIME("text/html"), plt)))
                 plt[:size] = sz
+                plt[:dpi] = dpi
             end
             # special handling for PlotlyJS
             function Juno.render(pane::Juno.PlotPane, plt::Plot{PlotlyJSBackend})

--- a/src/output.jl
+++ b/src/output.jl
@@ -332,7 +332,7 @@ end
 
                 scale = minimum(jsize[i] / sz[i] for i in 1:2)
                 plt[:size] = (s * scale for s in sz)
-                plt[:dpi] = 100
+                plt[:dpi] = Plots.DPI
                 plt[:thickness_scaling] *= scale
                 Juno.render(pane, HTML(stringmime(MIME("text/html"), plt)))
                 plt[:size] = sz


### PR DESCRIPTION
This tries to address the issues discussed in https://github.com/JuliaPlots/Plots.jl/issues/653, https://github.com/JuliaPlots/Plots.jl/issues/733, https://github.com/JuliaPlots/Plots.jl/pull/740, https://github.com/JuliaPlots/Plots.jl/issues/742, https://github.com/JuliaPlots/Plots.jl/issues/891, https://github.com/JuliaPlots/Plots.jl/issues/897, https://github.com/JuliaPlots/Plots.jl/issues/960 and https://github.com/JuliaPlots/Plots.jl/issues/1355.

`:dpi` increases both, plot size in pixels and line thicknesses, now on GR and PyPlot. The new plot attribute `:thickness_scaling::Real = 1` scales only the line thicknesses. So these commands produce the same plot:

```julia
x = rand(10)
plot(x, dpi = 100, size = (600, 400), thickness_scaling = 1) # default
plot(x, dpi = 200, size = (300, 200), thickness_scaling = 0.5)
plot(x, dpi = 50, size = (1200, 800), thickness_scaling = 2)
```

![gr_default](https://user-images.githubusercontent.com/16589944/41501089-d8b1ceda-719d-11e8-864d-1f1cbb491735.png)

Furthermore this PR changes the Juno preview integration to show the plot in the correct aspect ratio and respectively scaled line thicknesses to match the saved files.

I'm not really sure if that is the correct dpi interpretation now. Hence, pinging @ma-laforge, @mkborregaard, @jheinen, @juliohm

