### PR TITLE
Fix display on Juno 0.7

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -624,7 +624,7 @@ end
 function _update_min_padding!(sp::Subplot{GRBackend})
     dpi = sp.plt[:thickness_scaling]
     if !haskey(ENV, "GKSwstype")
-        if isijulia() || (isdefined(Main, :Juno) && Juno.isactive())
+        if isijulia()
             ENV["GKSwstype"] = "svg"
         end
     end


### PR DESCRIPTION
This PR makes Plots.jl compatible with Juno 0.7 on Julia 0.7. The `PLOTS_USE_ATOM_PLOTPANE` environment variable isn't necessary anymore since you can just disable the plot pane from within Juno now.

![image](https://user-images.githubusercontent.com/6735977/43641141-d54a5c3a-9722-11e8-987c-3b6875fef93a.png)
