### PR TITLE
Widen axes for most series types and log scales

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -140,5 +140,6 @@ const _arg_desc = KW(
 :gridstyle                => "Symbol. Style of the grid lines. Choose from $(_allStyles)",
 :gridlinewidth            => "Number. Width of the grid lines (in pixels)",
 :tick_direction           => "Symbol.  Direction of the ticks. `:in` or `:out`",
-:showaxis                 => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`"
+:showaxis                 => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`",
+:widen                    => "Bool. Widen the axis limits by a small factor to avoid cut-off markers and lines at the borders. Defaults to `true`.",
 )

--- a/src/args.jl
+++ b/src/args.jl
@@ -382,6 +382,7 @@ const _axis_defaults = KW(
     :gridlinewidth            => 0.5,
     :tick_direction           => :in,
     :showaxis                 => true,
+    :widen                    => true,
 )
 
 const _suppress_warnings = Set{Symbol}([

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -413,6 +413,7 @@ end
     z := nothing
     seriestype := :shape
     label := ""
+    widen --> false
     ()
 end
 @deps plots_heatmap shape


### PR DESCRIPTION
Now `plot(rand(10))` changes from
![gr_nowiden](https://user-images.githubusercontent.com/16589944/41821708-cf55fe90-77e4-11e8-9da1-dee2fd2c57de.png)

to
![gr_widen](https://user-images.githubusercontent.com/16589944/41821719-d9943c0a-77e4-11e8-9e2c-b8805047e590.png)

The old behaviour can be achieved with `widen = false`. Some seriestypes, like heatmaps, contour, images, etc. still default to no widening.
