### PR TITLE
More fixes for Julia v1.0

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -506,13 +506,17 @@ function _stepbins_path(edge, weights, baseline::Real, xscale::Symbol, yscale::S
     x = eltype(edge)[]
     y = eltype(weights)[]
 
-    it_e, it_w = start(edge), start(weights)
-    a, it_e = next(edge, it_e)
+    it_tuple_e = iterate(edge)
+    a, it_state_e = it_tuple_e
+    it_tuple_e = iterate(edge, it_state_e)
+
+    it_tuple_w = iterate(weights)
+
     last_w = eltype(weights)(NaN)
-    i = 1
-    while (!done(edge, it_e) && !done(edge, it_e))
-        b, it_e = next(edge, it_e)
-        w, it_w = next(weights, it_w)
+
+    while it_tuple_e != nothing && it_tuple_w != nothing
+        b, it_state_e = it_tuple_e
+        w, it_state_w = it_tuple_w
 
         if (log_scale_x && a ≈ 0)
             a = b/_logScaleBases[xscale]^3
@@ -536,6 +540,9 @@ function _stepbins_path(edge, weights, baseline::Real, xscale::Symbol, yscale::S
 
         a = b
         last_w = w
+
+        it_tuple_e = iterate(edge, it_state_e)
+        it_tuple_w = iterate(weights, it_state_w)
     end
     if (last_w != baseline)
         push!(x, a)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -498,8 +498,8 @@ function _stepbins_path(edge, weights, baseline::Real, xscale::Symbol, yscale::S
     log_scale_x = xscale in _logScales
     log_scale_y = yscale in _logScales
 
-    nbins = length(linearindices(weights))
-    if length(linearindices(edge)) != nbins + 1
+    nbins = length(eachindex(weights))
+    if length(eachindex(edge)) != nbins + 1
         error("Edge vector must be 1 longer than weight vector")
     end
 


### PR DESCRIPTION
* Use `length(eachindex(...))` instead of `length(linearindices(...))`
* Fix  _stepbins_path (new Julia v0.7/v1.0 iteration API)