### PR TITLE
WIP: Actually use PlotsDisplay()

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -294,19 +294,4 @@ end
 
 const CURRENT_BACKEND = CurrentBackend(:none)
 
-# for compatibility with Requires.jl:
-@init begin
-    if isdefined(Main, :PLOTS_DEFAULTS)
-        if haskey(Main.PLOTS_DEFAULTS, :theme)
-            theme(Main.PLOTS_DEFAULTS[:theme])
-        end
-        for (k,v) in Main.PLOTS_DEFAULTS
-            k == :theme || default(k, v)
-        end
-    end
-    pushdisplay(PlotsDisplay())
-end
-
-# ---------------------------------------------------------
-
 end # module

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -304,6 +304,7 @@ const CURRENT_BACKEND = CurrentBackend(:none)
             k == :theme || default(k, v)
         end
     end
+    pushdisplay(PlotsDisplay())
 end
 
 # ---------------------------------------------------------

--- a/src/init.jl
+++ b/src/init.jl
@@ -9,6 +9,13 @@ function __init__()
     end
     pushdisplay(PlotsDisplay())
 
+    atreplinit(i -> begin
+        if PlotDisplay() in Base.Multimedia.displays
+            popdisplay(PlotsDisplay())
+        end
+        pushdisplay(PlotsDisplay())
+    end)
+
     include(joinpath(@__DIR__, "backends", "plotly.jl"))
     include(joinpath(@__DIR__, "backends", "gr.jl"))
     include(joinpath(@__DIR__, "backends", "web.jl"))

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,4 +1,14 @@
 function __init__()
+    if isdefined(Main, :PLOTS_DEFAULTS)
+        if haskey(Main.PLOTS_DEFAULTS, :theme)
+            theme(Main.PLOTS_DEFAULTS[:theme])
+        end
+        for (k,v) in Main.PLOTS_DEFAULTS
+            k == :theme || default(k, v)
+        end
+    end
+    pushdisplay(PlotsDisplay())
+
     include(joinpath(@__DIR__, "backends", "plotly.jl"))
     include(joinpath(@__DIR__, "backends", "gr.jl"))
     include(joinpath(@__DIR__, "backends", "web.jl"))

--- a/src/output.jl
+++ b/src/output.jl
@@ -145,11 +145,6 @@ function Base.display(::PlotsDisplay, plt::Plot)
     _display(plt)
 end
 
-# override the REPL display to open a gui window
-using REPL
-Base.display(::REPL.REPLDisplay, ::MIME"text/plain", plt::Plot) = gui(plt)
-
-
 _do_plot_show(plt, showval::Bool) = showval && gui(plt)
 function _do_plot_show(plt, showval::Symbol)
     showval == :gui && gui(plt)


### PR DESCRIPTION
instead of overloading display for REPLDisplay.

This unfortunately doesn't work yet because the `@init` block apparently is never executed.