### PR TITLE
Fix hover and zcolor interaction in Plotly (Fixes #1567)

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -789,7 +789,7 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z)
         end
 
         plotly_polar!(d_out, series)
-        plotly_hover!(d_out, series[:hover])
+        plotly_hover!(d_out, _cycle(series[:hover], rng))
 
         if hasfillrange
             # if hasfillrange is true, return two dictionaries (one for original
@@ -840,6 +840,7 @@ function plotly_colorbar_hack(series::Series, d_base::KW, sym::Symbol)
     cmin, cmax = get_clims(series[:subplot])
     d_out[:showlegend] = false
     d_out[:type] = is3d(series) ? :scatter3d : :scatter
+    d_out[:hoverinfo] = :none
     d_out[:mode] = :markers
     d_out[:x], d_out[:y] = [series[:x][1]], [series[:y][1]]
     if is3d(series)
@@ -848,6 +849,7 @@ function plotly_colorbar_hack(series::Series, d_base::KW, sym::Symbol)
     # zrange = zmax == zmin ? 1 : zmax - zmin # if all marker_z values are the same, plot all markers same color (avoids division by zero in next line)
     d_out[:marker] = KW(
         :size => 0,
+        :opacity => 0,
         :color => [0.5],
         :cmin => cmin,
         :cmax => cmax,


### PR DESCRIPTION
#1567 

Should be working now 😄 

The extra (1.0, 1.0) hover was from the colorbar hack marker (which is meant to be invisible) not having its hoverinfo suppressed.
For some reason Plotly no longer/doesn't interpret `markersize = 0` as an invisible marker so the hack marker now has zero opacity.

I don't quite fully get how `iter_segments` works so I'm not 100% sure on the `_cycle(series[:hover], rng)` but for scatter it gives the right hover with and without zcolor.  When used with `line_z` eg. `plot([1,2,3], line_z = [1,2], hover = ["a","b"])` the middle point displays two values. Previously these were (a,b) now they are (b,b) which to me makes more sense. I can't think of a way to remove the double display of point though 😟.