### PR TITLE
WebIO integration for PlotlyJS backend

### DIFF
--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -122,7 +122,7 @@ end
 
 @require WebIO begin
     function WebIO.render(plt::Plot{PlotlyJSBackend})
-        _update_plot_object(plt)
+        prepare_output(plt)
         WebIO.render(plt.o)
     end
 end

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -120,6 +120,12 @@ function _display(plt::Plot{PlotlyJSBackend})
     end
 end
 
+@require WebIO begin
+    function WebIO.render(plt::Plot{PlotlyJSBackend})
+        _update_plot_object(plt)
+        WebIO.render(plt.o)
+    end
+end
 
 function closeall(::PlotlyJSBackend)
     if !isplotnull() && isa(current().o, PlotlyJS.SyncPlot)


### PR DESCRIPTION
This allows integrating plots with PlotlyJS backend smoothly in apps made with WebIO (in Blink, Juno, Julia and JupyterLab). It's the Plots.jl counterpart of [this PR](https://github.com/sglyon/PlotlyJS.jl/pull/193).

For example:

```julia
using WebIO, Plots
plotlyjs()
dom"div"(
  "A static plot",
  plot(rand(10)),
  "An updating plot",
  @manipulate for n in 1:10
    scatter(rand(n))
  end
)
```