### PR TITLE
Don't broadcast `plot_color`; fix #1641

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1569,13 +1569,13 @@ function _update_series_attributes!(d::KW, plt::Plot, sp::Subplot)
     for s in (:line, :marker, :fill)
         csym, asym = Symbol(s,:color), Symbol(s,:alpha)
         d[csym] = if d[csym] == :auto
-            plot_color.(if has_black_border_for_default(d[:seriestype]) && s == :line
+            plot_color(if has_black_border_for_default(d[:seriestype]) && s == :line
                 sp[:foreground_color_subplot]
             else
                 d[:seriescolor]
             end)
         elseif d[csym] == :match
-            plot_color.(d[:seriescolor])
+            plot_color(d[:seriescolor])
         else
             getSeriesRGBColor.(d[csym], Ref(sp), plotIndex)
         end


### PR DESCRIPTION
On 1.0 you can no longer pass a singleton argument to broadcast without escaping with `Ref`. But - `plot_color` has `Vector` methods, so it should be fine to not broadcast here. The example from the PR that introduced the broadcast here still works on this PR https://github.com/JuliaPlots/Plots.jl/pull/1467#issue-178940271 