### PR TITLE
New attributes for PGFPlots

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -384,12 +384,9 @@ function pgf_axis(sp::Subplot, letter)
     # axis guide
     kw[Symbol(letter,:label)] = axis[:guide]
 
-    # Add ticklabel rotations
-    push!(style, "$(letter)ticklabel style={rotate = $(axis[:rotation])}")
-
     # Add label font
     cstr, α = pgf_color(plot_color(axis[:guidefontcolor]))
-    push!(style, string(letter, "label style = {font = ", pgf_font(axis[:guidefontsize], pgf_thickness_scaling(sp)), ", color = ", cstr, ", draw opacity = ", α, "}"))
+    push!(style, string(letter, "label style = {font = ", pgf_font(axis[:guidefontsize], pgf_thickness_scaling(sp)), ", color = ", cstr, ", draw opacity = ", α, ", rotate = ", axis[:guidefontrotation], "}"))
 
     # flip/reverse?
     axis[:flip] && push!(style, "$letter dir=reverse")
@@ -446,7 +443,7 @@ function pgf_axis(sp::Subplot, letter)
         end
         push!(style, string(letter, "tick align = ", (axis[:tick_direction] == :out ? "outside" : "inside")))
         cstr, α = pgf_color(plot_color(axis[:tickfontcolor]))
-        push!(style, string(letter, "ticklabel style = {font = ", pgf_font(axis[:tickfontsize], pgf_thickness_scaling(sp)), ", color = ", cstr, ", draw opacity = ", α, "}"))
+        push!(style, string(letter, "ticklabel style = {font = ", pgf_font(axis[:tickfontsize], pgf_thickness_scaling(sp)), ", color = ", cstr, ", draw opacity = ", α, ", rotate = ", axis[:tickfontrotation], "}"))
         push!(style, string(letter, " grid style = {", pgf_linestyle(pgf_thickness_scaling(sp) * axis[:gridlinewidth], axis[:foreground_color_grid], axis[:gridalpha], axis[:gridstyle]), "}"))
     end
 
@@ -515,7 +512,7 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
         if sp[:title] != ""
             kw[:title] = "$(sp[:title])"
             cstr, α = pgf_color(plot_color(sp[:titlefontcolor]))
-            push!(style, string("title style = {font = ", pgf_font(sp[:titlefontsize], pgf_thickness_scaling(sp)), ", color = ", cstr, ", draw opacity = ", α, "}"))
+            push!(style, string("title style = {font = ", pgf_font(sp[:titlefontsize], pgf_thickness_scaling(sp)), ", color = ", cstr, ", draw opacity = ", α, ", rotate = ", sp[:titlefontrotation], "}"))
         end
 
         if sp[:aspect_ratio] in (1, :equal)

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -149,6 +149,10 @@ function pgf_colormap(grad::ColorGradient)
     end,", ")
 end
 
+pgf_thickness_scaling(plt::Plot) = plt[:thickness_scaling] * plt[:dpi] / DPI
+pgf_thickness_scaling(sp::Subplot) = pgf_thickness_scaling(sp.plt)
+pgf_thickness_scaling(series) = pgf_thickness_scaling(series[:subplot])
+
 function pgf_fillstyle(d, i = 1)
     cstr,a = pgf_color(get_fillcolor(d, i))
     fa = get_fillalpha(d, i)
@@ -167,7 +171,7 @@ function pgf_linestyle(d, i = 1)
     """
     color = $cstr,
     draw opacity=$a,
-    line width=$(get_linewidth(d, i)),
+    line width=$(pgf_thickness_scaling(d) * get_linewidth(d, i)),
     $(get(_pgfplots_linestyles, get_linestyle(d, i), "solid"))"""
 end
 
@@ -177,11 +181,11 @@ function pgf_marker(d, i = 1)
     cstr_stroke, a_stroke = pgf_color(plot_color(get_markerstrokecolor(d, i), get_markerstrokealpha(d, i)))
     """
     mark = $(get(_pgfplots_markers, shape, "*")),
-    mark size = $(0.5 * _cycle(d[:markersize], i)),
+    mark size = $(pgf_thickness_scaling(d) * 0.5 * _cycle(d[:markersize], i)),
     mark options = {
         color = $cstr_stroke, draw opacity = $a_stroke,
         fill = $cstr, fill opacity = $a,
-        line width = $(_cycle(d[:markerstrokewidth], i)),
+        line width = $(pgf_thickness_scaling(d) * _cycle(d[:markerstrokewidth], i)),
         rotate = $(shape == :dtriangle ? 180 : 0),
         $(get(_pgfplots_linestyles, _cycle(d[:markerstrokestyle], i), "solid"))
     }"""

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -201,17 +201,18 @@ function pgf_marker(d, i = 1)
     }"""
 end
 
-function pgf_add_annotation!(o,x,y,val)
+function pgf_add_annotation!(o, x, y, val, thickness_scaling = 1)
     # Construct the style string.
     # Currently supports color and orientation
     cstr,a = pgf_color(val.font.color)
     push!(o, PGFPlots.Plots.Node(val.str, # Annotation Text
-                                 x, y,
-                                 style="""
-                                 $(get(_pgf_annotation_halign,val.font.halign,"")),
-                                 color=$cstr, draw opacity=$(convert(Float16,a)),
-                                 rotate=$(val.font.rotation)
-                                 """))
+        x, y,
+        style="""
+        $(get(_pgf_annotation_halign,val.font.halign,"")),
+        color=$cstr, draw opacity=$(convert(Float16,a)),
+        rotate=$(val.font.rotation),
+        font=$(pgf_font(val.font.pointsize, thickness_scaling))
+        """))
 end
 
 # --------------------------------------------------------------------------------------
@@ -578,13 +579,13 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
             # add series annotations
             anns = series[:series_annotations]
             for (xi,yi,str,fnt) in EachAnn(anns, series[:x], series[:y])
-                pgf_add_annotation!(o, xi, yi, PlotText(str, fnt))
+                pgf_add_annotation!(o, xi, yi, PlotText(str, fnt), pgf_thickness_scaling(series))
             end
         end
 
         # add the annotations
         for ann in sp[:annotations]
-            pgf_add_annotation!(o, locate_annotation(sp, ann...)...)
+            pgf_add_annotation!(o, locate_annotation(sp, ann...)..., pgf_thickness_scaling(sp))
         end
 
 

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -150,7 +150,7 @@ function pgf_colormap(grad::ColorGradient)
     end,", ")
 end
 
-pgf_thickness_scaling(plt::Plot) = plt[:thickness_scaling] * plt[:dpi] / DPI
+pgf_thickness_scaling(plt::Plot) = plt[:thickness_scaling]
 pgf_thickness_scaling(sp::Subplot) = pgf_thickness_scaling(sp.plt)
 pgf_thickness_scaling(series) = pgf_thickness_scaling(series[:subplot])
 


### PR DESCRIPTION
This implements a bunch of new attributes for PGFPLots, like thickness_scaling, font sizes, font colors, font rotations, axes and grid arguments, etc. :
```julia
using Plots; pgfplots()
using Plots; pgfplots()
plot(cumsum(randn(100)),
    thickness_scaling = 2,
    fg_axis = :green,
    xforeground_color_grid = :red,
    xgridalpha = 1,
    ygridstyle = :dot,
    ygridalpha = 1,
    title = "My Plot",
    xlabel = "My x Label",
    ylabel = "My y Label",
    titlefontcolor = :blue,
    tickfontcolor = :cyan,
    guidefontcolor = :magenta,
    size = (900, 900),
    )
```
![pgf_double](https://user-images.githubusercontent.com/16589944/41814328-195fab86-7749-11e8-9c73-d1b50ebbeeb9.png)

`dpi` is not (yet) implemented, but it can be worked around using thickness_scaling and size.
