### PR TITLE
Fix axis flip on Plotly (Fixes #1556)

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -278,7 +278,7 @@ function plotly_axis(plt::Plot, axis::Axis, sp::Subplot)
 
         # flip
         if axis[:flip]
-            ax[:autorange] = "reversed"
+            ax[:range] = reverse(ax[:range])
         end
 
         # ticks


### PR DESCRIPTION
#1556 
```
using Plots; plotlyjs();
plot(0:0.1:π, sin, ylim=(0.2,0.8))
yflip!()
```
![yflip](https://user-images.githubusercontent.com/22132297/41908466-f9573ce2-793b-11e8-8eb8-a1e0ed4c5d6d.png)
