### PR TITLE
Make xticks!/yticks! behave like plot(xticks!/yticks! = ). (Fixes #1605)

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -236,10 +236,10 @@ zlims!(zmin::Real, zmax::Real; kw...)                     = plot!(; zlims = (zmi
 
 
 "Set xticks for an existing plot"
-xticks!(v::AVec{T}; kw...) where {T<:Real}                       = plot!(; xticks = v, kw...)
+xticks!(v::TicksArgs; kw...) where {T<:Real}                       = plot!(; xticks = v, kw...)
 
 "Set yticks for an existing plot"
-yticks!(v::AVec{T}; kw...) where {T<:Real}                       = plot!(; yticks = v, kw...)
+yticks!(v::TicksArgs; kw...) where {T<:Real}                       = plot!(; yticks = v, kw...)
 
 xticks!(
 ticks::AVec{T}, labels::AVec{S}; kw...) where {T<:Real,S<:AbstractString}     = plot!(; xticks = (ticks,labels), kw...)
@@ -274,8 +274,8 @@ let PlotOrSubplot = Union{Plot, Subplot}
     global xlims!(plt::PlotOrSubplot, xmin::Real, xmax::Real; kw...)             = plot!(plt; xlims = (xmin,xmax), kw...)
     global ylims!(plt::PlotOrSubplot, ymin::Real, ymax::Real; kw...)             = plot!(plt; ylims = (ymin,ymax), kw...)
     global zlims!(plt::PlotOrSubplot, zmin::Real, zmax::Real; kw...)             = plot!(plt; zlims = (zmin,zmax), kw...)
-    global xticks!(plt::PlotOrSubplot, ticks::AVec{T}; kw...) where {T<:Real}           = plot!(plt; xticks = ticks, kw...)
-    global yticks!(plt::PlotOrSubplot, ticks::AVec{T}; kw...) where {T<:Real}           = plot!(plt; yticks = ticks, kw...)
+    global xticks!(plt::PlotOrSubplot, ticks::TicksArgs; kw...) where {T<:Real}           = plot!(plt; xticks = ticks, kw...)
+    global yticks!(plt::PlotOrSubplot, ticks::TicksArgs; kw...) where {T<:Real}           = plot!(plt; yticks = ticks, kw...)
     global xticks!(plt::PlotOrSubplot,
    ticks::AVec{T}, labels::AVec{S}; kw...) where {T<:Real,S<:AbstractString}     = plot!(plt; xticks = (ticks,labels), kw...)
     global yticks!(plt::PlotOrSubplot,

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,6 +5,7 @@
 const AVec = AbstractVector
 const AMat = AbstractMatrix
 const KW = Dict{Symbol,Any}
+const TicksArgs = Union{AVec{T}, Tuple{AVec{T}, AVec{S}}, Symbol} where {T<:Real, S<:AbstractString}
 
 struct PlotsDisplay <: AbstractDisplay end
 


### PR DESCRIPTION
#1605 

```
p = plot(linspace(0, π, 20), rand(20))
xticks!(p, ([0, pi/4, pi/2, 3pi/4, pi],
            ["0", "pi/4", "pi/2", "3pi/4", "pi"]))
```
Also things like `xticks!(:auto)` will now work as well.