### PR TITLE
Plotly: fix log scale with no ticks

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -263,6 +263,7 @@ function plotly_axis(plt::Plot, axis::Axis, sp::Subplot)
     end
 
     ax[:tickangle] = -axis[:rotation]
+    ax[:type] = plotly_scale(axis[:scale])
     lims = axis_limits(axis)
 
     if axis[:ticks] != :native || axis[:lims] != :auto
@@ -271,7 +272,6 @@ function plotly_axis(plt::Plot, axis::Axis, sp::Subplot)
 
     if !(axis[:ticks] in (nothing, :none, false))
         ax[:titlefont] = plotly_font(guidefont(axis))
-        ax[:type] = plotly_scale(axis[:scale])
         ax[:tickfont] = plotly_font(tickfont(axis))
         ax[:tickcolor] = framestyle in (:zerolines, :grid) || !axis[:showaxis] ? rgba_string(invisible()) : rgb_string(axis[:foreground_color_axis])
         ax[:linecolor] = rgba_string(axis[:foreground_color_axis])


### PR DESCRIPTION
Plotly backend currently does not set the axis scale unless ticks are present.
Fixed by setting the axis scale unconditionally.
```
using Plots; plotlyjs()
plot(1:10,1:10,xscale=:log10,xticks=nothing)
```
Before:
![plot-noticks-bug](https://user-images.githubusercontent.com/4170948/41823992-886dbff4-7811-11e8-8198-37fa2286cf44.png)
After:
![plot-noticks-fix](https://user-images.githubusercontent.com/4170948/41823998-9cabde56-7811-11e8-8c37-cfe8da9296f6.png)

