### PR TITLE
change all instances of `d` to `plotattributes.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
-julia 0.7
+julia 1.0
 
-RecipesBase 0.2.3
+RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport

--- a/src/args.jl
+++ b/src/args.jl
@@ -604,7 +604,7 @@ end
 `default(key)` returns the current default value for that key
 `default(key, value)` sets the current default value for that key
 `default(; kw...)` will set the current default value for each key/value pair
-`default(plotattributes, key)` returns the key fromplotattributesif it exists, otherwise `default(key)`
+`default(plotattributes, key)` returns the key from  plotattributes if it exists, otherwise `default(key)`
 """
 function default(k::Symbol)
     k = get(_keyAliases, k, k)
@@ -1208,9 +1208,9 @@ slice_arg(v, idx) = v
 # given an argument key (k), we want to extract the argument value for this index.
 # matrices are sliced by column, otherwise we
 # if nothing is set (or container is empty), return the default or the existing value.
-function slice_arg!(plotattributes_in::KW,plotattributesout::KW, k::Symbol, default_value, idx::Int, remove_pair::Bool)
+function slice_arg!(plotattributes_in::KW,plotattributes_out::KW, k::Symbol, default_value, idx::Int, remove_pair::Bool)
     v = get(plotattributes_in, k, get(plotattributes_out, k, default_value))
-   plotattributesout[k] = if haskey(plotattributes_in, k) && typeof(v) <: AMat && !isempty(v)
+   plotattributes_out[k] = if haskey(plotattributes_in, k) && typeof(v) <: AMat && !isempty(v)
         slice_arg(v, idx)
     else
         v
@@ -1542,7 +1542,8 @@ function _add_defaults!(plotattributes::KW, plt::Plot, sp::Subplot, commandIndex
         slice_arg!(plotattributes, plotattributes, k, v, commandIndex, false)
     end
 
-    returnplotattributesend
+    return plotattributes
+end
 
 
 function _update_series_attributes!(plotattributes::KW, plt::Plot, sp::Subplot)
@@ -1616,7 +1617,8 @@ function _update_series_attributes!(plotattributes::KW, plt::Plot, sp::Subplot)
     plotattributes[:label] = label
 
     _replace_linewidth(plotattributes)
-   plotattributesend
+   plotattributes
+end
 
 function _series_index(plotattributes, sp)
     idx = 0
@@ -1624,7 +1626,8 @@ function _series_index(plotattributes, sp)
         if series[:primary]
             idx += 1
         end
-        if series ==plotattributes            return idx
+        if series == plotattributes
+            return idx
         end
     end
     if get(plotattributes, :primary, true)

--- a/src/args.jl
+++ b/src/args.jl
@@ -89,12 +89,12 @@ like_line(seriestype::Symbol)      = seriestype in _line_like
 like_surface(seriestype::Symbol)   = seriestype in _surface_like
 
 is3d(seriestype::Symbol) = seriestype in _3dTypes
-is3d(series::Series) = is3d(series.d)
-is3d(d::KW) = trueOrAllTrue(is3d, Symbol(d[:seriestype]))
+is3d(series::Series) = is3d(series.plotattributes)
+is3d(plotattributes::KW) = trueOrAllTrue(is3d, Symbol(plotattributes[:seriestype]))
 
 is3d(sp::Subplot) = string(sp.attr[:projection]) == "3d"
 ispolar(sp::Subplot) = string(sp.attr[:projection]) == "polar"
-ispolar(series::Series) = ispolar(series.d[:subplot])
+ispolar(series::Series) = ispolar(series.plotattributes[:subplot])
 
 # ------------------------------------------------------------
 
@@ -463,11 +463,11 @@ autopick(notarr, idx::Integer) = notarr
 autopick_ignore_none_auto(arr::AVec, idx::Integer) = autopick(setdiff(arr, [:none, :auto]), idx)
 autopick_ignore_none_auto(notarr, idx::Integer) = notarr
 
-function aliasesAndAutopick(d::KW, sym::Symbol, aliases::Dict{Symbol,Symbol}, options::AVec, plotIndex::Int)
-    if d[sym] == :auto
-        d[sym] = autopick_ignore_none_auto(options, plotIndex)
-    elseif haskey(aliases, d[sym])
-        d[sym] = aliases[d[sym]]
+function aliasesAndAutopick(plotattributes::KW, sym::Symbol, aliases::Dict{Symbol,Symbol}, options::AVec, plotIndex::Int)
+    if plotattributes[sym] == :auto
+        plotattributes[sym] = autopick_ignore_none_auto(options, plotIndex)
+    elseif haskey(aliases, [sym])
+        plotattributes[sym] = aliases[plotattributes[sym]]
     end
 end
 
@@ -604,7 +604,7 @@ end
 `default(key)` returns the current default value for that key
 `default(key, value)` sets the current default value for that key
 `default(; kw...)` will set the current default value for each key/value pair
-`default(d, key)` returns the key from d if it exists, otherwise `default(key)`
+`default(plotattributes, key)` returns the key fromplotattributesif it exists, otherwise `default(key)`
 """
 function default(k::Symbol)
     k = get(_keyAliases, k, k)
@@ -642,8 +642,8 @@ function default(; kw...)
     end
 end
 
-function default(d::KW, k::Symbol)
-    get(d, k, default(k))
+function default(plotattributes::KW, k::Symbol)
+    get(plotattributes, k, default(k))
 end
 
 function reset_defaults()
@@ -653,15 +653,15 @@ end
 
 # -----------------------------------------------------------------------------
 
-# if arg is a valid color value, then set d[csym] and return true
-function handleColors!(d::KW, arg, csym::Symbol)
+# if arg is a valid color value, then set plotattributes[csym] and return true
+function handleColors!(plotattributes::KW, arg, csym::Symbol)
     try
         if arg == :auto
-            d[csym] = :auto
+            plotattributes[csym] = :auto
         else
             # c = colorscheme(arg)
             c = plot_color(arg)
-            d[csym] = c
+            plotattributes[csym] = c
         end
         return true
     catch
@@ -671,201 +671,201 @@ end
 
 
 
-function processLineArg(d::KW, arg)
+function processLineArg(plotattributes::KW, arg)
     # seriestype
     if allLineTypes(arg)
-        d[:seriestype] = arg
+        plotattributes[:seriestype] = arg
 
     # linestyle
     elseif allStyles(arg)
-        d[:linestyle] = arg
+        plotattributes[:linestyle] = arg
 
     elseif typeof(arg) <: Stroke
-        arg.width == nothing || (d[:linewidth] = arg.width)
-        arg.color == nothing || (d[:linecolor] = arg.color == :auto ? :auto : plot_color(arg.color))
-        arg.alpha == nothing || (d[:linealpha] = arg.alpha)
-        arg.style == nothing || (d[:linestyle] = arg.style)
+        arg.width == nothing || (plotattributes[:linewidth] = arg.width)
+        arg.color == nothing || (plotattributes[:linecolor] = arg.color == :auto ? :auto : plot_color(arg.color))
+        arg.alpha == nothing || (plotattributes[:linealpha] = arg.alpha)
+        arg.style == nothing || (plotattributes[:linestyle] = arg.style)
 
     elseif typeof(arg) <: Brush
-        arg.size  == nothing || (d[:fillrange] = arg.size)
-        arg.color == nothing || (d[:fillcolor] = arg.color == :auto ? :auto : plot_color(arg.color))
-        arg.alpha == nothing || (d[:fillalpha] = arg.alpha)
+        arg.size  == nothing || (plotattributes[:fillrange] = arg.size)
+        arg.color == nothing || (plotattributes[:fillcolor] = arg.color == :auto ? :auto : plot_color(arg.color))
+        arg.alpha == nothing || (plotattributes[:fillalpha] = arg.alpha)
 
     elseif typeof(arg) <: Arrow || arg in (:arrow, :arrows)
-        d[:arrow] = arg
+        plotattributes[:arrow] = arg
 
     # linealpha
     elseif allAlphas(arg)
-        d[:linealpha] = arg
+        plotattributes[:linealpha] = arg
 
     # linewidth
     elseif allReals(arg)
-        d[:linewidth] = arg
+        plotattributes[:linewidth] = arg
 
     # color
-    elseif !handleColors!(d, arg, :linecolor)
+    elseif !handleColors!(plotattributes, arg, :linecolor)
         @warn("Skipped line arg $arg.")
 
     end
 end
 
 
-function processMarkerArg(d::KW, arg)
+function processMarkerArg(plotattributes::KW, arg)
     # markershape
     if allShapes(arg)
-        d[:markershape] = arg
+        plotattributes[:markershape] = arg
 
     # stroke style
     elseif allStyles(arg)
-        d[:markerstrokestyle] = arg
+        plotattributes[:markerstrokestyle] = arg
 
     elseif typeof(arg) <: Stroke
-        arg.width == nothing || (d[:markerstrokewidth] = arg.width)
-        arg.color == nothing || (d[:markerstrokecolor] = arg.color == :auto ? :auto : plot_color(arg.color))
-        arg.alpha == nothing || (d[:markerstrokealpha] = arg.alpha)
-        arg.style == nothing || (d[:markerstrokestyle] = arg.style)
+        arg.width == nothing || (plotattributes[:markerstrokewidth] = arg.width)
+        arg.color == nothing || (plotattributes[:markerstrokecolor] = arg.color == :auto ? :auto : plot_color(arg.color))
+        arg.alpha == nothing || (plotattributes[:markerstrokealpha] = arg.alpha)
+        arg.style == nothing || (plotattributes[:markerstrokestyle] = arg.style)
 
     elseif typeof(arg) <: Brush
-        arg.size  == nothing || (d[:markersize]  = arg.size)
-        arg.color == nothing || (d[:markercolor] = arg.color == :auto ? :auto : plot_color(arg.color))
-        arg.alpha == nothing || (d[:markeralpha] = arg.alpha)
+        arg.size  == nothing || (plotattributes[:markersize]  = arg.size)
+        arg.color == nothing || (plotattributes[:markercolor] = arg.color == :auto ? :auto : plot_color(arg.color))
+        arg.alpha == nothing || (plotattributes[:markeralpha] = arg.alpha)
 
     # linealpha
     elseif allAlphas(arg)
-        d[:markeralpha] = arg
+        plotattributes[:markeralpha] = arg
 
     # markersize
     elseif allReals(arg)
-        d[:markersize] = arg
+        plotattributes[:markersize] = arg
 
     # markercolor
-    elseif !handleColors!(d, arg, :markercolor)
+    elseif !handleColors!(plotattributes, arg, :markercolor)
         @warn("Skipped marker arg $arg.")
 
     end
 end
 
 
-function processFillArg(d::KW, arg)
-    # fr = get(d, :fillrange, 0)
+function processFillArg(plotattributes::KW, arg)
+    # fr = get(plotattributes, :fillrange, 0)
     if typeof(arg) <: Brush
-        arg.size  == nothing || (d[:fillrange] = arg.size)
-        arg.color == nothing || (d[:fillcolor] = arg.color == :auto ? :auto : plot_color(arg.color))
-        arg.alpha == nothing || (d[:fillalpha] = arg.alpha)
+        arg.size  == nothing || (plotattributes[:fillrange] = arg.size)
+        arg.color == nothing || (plotattributes[:fillcolor] = arg.color == :auto ? :auto : plot_color(arg.color))
+        arg.alpha == nothing || (plotattributes[:fillalpha] = arg.alpha)
 
     elseif typeof(arg) <: Bool
-        d[:fillrange] = arg ? 0 : nothing
+        plotattributes[:fillrange] = arg ? 0 : nothing
 
     # fillrange function
     elseif allFunctions(arg)
-        d[:fillrange] = arg
+        plotattributes[:fillrange] = arg
 
     # fillalpha
     elseif allAlphas(arg)
-        d[:fillalpha] = arg
+        plotattributes[:fillalpha] = arg
 
     # fillrange provided as vector or number
     elseif typeof(arg) <: Union{AbstractArray{<:Real}, Real}
-        d[:fillrange] = arg
+        plotattributes[:fillrange] = arg
 
-    elseif !handleColors!(d, arg, :fillcolor)
+    elseif !handleColors!(plotattributes, arg, :fillcolor)
 
-        d[:fillrange] = arg
+        plotattributes[:fillrange] = arg
     end
-    # d[:fillrange] = fr
+    # plotattributes[:fillrange] = fr
     return
 end
 
 
-function processGridArg!(d::KW, arg, letter)
+function processGridArg!(plotattributes::KW, arg, letter)
     if arg in _allGridArgs || isa(arg, Bool)
-        d[Symbol(letter, :grid)] = hasgrid(arg, letter)
+        plotattributes[Symbol(letter, :grid)] = hasgrid(arg, letter)
 
     elseif allStyles(arg)
-        d[Symbol(letter, :gridstyle)] = arg
+        plotattributes[Symbol(letter, :gridstyle)] = arg
 
     elseif typeof(arg) <: Stroke
-        arg.width == nothing || (d[Symbol(letter, :gridlinewidth)] = arg.width)
-        arg.color == nothing || (d[Symbol(letter, :foreground_color_grid)] = arg.color in (:auto, :match) ? :match : plot_color(arg.color))
-        arg.alpha == nothing || (d[Symbol(letter, :gridalpha)] = arg.alpha)
-        arg.style == nothing || (d[Symbol(letter, :gridstyle)] = arg.style)
+        arg.width == nothing || (plotattributes[Symbol(letter, :gridlinewidth)] = arg.width)
+        arg.color == nothing || (plotattributes[Symbol(letter, :foreground_color_grid)] = arg.color in (:auto, :match) ? :match : plot_color(arg.color))
+        arg.alpha == nothing || (plotattributes[Symbol(letter, :gridalpha)] = arg.alpha)
+        arg.style == nothing || (plotattributes[Symbol(letter, :gridstyle)] = arg.style)
 
     # linealpha
     elseif allAlphas(arg)
-        d[Symbol(letter, :gridalpha)] = arg
+        plotattributes[Symbol(letter, :gridalpha)] = arg
 
     # linewidth
     elseif allReals(arg)
-        d[Symbol(letter, :gridlinewidth)] = arg
+        plotattributes[Symbol(letter, :gridlinewidth)] = arg
 
     # color
-    elseif !handleColors!(d, arg, Symbol(letter, :foreground_color_grid))
+    elseif !handleColors!(plotattributes, arg, Symbol(letter, :foreground_color_grid))
         @warn("Skipped grid arg $arg.")
 
     end
 end
 
-function processMinorGridArg!(d::KW, arg, letter)
+function processMinorGridArg!(plotattributes::KW, arg, letter)
     if arg in _allGridArgs || isa(arg, Bool)
-        d[Symbol(letter, :minorgrid)] = hasgrid(arg, letter)
+        plotattributes[Symbol(letter, :minorgrid)] = hasgrid(arg, letter)
 
     elseif allStyles(arg)
-        d[Symbol(letter, :minorgridstyle)] = arg
-        d[Symbol(letter, :minorgrid)] = true
+        plotattributes[Symbol(letter, :minorgridstyle)] = arg
+        plotattributes[Symbol(letter, :minorgrid)] = true
 
     elseif typeof(arg) <: Stroke
-        arg.width == nothing || (d[Symbol(letter, :minorgridlinewidth)] = arg.width)
-        arg.color == nothing || (d[Symbol(letter, :foreground_color_minor_grid)] = arg.color in (:auto, :match) ? :match : plot_color(arg.color))
-        arg.alpha == nothing || (d[Symbol(letter, :minorgridalpha)] = arg.alpha)
-        arg.style == nothing || (d[Symbol(letter, :minorgridstyle)] = arg.style)
-        d[Symbol(letter, :minorgrid)] = true
+        arg.width == nothing || (plotattributes[Symbol(letter, :minorgridlinewidth)] = arg.width)
+        arg.color == nothing || (plotattributes[Symbol(letter, :foreground_color_minor_grid)] = arg.color in (:auto, :match) ? :match : plot_color(arg.color))
+        arg.alpha == nothing || (plotattributes[Symbol(letter, :minorgridalpha)] = arg.alpha)
+        arg.style == nothing || (plotattributes[Symbol(letter, :minorgridstyle)] = arg.style)
+        plotattributes[Symbol(letter, :minorgrid)] = true
 
     # linealpha
     elseif allAlphas(arg)
-        d[Symbol(letter, :minorgridalpha)] = arg
-        d[Symbol(letter, :minorgrid)] = true
+        plotattributes[Symbol(letter, :minorgridalpha)] = arg
+        plotattributes[Symbol(letter, :minorgrid)] = true
 
     # linewidth
     elseif allReals(arg)
-        d[Symbol(letter, :minorgridlinewidth)] = arg
-        d[Symbol(letter, :minorgrid)] = true
+        plotattributes[Symbol(letter, :minorgridlinewidth)] = arg
+        plotattributes[Symbol(letter, :minorgrid)] = true
 
     # color
-    elseif handleColors!(d, arg, Symbol(letter, :foreground_color_minor_grid))
-        d[Symbol(letter, :minorgrid)] = true
+    elseif handleColors!(plotattributes, arg, Symbol(letter, :foreground_color_minor_grid))
+        plotattributes[Symbol(letter, :minorgrid)] = true
     else
         @warn("Skipped grid arg $arg.")
     end
 end
 
-function processFontArg!(d::KW, fontname::Symbol, arg)
+function processFontArg!(plotattributes::KW, fontname::Symbol, arg)
     T = typeof(arg)
     if T <: Font
-        d[Symbol(fontname, :family)] = arg.family
-        d[Symbol(fontname, :size)] = arg.pointsize
-        d[Symbol(fontname, :halign)] = arg.halign
-        d[Symbol(fontname, :valign)] = arg.valign
-        d[Symbol(fontname, :rotation)] = arg.rotation
-        d[Symbol(fontname, :color)] = arg.color
+        plotattributes[Symbol(fontname, :family)] = arg.family
+        plotattributes[Symbol(fontname, :size)] = arg.pointsize
+        plotattributes[Symbol(fontname, :halign)] = arg.halign
+        plotattributes[Symbol(fontname, :valign)] = arg.valign
+        plotattributes[Symbol(fontname, :rotation)] = arg.rotation
+        plotattributes[Symbol(fontname, :color)] = arg.color
     elseif arg == :center
-        d[Symbol(fontname, :halign)] = :hcenter
-        d[Symbol(fontname, :valign)] = :vcenter
+        plotattributes[Symbol(fontname, :halign)] = :hcenter
+        plotattributes[Symbol(fontname, :valign)] = :vcenter
     elseif arg in (:hcenter, :left, :right)
-        d[Symbol(fontname, :halign)] = arg
+        plotattributes[Symbol(fontname, :halign)] = arg
     elseif arg in (:vcenter, :top, :bottom)
-        d[Symbol(fontname, :valign)] = arg
+        plotattributes[Symbol(fontname, :valign)] = arg
     elseif T <: Colorant
-        d[Symbol(fontname, :color)] = arg
+        plotattributes[Symbol(fontname, :color)] = arg
     elseif T <: Symbol || T <: AbstractString
         try
-            d[Symbol(fontname, :color)] = parse(Colorant, string(arg))
+            plotattributes[Symbol(fontname, :color)] = parse(Colorant, string(arg))
         catch
-            d[Symbol(fontname, :family)] = string(arg)
+            plotattributes[Symbol(fontname, :family)] = string(arg)
         end
     elseif typeof(arg) <: Integer
-        d[Symbol(fontname, :size)] = arg
+        plotattributes[Symbol(fontname, :size)] = arg
     elseif typeof(arg) <: Real
-        d[Symbol(fontname, :rotation)] = convert(Float64, arg)
+        plotattributes[Symbol(fontname, :rotation)] = convert(Float64, arg)
     else
         @warn("Skipped font arg: $arg ($(typeof(arg)))")
     end
@@ -875,150 +875,150 @@ _replace_markershape(shape::Symbol) = get(_markerAliases, shape, shape)
 _replace_markershape(shapes::AVec) = map(_replace_markershape, shapes)
 _replace_markershape(shape) = shape
 
-function _add_markershape(d::KW)
+function _add_markershape(plotattributes::KW)
     # add the markershape if it needs to be added... hack to allow "m=10" to add a shape,
     # and still allow overriding in _apply_recipe
-    ms = pop!(d, :markershape_to_add, :none)
-    if !haskey(d, :markershape) && ms != :none
-        d[:markershape] = ms
+    ms = pop!(plotattributes, :markershape_to_add, :none)
+    if !haskey(plotattributes, :markershape) && ms != :none
+        plotattributes[:markershape] = ms
     end
 end
 
 "Handle all preprocessing of args... break out colors/sizes/etc and replace aliases."
-function preprocessArgs!(d::KW)
-    replaceAliases!(d, _keyAliases)
+function preprocessArgs!(plotattributes::KW)
+    replaceAliases!(plotattributes, _keyAliases)
 
     # clear all axis stuff
-    # if haskey(d, :axis) && d[:axis] in (:none, nothing, false)
-    #     d[:ticks] = nothing
-    #     d[:foreground_color_border] = RGBA(0,0,0,0)
-    #     d[:foreground_color_axis] = RGBA(0,0,0,0)
-    #     d[:grid] = false
-    #     delete!(d, :axis)
+    # if haskey(plotattributes, :axis) && plotattributes[:axis] in (:none, nothing, false)
+    #     plotattributes[:ticks] = nothing
+    #     plotattributes[:foreground_color_border] = RGBA(0,0,0,0)
+    #     plotattributes[:foreground_color_axis] = RGBA(0,0,0,0)
+    #     plotattributes[:grid] = false
+    #     delete!(plotattributes, :axis)
     # end
     # for letter in (:x, :y, :z)
     #     asym = Symbol(letter, :axis)
-    #     if haskey(d, asym) || d[asym] in (:none, nothing, false)
-    #         d[Symbol(letter, :ticks)] = nothing
-    #         d[Symbol(letter, :foreground_color_border)] = RGBA(0,0,0,0)
+    #     if haskey(plotattributes, asym) || plotattributes[asym] in (:none, nothing, false)
+    #         plotattributes[Symbol(letter, :ticks)] = nothing
+    #         plotattributes[Symbol(letter, :foreground_color_border)] = RGBA(0,0,0,0)
     #     end
     # end
 
     # handle axis args common to all axis
-    args = pop!(d, :axis, ())
+    args = pop!(plotattributes, :axis, ())
     for arg in wraptuple(args)
         for letter in (:x, :y, :z)
-            process_axis_arg!(d, arg, letter)
+            process_axis_arg!(plotattributes, arg, letter)
         end
     end
     # handle axis args
     for letter in (:x, :y, :z)
         asym = Symbol(letter, :axis)
-        args = pop!(d, asym, ())
+        args = pop!(plotattributes, asym, ())
         if !(typeof(args) <: Axis)
             for arg in wraptuple(args)
-                process_axis_arg!(d, arg, letter)
+                process_axis_arg!(plotattributes, arg, letter)
             end
         end
     end
 
     # handle grid args common to all axes
-    args = pop!(d, :grid, ())
+    args = pop!(plotattributes, :grid, ())
     for arg in wraptuple(args)
         for letter in (:x, :y, :z)
-            processGridArg!(d, arg, letter)
+            processGridArg!(plotattributes, arg, letter)
         end
     end
     # handle individual axes grid args
     for letter in (:x, :y, :z)
         gridsym = Symbol(letter, :grid)
-        args = pop!(d, gridsym, ())
+        args = pop!(plotattributes, gridsym, ())
         for arg in wraptuple(args)
-            processGridArg!(d, arg, letter)
+            processGridArg!(plotattributes, arg, letter)
         end
     end
     # handle minor grid args common to all axes
-    args = pop!(d, :minorgrid, ())
+    args = pop!(plotattributes, :minorgrid, ())
     for arg in wraptuple(args)
         for letter in (:x, :y, :z)
-            processMinorGridArg!(d, arg, letter)
+            processMinorGridArg!(plotattributes, arg, letter)
         end
     end
     # handle individual axes grid args
     for letter in (:x, :y, :z)
         gridsym = Symbol(letter, :minorgrid)
-        args = pop!(d, gridsym, ())
+        args = pop!(plotattributes, gridsym, ())
         for arg in wraptuple(args)
-            processMinorGridArg!(d, arg, letter)
+            processMinorGridArg!(plotattributes, arg, letter)
         end
     end
     # fonts
     for fontname in (:titlefont, :legendfont)
-        args = pop!(d, fontname, ())
+        args = pop!(plotattributes, fontname, ())
         for arg in wraptuple(args)
-            processFontArg!(d, fontname, arg)
+            processFontArg!(plotattributes, fontname, arg)
         end
     end
     # handle font args common to all axes
     for fontname in (:tickfont, :guidefont)
-        args = pop!(d, fontname, ())
+        args = pop!(plotattributes, fontname, ())
         for arg in wraptuple(args)
             for letter in (:x, :y, :z)
-                processFontArg!(d, Symbol(letter, fontname), arg)
+                processFontArg!(plotattributes, Symbol(letter, fontname), arg)
             end
         end
     end
     # handle individual axes font args
     for letter in (:x, :y, :z)
         for fontname in (:tickfont, :guidefont)
-            args = pop!(d, Symbol(letter, fontname), ())
+            args = pop!(plotattributes, Symbol(letter, fontname), ())
             for arg in wraptuple(args)
-                processFontArg!(d, Symbol(letter, fontname), arg)
+                processFontArg!(plotattributes, Symbol(letter, fontname), arg)
             end
         end
     end
 
     # handle line args
-    for arg in wraptuple(pop!(d, :line, ()))
-        processLineArg(d, arg)
+    for arg in wraptuple(pop!(plotattributes, :line, ()))
+        processLineArg(plotattributes, arg)
     end
 
-    if haskey(d, :seriestype) && haskey(_typeAliases, d[:seriestype])
-        d[:seriestype] = _typeAliases[d[:seriestype]]
+    if haskey(plotattributes, :seriestype) && haskey(_typeAliases, plotattributes[:seriestype])
+        plotattributes[:seriestype] = _typeAliases[plotattributes[:seriestype]]
     end
 
     # handle marker args... default to ellipse if shape not set
     anymarker = false
-    for arg in wraptuple(get(d, :marker, ()))
-        processMarkerArg(d, arg)
+    for arg in wraptuple(get(plotattributes, :marker, ()))
+        processMarkerArg(plotattributes, arg)
         anymarker = true
     end
-    delete!(d, :marker)
-    if haskey(d, :markershape)
-        d[:markershape] = _replace_markershape(d[:markershape])
-        if d[:markershape] == :none && d[:seriestype] in (:scatter, :scatterbins, :scatterhist, :scatter3d) #the default should be :auto, not :none, so that :none can be set explicitly and would be respected
-            d[:markershape] = :circle
+    delete!(plotattributes, :marker)
+    if haskey(plotattributes, :markershape)
+        plotattributes[:markershape] = _replace_markershape(plotattributes[:markershape])
+        if plotattributes[:markershape] == :none && plotattributes[:seriestype] in (:scatter, :scatterbins, :scatterhist, :scatter3d) #the default should be :auto, not :none, so that :none can be set explicitly and would be respected
+            plotattributes[:markershape] = :circle
         end
     elseif anymarker
-        d[:markershape_to_add] = :circle  # add it after _apply_recipe
+        plotattributes[:markershape_to_add] = :circle  # add it after _apply_recipe
     end
 
     # handle fill
-    for arg in wraptuple(get(d, :fill, ()))
-        processFillArg(d, arg)
+    for arg in wraptuple(get(plotattributes, :fill, ()))
+        processFillArg(plotattributes, arg)
     end
-    delete!(d, :fill)
+    delete!(plotattributes, :fill)
 
     # handle series annotations
-    if haskey(d, :series_annotations)
-        d[:series_annotations] = series_annotations(wraptuple(d[:series_annotations])...)
+    if haskey(plotattributes, :series_annotations)
+        plotattributes[:series_annotations] = series_annotations(wraptuple(plotattributes[:series_annotations])...)
     end
 
   # convert into strokes and brushes
 
-    if haskey(d, :arrow)
-        a = d[:arrow]
-        d[:arrow] = if a == true
+    if haskey(plotattributes, :arrow)
+        a = plotattributes[:arrow]
+        plotattributes[:arrow] = if a == true
             arrow()
         elseif a in (false, nothing, :none)
             nothing
@@ -1030,25 +1030,25 @@ function preprocessArgs!(d::KW)
     end
 
 
-    # if get(d, :arrow, false) == true
-    #     d[:arrow] = arrow()
+    # if get(plotattributes, :arrow, false) == true
+    #     plotattributes[:arrow] = arrow()
     # end
 
     # legends
-    if haskey(d, :legend)
-        d[:legend] = convertLegendValue(d[:legend])
+    if haskey(plotattributes, :legend)
+        plotattributes[:legend] = convertLegendValue(plotattributes[:legend])
     end
-    if haskey(d, :colorbar)
-        d[:colorbar] = convertLegendValue(d[:colorbar])
+    if haskey(plotattributes, :colorbar)
+        plotattributes[:colorbar] = convertLegendValue(plotattributes[:colorbar])
     end
 
     # framestyle
-    if haskey(d, :framestyle) && haskey(_framestyleAliases, d[:framestyle])
-        d[:framestyle] = _framestyleAliases[d[:framestyle]]
+    if haskey(plotattributes, :framestyle) && haskey(_framestyleAliases, plotattributes[:framestyle])
+        plotattributes[:framestyle] = _framestyleAliases[plotattributes[:framestyle]]
     end
 
     # warnings for moved recipes
-    st = get(d, :seriestype, :path)
+    st = get(plotattributes, :seriestype, :path)
     if st in (:boxplot, :violin, :density) && !isdefined(Main, :StatPlots)
         @warn("seriestype $st has been moved to StatPlots.  To use: \`Pkg.add(\"StatPlots\"); using StatPlots\`")
     end
@@ -1105,16 +1105,16 @@ end
 filter_data(v::AVec, idxfilter::AVec{Int}) = v[idxfilter]
 filter_data(v, idxfilter) = v
 
-function filter_data!(d::KW, idxfilter)
+function filter_data!(plotattributes::KW, idxfilter)
     for s in (:x, :y, :z)
-        d[s] = filter_data(get(d, s, nothing), idxfilter)
+        plotattributes[s] = filter_data(get(plotattributes, s, nothing), idxfilter)
     end
 end
 
-function _filter_input_data!(d::KW)
-    idxfilter = pop!(d, :idxfilter, nothing)
+function _filter_input_data!(plotattributes::KW)
+    idxfilter = pop!(plotattributes, :idxfilter, nothing)
     if idxfilter != nothing
-        filter_data!(d, idxfilter)
+        filter_data!(plotattributes, idxfilter)
     end
 end
 
@@ -1124,14 +1124,14 @@ end
 const _already_warned = Dict{Symbol,Set{Symbol}}()
 const _to_warn = Set{Symbol}()
 
-function warnOnUnsupported_args(pkg::AbstractBackend, d::KW)
+function warnOnUnsupported_args(pkg::AbstractBackend, plotattributes::KW)
     empty!(_to_warn)
     bend = backend_name(pkg)
     already_warned = get!(_already_warned, bend, Set{Symbol}())
-    for k in keys(d)
+    for k in keys(plotattributes)
         is_attr_supported(pkg, k) && continue
         k in _suppress_warnings && continue
-        if d[k] != default(k)
+        if plotattributes[k] != default(k)
             k in already_warned || push!(_to_warn, k)
         end
     end
@@ -1148,22 +1148,22 @@ end
 # _markershape_supported(pkg::AbstractBackend, shape::Shape) = Shape in supported_markers(pkg)
 # _markershape_supported(pkg::AbstractBackend, shapes::AVec) = all([_markershape_supported(pkg, shape) for shape in shapes])
 
-function warnOnUnsupported(pkg::AbstractBackend, d::KW)
-    if !is_seriestype_supported(pkg, d[:seriestype])
-        @warn("seriestype $(d[:seriestype]) is unsupported with $pkg.  Choose from: $(supported_seriestypes(pkg))")
+function warnOnUnsupported(pkg::AbstractBackend, plotattributes::KW)
+    if !is_seriestype_supported(pkg, plotattributes[:seriestype])
+        @warn("seriestype $(plotattributes[:seriestype]) is unsupported with $pkg.  Choose from: $(supported_seriestypes(pkg))")
     end
-    if !is_style_supported(pkg, d[:linestyle])
-        @warn("linestyle $(d[:linestyle]) is unsupported with $pkg.  Choose from: $(supported_styles(pkg))")
+    if !is_style_supported(pkg, plotattributes[:linestyle])
+        @warn("linestyle $(plotattributes[:linestyle]) is unsupported with $pkg.  Choose from: $(supported_styles(pkg))")
     end
-    if !is_marker_supported(pkg, d[:markershape])
-        @warn("markershape $(d[:markershape]) is unsupported with $pkg.  Choose from: $(supported_markers(pkg))")
+    if !is_marker_supported(pkg, plotattributes[:markershape])
+        @warn("markershape $(plotattributes[:markershape]) is unsupported with $pkg.  Choose from: $(supported_markers(pkg))")
     end
 end
 
-function warnOnUnsupported_scales(pkg::AbstractBackend, d::KW)
+function warnOnUnsupported_scales(pkg::AbstractBackend, plotattributes::KW)
     for k in (:xscale, :yscale, :zscale, :scale)
-        if haskey(d, k)
-            v = d[k]
+        if haskey(plotattributes, k)
+            v = plotattributes[k]
             if !is_scale_supported(pkg, v)
                 @warn("scale $v is unsupported with $pkg.  Choose from: $(supported_scales(pkg))")
             end
@@ -1208,15 +1208,15 @@ slice_arg(v, idx) = v
 # given an argument key (k), we want to extract the argument value for this index.
 # matrices are sliced by column, otherwise we
 # if nothing is set (or container is empty), return the default or the existing value.
-function slice_arg!(d_in::KW, d_out::KW, k::Symbol, default_value, idx::Int, remove_pair::Bool)
-    v = get(d_in, k, get(d_out, k, default_value))
-    d_out[k] = if haskey(d_in, k) && typeof(v) <: AMat && !isempty(v)
+function slice_arg!(plotattributes_in::KW,plotattributesout::KW, k::Symbol, default_value, idx::Int, remove_pair::Bool)
+    v = get(plotattributes_in, k, get(plotattributes_out, k, default_value))
+   plotattributesout[k] = if haskey(plotattributes_in, k) && typeof(v) <: AMat && !isempty(v)
         slice_arg(v, idx)
     else
         v
     end
     if remove_pair
-        delete!(d_in, k)
+        delete!(plotattributes_in, k)
     end
     return
 end
@@ -1225,9 +1225,9 @@ end
 
 # # if the value is `:match` then we take whatever match_color is.
 # # this is mainly used for cascading defaults for foreground and background colors
-# function color_or_match!(d::KW, k::Symbol, match_color)
-#     v = d[k]
-#     d[k] = if v == :match
+# function color_or_match!(plotattributes::KW, k::Symbol, match_color)
+#     v = plotattributes[k]
+#     plotattributes[k] = if v == :match
 #         match_color
 #     elseif v == nothing
 #         plot_color(RGBA(0,0,0,0))
@@ -1236,9 +1236,9 @@ end
 #     end
 # end
 
-function color_or_nothing!(d::KW, k::Symbol)
-    v = d[k]
-    d[k] = if v == nothing || v == false
+function color_or_nothing!(plotattributes::KW, k::Symbol)
+    v = plotattributes[k]
+    plotattributes[k] = if v == nothing || v == false
         RGBA{Float64}(0,0,0,0)
     elseif v != :match
         plot_color(v)
@@ -1312,7 +1312,7 @@ end
 
 # properly retrieve from axis.attr, passing `:match` to the correct key
 function Base.getindex(axis::Axis, k::Symbol)
-    v = axis.d[k]
+    v = axis.plotattributes[k]
     if v == :match
         if haskey(_match_map2, k)
             axis.sps[1][_match_map2[k]]
@@ -1325,36 +1325,36 @@ function Base.getindex(axis::Axis, k::Symbol)
 end
 
 function Base.getindex(series::Series, k::Symbol)
-    series.d[k]
+    series.plotattributes[k]
 end
 
 Base.setindex!(plt::Plot, v, k::Symbol)      = (plt.attr[k] = v)
 Base.setindex!(sp::Subplot, v, k::Symbol)    = (sp.attr[k] = v)
-Base.setindex!(axis::Axis, v, k::Symbol)     = (axis.d[k] = v)
-Base.setindex!(series::Series, v, k::Symbol) = (series.d[k] = v)
+Base.setindex!(axis::Axis, v, k::Symbol)     = (axis.plotattributes[k] = v)
+Base.setindex!(series::Series, v, k::Symbol) = (series.plotattributes[k] = v)
 
 Base.get(plt::Plot, k::Symbol, v)      = get(plt.attr, k, v)
 Base.get(sp::Subplot, k::Symbol, v)    = get(sp.attr, k, v)
-Base.get(axis::Axis, k::Symbol, v)     = get(axis.d, k, v)
-Base.get(series::Series, k::Symbol, v) = get(series.d, k, v)
+Base.get(axis::Axis, k::Symbol, v)     = get(axis.plotattributes, k, v)
+Base.get(series::Series, k::Symbol, v) = get(series.plotattributes, k, v)
 
 
 # -----------------------------------------------------------------------------
 
-function fg_color(d::KW)
-    fg = default(d, :foreground_color)
+function fg_color(plotattributes::KW)
+    fg = default(plotattributes, :foreground_color)
     if fg == :auto
-        bg = plot_color(default(d, :background_color))
+        bg = plot_color(default(plotattributes, :background_color))
         fg = isdark(bg) ? colorant"white" : colorant"black"
     else
         plot_color(fg)
     end
 end
 
-function fg_color_sp(d::KW)
-    fgsp = default(d, :foreground_color_subplot)
+function fg_color_sp(plotattributes::KW)
+    fgsp = default(plotattributes, :foreground_color_subplot)
     if fg == :match
-        fg_color(d)
+        fg_color(plotattributes)
     else
         plot_color(fgsp)
     end
@@ -1363,15 +1363,15 @@ end
 
 
 # update attr from an input dictionary
-function _update_plot_args(plt::Plot, d_in::KW)
+function _update_plot_args(plt::Plot, plotattributes_in::KW)
     for (k,v) in _plot_defaults
-        slice_arg!(d_in, plt.attr, k, v, 1, true)
+        slice_arg!(plotattributes_in, plt.attr, k, v, 1, true)
     end
 
     # handle colors
-    d = plt.attr
-    plt[:background_color] = plot_color(d[:background_color])
-    plt[:foreground_color] = fg_color(d)
+   plotattributes= plt.attr
+    plt[:background_color] = plot_color(plotattributes[:background_color])
+    plt[:foreground_color] = fg_color(plotattributes)
     # bg = plot_color(plt.attr[:background_color])
     # fg = plt.attr[:foreground_color]
     # if fg == :auto
@@ -1416,11 +1416,11 @@ function _update_subplot_colors(sp::Subplot)
     return
 end
 
-function _update_axis(plt::Plot, sp::Subplot, d_in::KW, letter::Symbol, subplot_index::Int)
+function _update_axis(plt::Plot, sp::Subplot, plotattributes_in::KW, letter::Symbol, subplot_index::Int)
     # get (maybe initialize) the axis
     axis = get_axis(sp, letter)
 
-    _update_axis(axis, d_in, letter, subplot_index)
+    _update_axis(axis, plotattributes_in, letter, subplot_index)
 
     # convert a bool into auto or nothing
     if isa(axis[:ticks], Bool)
@@ -1432,23 +1432,23 @@ function _update_axis(plt::Plot, sp::Subplot, d_in::KW, letter::Symbol, subplot_
     return
 end
 
-function _update_axis(axis::Axis, d_in::KW, letter::Symbol, subplot_index::Int)
+function _update_axis(axis::Axis, plotattributes_in::KW, letter::Symbol, subplot_index::Int)
     # grab magic args (for example `xaxis = (:flip, :log)`)
-    args = wraptuple(get(d_in, Symbol(letter, :axis), ()))
+    args = wraptuple(get(plotattributes_in, Symbol(letter, :axis), ()))
 
     # build the KW of arguments from the letter version (i.e. xticks --> ticks)
     kw = KW()
     for (k,v) in _axis_defaults
         # first get the args without the letter: `tickfont = font(10)`
         # note: we don't pop because we want this to apply to all axes! (delete after all have finished)
-        if haskey(d_in, k)
-            kw[k] = slice_arg(d_in[k], subplot_index)
+        if haskey(plotattributes_in, k)
+            kw[k] = slice_arg(plotattributes_in[k], subplot_index)
         end
 
         # then get those args that were passed with a leading letter: `xlabel = "X"`
         lk = Symbol(letter, k)
-        if haskey(d_in, lk)
-            kw[k] = slice_arg(d_in[lk], subplot_index)
+        if haskey(plotattributes_in, lk)
+            kw[k] = slice_arg(plotattributes_in[lk], subplot_index)
         end
     end
 
@@ -1459,12 +1459,12 @@ end
 
 function _update_axis_colors(axis::Axis)
     # # update the axis colors
-    color_or_nothing!(axis.d, :foreground_color_axis)
-    color_or_nothing!(axis.d, :foreground_color_border)
-    color_or_nothing!(axis.d, :foreground_color_guide)
-    color_or_nothing!(axis.d, :foreground_color_text)
-    color_or_nothing!(axis.d, :foreground_color_grid)
-    color_or_nothing!(axis.d, :foreground_color_minor_grid)
+    color_or_nothing!(axis.plotattributes, :foreground_color_axis)
+    color_or_nothing!(axis.plotattributes, :foreground_color_border)
+    color_or_nothing!(axis.plotattributes, :foreground_color_guide)
+    color_or_nothing!(axis.plotattributes, :foreground_color_text)
+    color_or_nothing!(axis.plotattributes, :foreground_color_grid)
+    color_or_nothing!(axis.plotattributes, :foreground_color_minor_grid)
     return
 end
 
@@ -1477,25 +1477,25 @@ function _update_axis_links(plt::Plot, axis::Axis, letter::Symbol)
             other_sp = get_subplot(plt, other_sp)
             link_axes!(axis, get_axis(other_sp, letter))
         end
-        axis.d[:link] = []
+        axis.plotattributes[:link] = []
     end
     return
 end
 
 # update a subplots args and axes
-function _update_subplot_args(plt::Plot, sp::Subplot, d_in::KW, subplot_index::Int, remove_pair::Bool)
+function _update_subplot_args(plt::Plot, sp::Subplot, plotattributes_in::KW, subplot_index::Int, remove_pair::Bool)
     anns = pop!(sp.attr, :annotations, [])
 
     # grab those args which apply to this subplot
     for (k,v) in _subplot_defaults
-        slice_arg!(d_in, sp.attr, k, v, subplot_index, remove_pair)
+        slice_arg!(plotattributes_in, sp.attr, k, v, subplot_index, remove_pair)
     end
 
     _update_subplot_periphery(sp, anns)
     _update_subplot_colors(sp)
 
     for letter in (:x, :y, :z)
-        _update_axis(plt, sp, d_in, letter, subplot_index)
+        _update_axis(plt, sp, plotattributes_in, letter, subplot_index)
     end
 end
 
@@ -1523,114 +1523,111 @@ function getSeriesRGBColor(c::AbstractArray, sp::Subplot, n::Int)
     map(x->getSeriesRGBColor(x, sp, n), c)
 end
 
-function ensure_gradient!(d::KW, csym::Symbol, asym::Symbol)
-    if !isa(d[csym], ColorGradient)
-        d[csym] = typeof(d[asym]) <: AbstractVector ? cgrad() : cgrad(alpha = d[asym])
+function ensure_gradient!(plotattributes::KW, csym::Symbol, asym::Symbol)
+    if !isa(plotattributes[csym], ColorGradient)
+        plotattributes[csym] = typeof(plotattributes[asym]) <: AbstractVector ? cgrad() : cgrad(alpha = plotattributes[asym])
     end
 end
 
-function _replace_linewidth(d::KW)
+function _replace_linewidth(plotattributes::KW)
     # get a good default linewidth... 0 for surface and heatmaps
-    if get(d, :linewidth, :auto) == :auto
-        d[:linewidth] = (get(d, :seriestype, :path) in (:surface,:heatmap,:image) ? 0 : 1)
+    if get(plotattributes, :linewidth, :auto) == :auto
+        plotattributes[:linewidth] = (get(plotattributes, :seriestype, :path) in (:surface,:heatmap,:image) ? 0 : 1)
     end
 end
 
-function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
+function _add_defaults!(plotattributes::KW, plt::Plot, sp::Subplot, commandIndex::Int)
     # add default values to our dictionary, being careful not to delete what we just added!
     for (k,v) in _series_defaults
-        slice_arg!(d, d, k, v, commandIndex, false)
+        slice_arg!(plotattributes, plotattributes, k, v, commandIndex, false)
     end
 
-    return d
-end
+    returnplotattributesend
 
 
-function _update_series_attributes!(d::KW, plt::Plot, sp::Subplot)
+function _update_series_attributes!(plotattributes::KW, plt::Plot, sp::Subplot)
     pkg = plt.backend
-    globalIndex = d[:series_plotindex]
-    plotIndex = _series_index(d, sp)
+    globalIndex = plotattributes[:series_plotindex]
+    plotIndex = _series_index(plotattributes, sp)
 
-    aliasesAndAutopick(d, :linestyle, _styleAliases, supported_styles(pkg), plotIndex)
-    aliasesAndAutopick(d, :markershape, _markerAliases, supported_markers(pkg), plotIndex)
+    aliasesAndAutopick(plotattributes, :linestyle, _styleAliases, supported_styles(pkg), plotIndex)
+    aliasesAndAutopick(plotattributes, :markershape, _markerAliases, supported_markers(pkg), plotIndex)
 
     # update alphas
     for asym in (:linealpha, :markeralpha, :fillalpha)
-        if d[asym] == nothing
-            d[asym] = d[:seriesalpha]
+        if plotattributes[asym] == nothing
+            plotattributes[asym] = plotattributes[:seriesalpha]
         end
     end
-    if d[:markerstrokealpha] == nothing
-        d[:markerstrokealpha] = d[:markeralpha]
+    if plotattributes[:markerstrokealpha] == nothing
+        plotattributes[:markerstrokealpha] = plotattributes[:markeralpha]
     end
 
     # update series color
-    d[:seriescolor] = getSeriesRGBColor(d[:seriescolor], sp, plotIndex)
+    plotattributes[:seriescolor] = getSeriesRGBColor(plotattributes[:seriescolor], sp, plotIndex)
 
     # update other colors
     for s in (:line, :marker, :fill)
         csym, asym = Symbol(s,:color), Symbol(s,:alpha)
-        d[csym] = if d[csym] == :auto
-            plot_color(if has_black_border_for_default(d[:seriestype]) && s == :line
+        plotattributes[csym] = if plotattributes[csym] == :auto
+            plot_color(if has_black_border_for_default(plotattributes[:seriestype]) && s == :line
                 sp[:foreground_color_subplot]
             else
-                d[:seriescolor]
+                plotattributes[:seriescolor]
             end)
-        elseif d[csym] == :match
-            plot_color(d[:seriescolor])
+        elseif plotattributes[csym] == :match
+            plot_color(plotattributes[:seriescolor])
         else
-            getSeriesRGBColor(d[csym], sp, plotIndex)
+            getSeriesRGBColor(plotattributes[csym], sp, plotIndex)
         end
     end
 
     # update markerstrokecolor
-    d[:markerstrokecolor] = if d[:markerstrokecolor] == :match
+    plotattributes[:markerstrokecolor] = if plotattributes[:markerstrokecolor] == :match
         plot_color(sp[:foreground_color_subplot])
-    elseif d[:markerstrokecolor] == :auto
-        getSeriesRGBColor(d[:markercolor], sp, plotIndex)
+    elseif plotattributes[:markerstrokecolor] == :auto
+        getSeriesRGBColor(plotattributes[:markercolor], sp, plotIndex)
     else
-        getSeriesRGBColor(d[:markerstrokecolor], sp, plotIndex)
+        getSeriesRGBColor(plotattributes[:markerstrokecolor], sp, plotIndex)
     end
 
     # if marker_z, fill_z or line_z are set, ensure we have a gradient
-    if d[:marker_z] != nothing
-        ensure_gradient!(d, :markercolor, :markeralpha)
+    if plotattributes[:marker_z] != nothing
+        ensure_gradient!(plotattributes, :markercolor, :markeralpha)
     end
-    if d[:line_z] != nothing
-        ensure_gradient!(d, :linecolor, :linealpha)
+    if plotattributes[:line_z] != nothing
+        ensure_gradient!(plotattributes, :linecolor, :linealpha)
     end
-    if d[:fill_z] != nothing
-        ensure_gradient!(d, :fillcolor, :fillalpha)
+    if plotattributes[:fill_z] != nothing
+        ensure_gradient!(plotattributes, :fillcolor, :fillalpha)
     end
 
     # scatter plots don't have a line, but must have a shape
-    if d[:seriestype] in (:scatter, :scatterbins, :scatterhist, :scatter3d)
-        d[:linewidth] = 0
-        if d[:markershape] == :none
-            d[:markershape] = :circle
+    if plotattributes[:seriestype] in (:scatter, :scatterbins, :scatterhist, :scatter3d)
+        plotattributes[:linewidth] = 0
+        if plotattributes[:markershape] == :none
+            plotattributes[:markershape] = :circle
         end
     end
 
     # set label
-    label = d[:label]
+    label = plotattributes[:label]
     label = (label == "AUTO" ? "y$globalIndex" : label)
-    d[:label] = label
+    plotattributes[:label] = label
 
-    _replace_linewidth(d)
-    d
-end
+    _replace_linewidth(plotattributes)
+   plotattributesend
 
-function _series_index(d, sp)
+function _series_index(plotattributes, sp)
     idx = 0
     for series in series_list(sp)
         if series[:primary]
             idx += 1
         end
-        if series == d
-            return idx
+        if series ==plotattributes            return idx
         end
     end
-    if get(d, :primary, true)
+    if get(plotattributes, :primary, true)
         idx += 1
     end
     return idx

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -457,7 +457,7 @@ end
 
 # ----------------------------------------------------------------
 
-# Override this to update plot items (title, xlabel, etc), and add annotations (d[:annotations])
+# Override this to update plot items (title, xlabel, etc), and add annotations (plotattributes[:annotations])
 function _update_plot_object(plt::Plot{InspectDRBackend})
     mplot = _inspectdr_getmplot(plt.o)
     if nothing == mplot; return; end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -149,7 +149,7 @@ function plotly_annotation_dict(x, y, ptxt::PlotText; xref="paper", yref="paper"
     ))
 end
 
-# function get_annotation_dict_for_arrow(d::KW, xyprev::Tuple, xy::Tuple, a::Arrow)
+# function get_annotation_dict_for_arrow(plotattributes::KW, xyprev::Tuple, xy::Tuple, a::Arrow)
 #     xdiff = xyprev[1] - xy[1]
 #     ydiff = xyprev[2] - xy[2]
 #     dist = sqrt(xdiff^2 + ydiff^2)
@@ -163,7 +163,7 @@ end
 #         # :ay => -40,
 #         :ax => 10xdiff / dist,
 #         :ay => -10ydiff / dist,
-#         :arrowcolor => rgba_string(d[:linecolor]),
+#         :arrowcolor => rgba_string(plotattributes[:linecolor]),
 #         :xref => "x",
 #         :yref => "y",
 #         :arrowsize => 10a.headwidth,
@@ -306,14 +306,14 @@ function plotly_polaraxis(axis::Axis)
 end
 
 function plotly_layout(plt::Plot)
-    d_out = KW()
+    plotattributes_out = KW()
 
     w, h = plt[:size]
-    d_out[:width], d_out[:height] = w, h
-    d_out[:paper_bgcolor] = rgba_string(plt[:background_color_outside])
-    d_out[:margin] = KW(:l=>0, :b=>20, :r=>0, :t=>20)
+    plotattributes_out[:width], plotattributes_out[:height] = w, h
+    plotattributes_out[:paper_bgcolor] = rgba_string(plt[:background_color_outside])
+    plotattributes_out[:margin] = KW(:l=>0, :b=>20, :r=>0, :t=>20)
 
-    d_out[:annotations] = KW[]
+    plotattributes_out[:annotations] = KW[]
 
     multiple_subplots = length(plt.subplots) > 1
 
@@ -334,10 +334,10 @@ function plotly_layout(plt::Plot)
             end
             titlex, titley = xy_mm_to_pcts(xmm, top(bbox(sp)), w*px, h*px)
             title_font = font(titlefont(sp), :top)
-            push!(d_out[:annotations], plotly_annotation_dict(titlex, titley, text(sp[:title], title_font)))
+            push!(plotattributes_out[:annotations], plotly_annotation_dict(titlex, titley, text(sp[:title], title_font)))
         end
 
-        d_out[:plot_bgcolor] = rgba_string(sp[:background_color_inside])
+        plotattributes_out[:plot_bgcolor] = rgba_string(sp[:background_color_inside])
 
         # set to supported framestyle
         sp[:framestyle] = _plotly_framestyle(sp[:framestyle])
@@ -346,7 +346,7 @@ function plotly_layout(plt::Plot)
         if is3d(sp)
             azim = sp[:camera][1] - 90 #convert azimuthal to match GR behaviour
             theta = 90 - sp[:camera][2] #spherical coordinate angle from z axis
-            d_out[:scene] = KW(
+            plotattributes_out[:scene] = KW(
                 Symbol("xaxis$(spidx)") => plotly_axis(plt, sp[:xaxis], sp),
                 Symbol("yaxis$(spidx)") => plotly_axis(plt, sp[:yaxis], sp),
                 Symbol("zaxis$(spidx)") => plotly_axis(plt, sp[:zaxis], sp),
@@ -361,19 +361,19 @@ function plotly_layout(plt::Plot)
                 ),
             )
         elseif ispolar(sp)
-            d_out[Symbol("angularaxis$(spidx)")] = plotly_polaraxis(sp[:xaxis])
-            d_out[Symbol("radialaxis$(spidx)")] = plotly_polaraxis(sp[:yaxis])
+            plotattributes_out[Symbol("angularaxis$(spidx)")] = plotly_polaraxis(sp[:xaxis])
+            plotattributes_out[Symbol("radialaxis$(spidx)")] = plotly_polaraxis(sp[:yaxis])
         else
-            d_out[Symbol("xaxis$(x_idx)")] = plotly_axis(plt, sp[:xaxis], sp)
+            plotattributes_out[Symbol("xaxis$(x_idx)")] = plotly_axis(plt, sp[:xaxis], sp)
             # don't allow yaxis to be reupdated/reanchored in a linked subplot
-            spidx == y_idx ? d_out[Symbol("yaxis$(y_idx)")] = plotly_axis(plt, sp[:yaxis], sp) : nothing
+            spidx == y_idx ? plotattributes_out[Symbol("yaxis$(y_idx)")] = plotly_axis(plt, sp[:yaxis], sp) : nothing
         end
 
         # legend
-        d_out[:showlegend] = sp[:legend] != :none
+        plotattributes_out[:showlegend] = sp[:legend] != :none
         xpos,ypos = plotly_legend_pos(sp[:legend])
         if sp[:legend] != :none
-            d_out[:legend] = KW(
+            plotattributes_out[:legend] = KW(
                 :bgcolor  => rgba_string(sp[:background_color_legend]),
                 :bordercolor => rgba_string(sp[:foreground_color_legend]),
                 :font     => plotly_font(legendfont(sp)),
@@ -385,13 +385,13 @@ function plotly_layout(plt::Plot)
 
         # annotations
         for ann in sp[:annotations]
-            append!(d_out[:annotations], KW[plotly_annotation_dict(locate_annotation(sp, ann...)...; xref = "x$(x_idx)", yref = "y$(y_idx)")])
+            append!(plotattributes_out[:annotations], KW[plotly_annotation_dict(locate_annotation(sp, ann...)...; xref = "x$(x_idx)", yref = "y$(y_idx)")])
         end
         # series_annotations
         for series in series_list(sp)
             anns = series[:series_annotations]
             for (xi,yi,str,fnt) in EachAnn(anns, series[:x], series[:y])
-                push!(d_out[:annotations], plotly_annotation_dict(
+                push!(plotattributes_out[:annotations], plotly_annotation_dict(
                     xi,
                     yi,
                     PlotText(str,fnt); xref = "x$(x_idx)", yref = "y$(y_idx)")
@@ -404,24 +404,24 @@ function plotly_layout(plt::Plot)
         #     a = sargs[:arrow]
         #     if sargs[:seriestype] in (:path, :line) && typeof(a) <: Arrow
         #         add_arrows(sargs[:x], sargs[:y]) do xyprev, xy
-        #             push!(d_out[:annotations], get_annotation_dict_for_arrow(sargs, xyprev, xy, a))
+        #             push!(plotattributes_out[:annotations], get_annotation_dict_for_arrow(sargs, xyprev, xy, a))
         #         end
         #     end
         # end
 
         if ispolar(sp)
-            d_out[:direction] = "counterclockwise"
+            plotattributes_out[:direction] = "counterclockwise"
         end
 
-        d_out
+        plotattributes_out
     end
 
     # turn off hover if nothing's using it
-    if all(series -> series.d[:hover] in (false,:none), plt.series_list)
-        d_out[:hovermode] = "none"
+    if all(series -> series.plotattributes[:hover] in (false,:none), plt.series_list)
+        plotattributes_out[:hovermode] = "none"
     end
 
-    d_out
+    plotattributes_out
 end
 
 function plotly_layout_json(plt::Plot)
@@ -527,7 +527,7 @@ end
 as_gradient(grad::ColorGradient, α) = grad
 as_gradient(grad, α) = cgrad(alpha = α)
 
-# get a dictionary representing the series params (d is the Plots-dict, d_out is the Plotly-dict)
+# get a dictionary representing the series params (plotattributes is the Plots-dict, plotattributes_out is the Plotly-dict)
 function plotly_series(plt::Plot, series::Series)
     st = series[:seriestype]
 
@@ -538,13 +538,13 @@ function plotly_series(plt::Plot, series::Series)
         return plotly_series_shapes(plt, series, clims)
     end
 
-    d_out = KW()
+    plotattributes_out = KW()
 
     # these are the axes that the series should be mapped to
     x_idx, y_idx = plotly_link_indicies(plt, sp)
-    d_out[:xaxis] = "x$(x_idx)"
-    d_out[:yaxis] = "y$(y_idx)"
-    d_out[:showlegend] = should_add_to_legend(series)
+    plotattributes_out[:xaxis] = "x$(x_idx)"
+    plotattributes_out[:yaxis] = "y$(y_idx)"
+    plotattributes_out[:showlegend] = should_add_to_legend(series)
 
     if st == :straightline
         x, y = straightline_data(series)
@@ -557,7 +557,7 @@ function plotly_series(plt::Plot, series::Series)
         for (letter, data) in zip((:x, :y, :z), (x, y, z))
     )
 
-    d_out[:name] = series[:label]
+    plotattributes_out[:name] = series[:label]
 
     isscatter = st in (:scatter, :scatter3d, :scattergl)
     hasmarker = isscatter || series[:markershape] != :none
@@ -565,10 +565,10 @@ function plotly_series(plt::Plot, series::Series)
     hasfillrange = st in (:path, :scatter, :scattergl, :straightline) &&
         (isa(series[:fillrange], AbstractVector) || isa(series[:fillrange], Tuple))
 
-    d_out[:colorbar] = KW(:title => sp[:colorbar_title])
+    plotattributes_out[:colorbar] = KW(:title => sp[:colorbar_title])
 
     if is_2tuple(clims)
-        d_out[:zmin], d_out[:zmax] = clims
+        plotattributes_out[:zmin], plotattributes_out[:zmax] = clims
     end
 
     # set the "type"
@@ -578,46 +578,46 @@ function plotly_series(plt::Plot, series::Series)
     elseif st == :heatmap
         x = heatmap_edges(x, sp[:xaxis][:scale])
         y = heatmap_edges(y, sp[:yaxis][:scale])
-        d_out[:type] = "heatmap"
-        d_out[:x], d_out[:y], d_out[:z] = x, y, z
-        d_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
-        d_out[:showscale] = hascolorbar(sp)
+        plotattributes_out[:type] = "heatmap"
+        plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
+        plotattributes_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
+        plotattributes_out[:showscale] = hascolorbar(sp)
 
     elseif st == :contour
-        d_out[:type] = "contour"
-        d_out[:x], d_out[:y], d_out[:z] = x, y, z
-        # d_out[:showscale] = series[:colorbar] != :none
-        d_out[:ncontours] = series[:levels]
-        d_out[:contours] = KW(:coloring => series[:fillrange] != nothing ? "fill" : "lines", :showlabels => series[:contour_labels] == true)
-        d_out[:colorscale] = plotly_colorscale(series[:linecolor], series[:linealpha])
-        d_out[:showscale] = hascolorbar(sp)
+        plotattributes_out[:type] = "contour"
+        plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
+        # plotattributes_out[:showscale] = series[:colorbar] != :none
+        plotattributes_out[:ncontours] = series[:levels]
+        plotattributes_out[:contours] = KW(:coloring => series[:fillrange] != nothing ? "fill" : "lines", :showlabels => series[:contour_labels] == true)
+        plotattributes_out[:colorscale] = plotly_colorscale(series[:linecolor], series[:linealpha])
+        plotattributes_out[:showscale] = hascolorbar(sp)
 
     elseif st in (:surface, :wireframe)
-        d_out[:type] = "surface"
-        d_out[:x], d_out[:y], d_out[:z] = x, y, z
+        plotattributes_out[:type] = "surface"
+        plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
         if st == :wireframe
-            d_out[:hidesurface] = true
+            plotattributes_out[:hidesurface] = true
             wirelines = KW(
                 :show => true,
                 :color => rgba_string(plot_color(series[:linecolor], series[:linealpha])),
                 :highlightwidth => series[:linewidth],
             )
-            d_out[:contours] = KW(:x => wirelines, :y => wirelines, :z => wirelines)
-            d_out[:showscale] = false
+            plotattributes_out[:contours] = KW(:x => wirelines, :y => wirelines, :z => wirelines)
+            plotattributes_out[:showscale] = false
         else
-            d_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
-            d_out[:opacity] = series[:fillalpha]
+            plotattributes_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
+            plotattributes_out[:opacity] = series[:fillalpha]
             if series[:fill_z] != nothing
-                d_out[:surfacecolor] = plotly_surface_data(series, series[:fill_z])
+                plotattributes_out[:surfacecolor] = plotly_surface_data(series, series[:fill_z])
             end
-            d_out[:showscale] = hascolorbar(sp)
+            plotattributes_out[:showscale] = hascolorbar(sp)
         end
 
     elseif st == :pie
-        d_out[:type] = "pie"
-        d_out[:labels] = pie_labels(sp, series)
-        d_out[:values] = y
-        d_out[:hoverinfo] = "label+percent+name"
+        plotattributes_out[:type] = "pie"
+        plotattributes_out[:labels] = pie_labels(sp, series)
+        plotattributes_out[:values] = y
+        plotattributes_out[:hoverinfo] = "label+percent+name"
 
     else
         @warn("Plotly: seriestype $st isn't supported.")
@@ -627,7 +627,7 @@ function plotly_series(plt::Plot, series::Series)
     # add "marker"
     if hasmarker
         inds = eachindex(x)
-        d_out[:marker] = KW(
+        plotattributes_out[:marker] = KW(
             :symbol => get(_plotly_markers, series[:markershape], string(series[:markershape])),
             # :opacity => series[:markeralpha],
             :size => 2 * _cycle(series[:markersize], inds),
@@ -639,22 +639,22 @@ function plotly_series(plt::Plot, series::Series)
         )
     end
 
-    plotly_polar!(d_out, series)
-    plotly_hover!(d_out, series[:hover])
+    plotly_polar!(plotattributes_out, series)
+    plotly_hover!(plotattributes_out, series[:hover])
 
-    return [d_out]
+    return [plotattributes_out]
 end
 
 function plotly_series_shapes(plt::Plot, series::Series, clims)
     segments = iter_segments(series)
-    d_outs = Vector{KW}(undef, length(segments))
+    plotattributes_outs = Vector{KW}(undef, length(segments))
 
-    # TODO: create a d_out for each polygon
+    # TODO: create a plotattributes_out for each polygon
     # x, y = series[:x], series[:y]
 
     # these are the axes that the series should be mapped to
     x_idx, y_idx = plotly_link_indicies(plt, series[:subplot])
-    d_base = KW(
+    plotattributes_base = KW(
         :xaxis => "x$(x_idx)",
         :yaxis => "y$(y_idx)",
         :name => series[:label],
@@ -669,7 +669,7 @@ function plotly_series_shapes(plt::Plot, series::Series, clims)
         length(rng) < 2 && continue
 
         # to draw polygons, we actually draw lines with fill
-        d_out = merge(d_base, KW(
+        plotattributes_out = merge(plotattributes_base, KW(
             :type => "scatter",
             :mode => "lines",
             :x => vcat(x[rng], x[rng[1]]),
@@ -684,19 +684,19 @@ function plotly_series_shapes(plt::Plot, series::Series, clims)
                 :dash => string(get_linestyle(series, i)),
             )
         end
-        d_out[:showlegend] = i==1 ? should_add_to_legend(series) : false
-        plotly_polar!(d_out, series)
-        plotly_hover!(d_out, _cycle(series[:hover], i))
-        d_outs[i] = d_out
+        plotattributes_out[:showlegend] = i==1 ? should_add_to_legend(series) : false
+        plotly_polar!(plotattributes_out, series)
+        plotly_hover!(plotattributes_out, _cycle(series[:hover], i))
+        plotattributes_outs[i] = plotattributes_out
     end
     if series[:fill_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, d_base, :fill))
+        push!(plotattributes_outs, plotly_colorbar_hack(series, plotattributes_base, :fill))
     elseif series[:line_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, d_base, :line))
+        push!(plotattributes_outs, plotly_colorbar_hack(series, plotattributes_base, :line))
     elseif series[:marker_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, d_base, :marker))
+        push!(plotattributes_outs, plotly_colorbar_hack(series, plotattributes_base, :marker))
     end
-    d_outs
+    plotattributes_outs
 end
 
 function plotly_series_segments(series::Series, d_base::KW, x, y, z, clims)
@@ -709,19 +709,19 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z, clims)
         (isa(series[:fillrange], AbstractVector) || isa(series[:fillrange], Tuple))
 
     segments = iter_segments(series)
-    d_outs = Vector{KW}(undef, (hasfillrange ? 2 : 1 ) * length(segments))
+    plotattributes_outs = Vector{KW}(undef, (hasfillrange ? 2 : 1 ) * length(segments))
 
     for (i,rng) in enumerate(segments)
         !isscatter && length(rng) < 2 && continue
 
-        d_out = deepcopy(d_base)
-        d_out[:showlegend] = i==1 ? should_add_to_legend(series) : false
-        d_out[:legendgroup] = series[:label]
+        plotattributes_out = deepcopy(plotattributes_base)
+        plotattributes_out[:showlegend] = i==1 ? should_add_to_legend(series) : false
+        plotattributes_out[:legendgroup] = series[:label]
 
         # set the type
         if st in (:path, :scatter, :scattergl, :straightline)
-            d_out[:type] = st==:scattergl ? "scattergl" : "scatter"
-            d_out[:mode] = if hasmarker
+            plotattributes_out[:type] = st==:scattergl ? "scattergl" : "scatter"
+            plotattributes_out[:mode] = if hasmarker
                 hasline ? "lines+markers" : "markers"
             else
                 hasline ? "lines" : "none"
@@ -735,21 +735,21 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z, clims)
             elseif !(series[:fillrange] in (false, nothing))
                 @warn("fillrange ignored... plotly only supports filling to zero and to a vector of values. fillrange: $(series[:fillrange])")
             end
-            d_out[:x], d_out[:y] = x[rng], y[rng]
+            plotattributes_out[:x], plotattributes_out[:y] = x[rng], y[rng]
 
         elseif st in (:path3d, :scatter3d)
-            d_out[:type] = "scatter3d"
-            d_out[:mode] = if hasmarker
+            plotattributes_out[:type] = "scatter3d"
+            plotattributes_out[:mode] = if hasmarker
                 hasline ? "lines+markers" : "markers"
             else
                 hasline ? "lines" : "none"
             end
-            d_out[:x], d_out[:y], d_out[:z] = x[rng], y[rng], z[rng]
+            plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x[rng], y[rng], z[rng]
         end
 
         # add "marker"
         if hasmarker
-            d_out[:marker] = KW(
+            plotattributes_out[:marker] = KW(
                 :symbol => get(_plotly_markers, _cycle(series[:markershape], i), string(_cycle(series[:markershape], i))),
                 # :opacity => series[:markeralpha],
                 :size => 2 * _cycle(series[:markersize], i),
@@ -777,14 +777,14 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z, clims)
             )
         end
 
-        plotly_polar!(d_out, series)
-        plotly_hover!(d_out, _cycle(series[:hover], rng))
+        plotly_polar!(plotattributes_out, series)
+        plotly_hover!(plotattributes_out, _cycle(series[:hover], rng))
 
         if hasfillrange
             # if hasfillrange is true, return two dictionaries (one for original
             # series, one for series being filled to) instead of one
-            d_out_fillrange = deepcopy(d_out)
-            d_out_fillrange[:showlegend] = false
+            plotattributes_out_fillrange = deepcopy(plotattributes_out)
+            plotattributes_out_fillrange[:showlegend] = false
             # if fillrange is provided as real or tuple of real, expand to array
             if typeof(series[:fillrange]) <: Real
                 series[:fillrange] = fill(series[:fillrange], length(rng))
@@ -794,49 +794,49 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z, clims)
                 series[:fillrange] = (f1, f2)
             end
             if isa(series[:fillrange], AbstractVector)
-                d_out_fillrange[:y] = series[:fillrange][rng]
-                delete!(d_out_fillrange, :fill)
-                delete!(d_out_fillrange, :fillcolor)
+                plotattributes_out_fillrange[:y] = series[:fillrange][rng]
+                delete!(plotattributes_out_fillrange, :fill)
+                delete!(plotattributes_out_fillrange, :fillcolor)
             else
-                # if fillrange is a tuple with upper and lower limit, d_out_fillrange
+                # if fillrange is a tuple with upper and lower limit, plotattributes_out_fillrange
                 # is the series that will do the filling
                 fillrng = Tuple(series[:fillrange][i][rng] for i in 1:2)
-                d_out_fillrange[:x], d_out_fillrange[:y] = concatenate_fillrange(x[rng], fillrng)
-                d_out_fillrange[:line][:width] = 0
-                delete!(d_out, :fill)
-                delete!(d_out, :fillcolor)
+                plotattributes_out_fillrange[:x], plotattributes_out_fillrange[:y] = concatenate_fillrange(x[rng], fillrng)
+                plotattributes_out_fillrange[:line][:width] = 0
+                delete!(plotattributes_out, :fill)
+                delete!(plotattributes_out, :fillcolor)
             end
 
-            d_outs[(2 * i - 1):(2 * i)] = [d_out_fillrange, d_out]
+            plotattributes_outs[(2 * i - 1):(2 * i)] = [plotattributes_out_fillrange, plotattributes_out]
         else
-            d_outs[i] = d_out
+            plotattributes_outs[i] = plotattributes_out
         end
     end
 
     if series[:line_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, d_base, :line))
+        push!(plotattributes_outs, plotly_colorbar_hack(series, plotattributes_base, :line))
     elseif series[:fill_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, d_base, :fill))
+        push!(plotattributes_outs, plotly_colorbar_hack(series, plotattributes_base, :fill))
     elseif series[:marker_z] != nothing
-        push!(d_outs, plotly_colorbar_hack(series, d_base, :marker))
+        push!(plotattributes_outs, plotly_colorbar_hack(series, plotattributes_base, :marker))
     end
 
-    d_outs
+    plotattributes_outs
 end
 
-function plotly_colorbar_hack(series::Series, d_base::KW, sym::Symbol)
-    d_out = deepcopy(d_base)
+function plotly_colorbar_hack(series::Series, plotattributes_base::KW, sym::Symbol)
+    plotattributes_out = deepcopy(plotattributes_base)
     cmin, cmax = get_clims(series[:subplot])
-    d_out[:showlegend] = false
-    d_out[:type] = is3d(series) ? :scatter3d : :scatter
-    d_out[:hoverinfo] = :none
-    d_out[:mode] = :markers
-    d_out[:x], d_out[:y] = [series[:x][1]], [series[:y][1]]
+    plotattributes_out[:showlegend] = false
+    plotattributes_out[:type] = is3d(series) ? :scatter3d : :scatter
+    plotattributes_out[:hoverinfo] = :none
+    plotattributes_out[:mode] = :markers
+    plotattributes_out[:x], plotattributes_out[:y] = [series[:x][1]], [series[:y][1]]
     if is3d(series)
-        d_out[:z] = [series[:z][1]]
+        plotattributes_out[:z] = [series[:z][1]]
     end
     # zrange = zmax == zmin ? 1 : zmax - zmin # if all marker_z values are the same, plot all markers same color (avoids division by zero in next line)
-    d_out[:marker] = KW(
+    plotattributes_out[:marker] = KW(
         :size => 0,
         :opacity => 0,
         :color => [0.5],
@@ -845,26 +845,26 @@ function plotly_colorbar_hack(series::Series, d_base::KW, sym::Symbol)
         :colorscale => plotly_colorscale(series[Symbol("$(sym)color")], 1),
         :showscale => hascolorbar(series[:subplot]),
     )
-    return d_out
+    return plotattributes_out
 end
 
 
-function plotly_polar!(d_out::KW, series::Series)
+function plotly_polar!(plotattributes_out::KW, series::Series)
     # convert polar plots x/y to theta/radius
     if ispolar(series[:subplot])
-        theta, r = filter_radial_data(pop!(d_out, :x), pop!(d_out, :y), axis_limits(series[:subplot][:yaxis]))
-        d_out[:t] = rad2deg.(theta)
-        d_out[:r] = r
+        theta, r = filter_radial_data(pop!(plotattributes_out, :x), pop!(plotattributes_out, :y), axis_limits(series[:subplot][:yaxis]))
+        plotattributes_out[:t] = rad2deg.(theta)
+        plotattributes_out[:r] = r
     end
 end
 
-function plotly_hover!(d_out::KW, hover)
+function plotly_hover!(plotattributes_out::KW, hover)
     # hover text
     if hover in (:none, false)
-        d_out[:hoverinfo] = "none"
+        plotattributes_out[:hoverinfo] = "none"
     elseif hover != nothing
-        d_out[:hoverinfo] = "text"
-        d_out[:text] = hover
+        plotattributes_out[:hoverinfo] = "text"
+        plotattributes_out[:text] = hover
     end
 end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -573,7 +573,7 @@ function plotly_series(plt::Plot, series::Series)
 
     # set the "type"
     if st in (:path, :scatter, :scattergl, :straightline, :path3d, :scatter3d)
-        return plotly_series_segments(series, d_out, x, y, z, clims)
+        return plotly_series_segments(series, plotattributes, x, y, z, clims)
 
     elseif st == :heatmap
         x = heatmap_edges(x, sp[:xaxis][:scale])
@@ -678,7 +678,7 @@ function plotly_series_shapes(plt::Plot, series::Series, clims)
             :fillcolor => rgba_string(plot_color(get_fillcolor(series, clims, i), get_fillalpha(series, i))),
         ))
         if series[:markerstrokewidth] > 0
-            d_out[:line] = KW(
+            plotattributes[:line] = KW(
                 :color => rgba_string(plot_color(get_linecolor(series, clims, i), get_linealpha(series, i))),
                 :width => get_linewidth(series, i),
                 :dash => string(get_linestyle(series, i)),
@@ -699,7 +699,7 @@ function plotly_series_shapes(plt::Plot, series::Series, clims)
     plotattributes_outs
 end
 
-function plotly_series_segments(series::Series, d_base::KW, x, y, z, clims)
+function plotly_series_segments(series::Series, ploattributes_base::KW, x, y, z, clims)
     st = series[:seriestype]
     sp = series[:subplot]
     isscatter = st in (:scatter, :scatter3d, :scattergl)
@@ -727,11 +727,11 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z, clims)
                 hasline ? "lines" : "none"
             end
             if series[:fillrange] == true || series[:fillrange] == 0 || isa(series[:fillrange], Tuple)
-                d_out[:fill] = "tozeroy"
-                d_out[:fillcolor] = rgba_string(plot_color(get_fillcolor(series, clims, i), get_fillalpha(series, i)))
+                plotattributes[:fill] = "tozeroy"
+                plotattributes[:fillcolor] = rgba_string(plot_color(get_fillcolor(series, clims, i), get_fillalpha(series, i)))
             elseif typeof(series[:fillrange]) <: Union{AbstractVector{<:Real}, Real}
-                d_out[:fill] = "tonexty"
-                d_out[:fillcolor] = rgba_string(plot_color(get_fillcolor(series, clims, i), get_fillalpha(series, i)))
+                plotattributes[:fill] = "tonexty"
+                plotattributes[:fillcolor] = rgba_string(plot_color(get_fillcolor(series, clims, i), get_fillalpha(series, i)))
             elseif !(series[:fillrange] in (false, nothing))
                 @warn("fillrange ignored... plotly only supports filling to zero and to a vector of values. fillrange: $(series[:fillrange])")
             end
@@ -763,7 +763,7 @@ function plotly_series_segments(series::Series, d_base::KW, x, y, z, clims)
 
         # add "line"
         if hasline
-            d_out[:line] = KW(
+            plotattributes[:line] = KW(
                 :color => rgba_string(plot_color(get_linecolor(series, clims, i), get_linealpha(series, i))),
                 :width => get_linewidth(series, i),
                 :shape => if st == :steppre

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -31,7 +31,7 @@ end
 
 function _series_updated(plt::Plot{PlotlyJSBackend}, series::Series)
     xsym, ysym = (ispolar(series) ? (:t,:r) : (:x,:y))
-    kw = KW(xsym => (series.d[:x],), ysym => (series.d[:y],))
+    kw = KW(xsym => (series.plotattributes[:x],), ysym => (series.plotattributes[:y],))
     z = series[:z]
     if z != nothing
         kw[:z] = (isa(z,Surface) ? transpose_z(series, series[:z].surf, false) : z,)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -263,7 +263,7 @@ end
 function fix_xy_lengths!(plt::Plot{PyPlotBackend}, series::Series)
     x, y = series[:x], series[:y]
     nx, ny = length(x), length(y)
-    if !isa(get(series.d, :z, nothing), Surface) && nx != ny
+    if !isa(get(series.plotattributes, :z, nothing), Surface) && nx != ny
         if nx < ny
             series[:x] = Float64[x[mod1(i,nx)] for i=1:ny]
         else
@@ -299,7 +299,7 @@ py_fillcolormap(series::Series)       = py_colormap(series[:fillcolor])
 # getAxis(sp::Subplot) = sp.o
 
 # function getAxis(plt::Plot{PyPlotBackend}, series::Series)
-#     sp = get_subplot(plt, get(series.d, :subplot, 1))
+#     sp = get_subplot(plt, get(series.plotattributes, :subplot, 1))
 #     getAxis(sp)
 # end
 
@@ -412,12 +412,12 @@ end
 # ---------------------------------------------------------------------------
 
 
-# function _series_added(pkg::PyPlotBackend, plt::Plot, d::KW)
+# function _series_added(pkg::PyPlotBackend, plt::Plot, plotattributes::KW)
 # TODO: change this to accept Subplot??
 # function _series_added(plt::Plot{PyPlotBackend}, series::Series)
 
 function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
-    # d = series.d
+    # plotattributes = series.plotattributes
     st = series[:seriestype]
     sp = series[:subplot]
     ax = sp.o
@@ -862,7 +862,7 @@ function py_compute_axis_minval(axis::Axis)
     sps = axis.sps
     for sp in sps
         for series in series_list(sp)
-            v = series.d[axis[:letter]]
+            v = series.plotattributes[axis[:letter]]
             if !isempty(v)
                 minval = NaNMath.min(minval, ignorenan_minimum(abs.(v)))
             end
@@ -1066,7 +1066,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             axis[:ticks] != :native ? py_set_ticks(ax, ticks, letter) : nothing
             pyaxis[:set_tick_params](direction = axis[:tick_direction] == :out ? "out" : "in")
             ax[Symbol("set_", letter, "label")](axis[:guide])
-            if get(axis.d, :flip, false)
+            if get(axis.plotattributes, :flip, false)
                 ax[Symbol("invert_", letter, "axis")]()
             end
             pyaxis[:label][:set_fontsize](py_thickness_scale(plt, axis[:guidefontsize]))

--- a/src/backends/template.jl
+++ b/src/backends/template.jl
@@ -49,7 +49,7 @@ end
 
 # ----------------------------------------------------------------
 
-# Override this to update plot items (title, xlabel, etc), and add annotations (d[:annotations])
+# Override this to update plot items (title, xlabel, etc), and add annotations (plotattributes[:annotations])
 function _update_plot_object(plt::Plot{[PkgName]Backend})
 end
 

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -25,7 +25,7 @@ const _unicodeplots_scale = [:identity]
 
 
 # don't warn on unsupported... there's just too many warnings!!
-warnOnUnsupported_args(::UnicodePlotsBackend, d::KW) = nothing
+warnOnUnsupported_args(::UnicodePlotsBackend, plotattributes::KW) = nothing
 
 # --------------------------------------------------------------------------------------
 
@@ -104,7 +104,7 @@ function rebuildUnicodePlot!(plt::Plot, width, height)
 
         # now use the ! functions to add to the plot
         for series in series_list(sp)
-            addUnicodeSeries!(o, series.d, sp[:legend] != :none, xlim, ylim)
+            addUnicodeSeries!(o, series.plotattributes, sp[:legend] != :none, xlim, ylim)
         end
 
         # save the object
@@ -114,17 +114,17 @@ end
 
 
 # add a single series
-function addUnicodeSeries!(o, d::KW, addlegend::Bool, xlim, ylim)
+function addUnicodeSeries!(o, plotattributes::KW, addlegend::Bool, xlim, ylim)
     # get the function, or special handling for step/bar/hist
-    st = d[:seriestype]
+    st = plotattributes[:seriestype]
     if st == :histogram2d
-        UnicodePlots.densityplot!(o, d[:x], d[:y])
+        UnicodePlots.densityplot!(o, plotattributes[:x], plotattributes[:y])
         return
     end
 
     if st in (:path, :straightline)
         func = UnicodePlots.lineplot!
-    elseif st == :scatter || d[:markershape] != :none
+    elseif st == :scatter || plotattributes[:markershape] != :none
         func = UnicodePlots.scatterplot!
     # elseif st == :bar
     #     func = UnicodePlots.barplot!
@@ -136,16 +136,16 @@ function addUnicodeSeries!(o, d::KW, addlegend::Bool, xlim, ylim)
 
     # get the series data and label
     x, y = if st == :straightline
-        straightline_data(d)
+        straightline_data(plotattributes)
     elseif st == :shape
         shape_data(series)
     else
-        [collect(float(d[s])) for s in (:x, :y)]
+        [collect(float(plotattributes[s])) for s in (:x, :y)]
     end
-    label = addlegend ? d[:label] : ""
+    label = addlegend ? plotattributes[:label] : ""
 
     # if we happen to pass in allowed color symbols, great... otherwise let UnicodePlots decide
-    color = d[:linecolor] in UnicodePlots.color_cycle ? d[:linecolor] : :auto
+    color = plotattributes[:linecolor] in UnicodePlots.color_cycle ? plotattributes[:linecolor] : :auto
 
     # add the series
     x, y = Plots.unzip(collect(Base.Iterators.filter(xy->isfinite(xy[1])&&isfinite(xy[2]), zip(x,y))))

--- a/src/deprecated/backends/bokeh.jl
+++ b/src/deprecated/backends/bokeh.jl
@@ -95,9 +95,9 @@ const _glyphtypes = KW(
   )
 
 
-function bokeh_glyph_type(d::KW)
-  st = d[:seriestype]
-  mt = d[:markershape]
+function bokeh_glyph_type(plotattributes::KW)
+  st = plotattributes[:seriestype]
+  mt = plotattributes[:markershape]
   if st == :scatter && mt == :none
     mt = :circle
   end
@@ -125,7 +125,7 @@ end
 
 # ---------------------------------------------------------------------------
 
-# function _create_plot(pkg::BokehBackend, d::KW)
+# function _create_plot(pkg::BokehBackend, plotattributes::KW)
 function _create_backend_figure(plt::Plot{BokehBackend})
   # TODO: create the window/canvas/context that is the plot within the backend (call it `o`)
   # TODO: initialize the plot... title, xlabel, bgcolor, etc
@@ -142,34 +142,34 @@ function _create_backend_figure(plt::Plot{BokehBackend})
   extra_args = KW()  # TODO: we'll put extra settings (xlim, etc) here
   Bokeh.Plot(datacolumns, tools, filename, title, w, h, xaxis_type, yaxis_type, legend) #, extra_args)
 
-  # Plot(bplt, pkg, 0, d, KW[])
+  # Plot(bplt, pkg, 0, plotattributes, KW[])
 end
 
 
-# function _series_added(::BokehBackend, plt::Plot, d::KW)
+# function _series_added(::BokehBackend, plt::Plot, plotattributes::KW)
 function _series_added(plt::Plot{BokehBackend}, series::Series)
-  bdata = Dict{Symbol, Vector}(:x => collect(series.d[:x]), :y => collect(series.d[:y]))
+  bdata = Dict{Symbol, Vector}(:x => collect(series.plotattributes[:x]), :y => collect(series.plotattributes[:y]))
 
   glyph = Bokeh.Bokehjs.Glyph(
-      glyphtype = bokeh_glyph_type(d),
-      linecolor = webcolor(d[:linecolor]),  # shape's stroke or line color
-      linewidth = d[:linewidth],          # shape's stroke width or line width
-      fillcolor = webcolor(d[:markercolor]),
-      size      = ceil(Int, d[:markersize] * 2.5),  # magic number 2.5 to keep in same scale as other backends
-      dash      = get_stroke_vector(d[:linestyle])
+      glyphtype = bokeh_glyph_type(plotattributes),
+      linecolor = webcolor(plotattributes[:linecolor]),  # shape's stroke or line color
+      linewidth = plotattributes[:linewidth],          # shape's stroke width or line width
+      fillcolor = webcolor(plotattributes[:markercolor]),
+      size      = ceil(Int, plotattributes[:markersize] * 2.5),  # magic number 2.5 to keep in same scale as other backends
+      dash      = get_stroke_vector(plotattributes[:linestyle])
     )
 
   legend = nothing  # TODO
   push!(plt.o.datacolumns, Bokeh.BokehDataSet(bdata, glyph, legend))
 
-  # push!(plt.seriesargs, d)
+  # push!(plt.seriesargs, plotattributes)
   # plt
 end
 
 # ----------------------------------------------------------------
 
 # TODO: override this to update plot items (title, xlabel, etc) after creation
-function _update_plot_object(plt::Plot{BokehBackend}, d::KW)
+function _update_plot_object(plt::Plot{BokehBackend}, plotattributes::KW)
 end
 
 # ----------------------------------------------------------------

--- a/src/deprecated/backends/immerse.jl
+++ b/src/deprecated/backends/immerse.jl
@@ -18,9 +18,9 @@ function _initialize_backend(::ImmerseBackend; kw...)
   end
 end
 
-function createImmerseFigure(d::KW)
-  w,h = d[:size]
-  figidx = Immerse.figure(; name = d[:window_title], width = w, height = h)
+function createImmerseFigure(plotattributes::KW)
+  w,h = plotattributes[:size]
+  figidx = Immerse.figure(; name = plotattributes[:window_title], width = w, height = h)
   Immerse.Figure(figidx)
 end
 
@@ -28,12 +28,12 @@ end
 
 
 # create a blank Gadfly.Plot object
-# function _create_plot(pkg::ImmerseBackend, d::KW)
+# function _create_plot(pkg::ImmerseBackend, plotattributes::KW)
 #   # create the underlying Gadfly.Plot object
-#   gplt = createGadflyPlotObject(d)
+#   gplt = createGadflyPlotObject(plotattributes)
 #
 #   # save both the Immerse.Figure and the Gadfly.Plot
-#   Plot((nothing,gplt), pkg, 0, d, KW[])
+#   Plot((nothing,gplt), pkg, 0, plotattributes, KW[])
 # end
 function _create_backend_figure(plt::Plot{ImmerseBackend})
     (nothing, createGadflyPlotObject(plt.attr))
@@ -41,20 +41,20 @@ end
 
 
 # # plot one data series
-# function _series_added(::ImmerseBackend, plt::Plot, d::KW)
-#   addGadflySeries!(plt, d)
-#   push!(plt.seriesargs, d)
+# function _series_added(::ImmerseBackend, plt::Plot, plotattributes::KW)
+#   addGadflySeries!(plt, plotattributes)
+#   push!(plt.seriesargs, plotattributes)
 #   plt
 # end
 
 function _series_added(plt::Plot{ImmerseBackend}, series::Series)
-    addGadflySeries!(plt, series.d)
+    addGadflySeries!(plt, series.plotattributes)
 end
 
 
-function _update_plot_object(plt::Plot{ImmerseBackend}, d::KW)
-  updateGadflyGuides(plt, d)
-  updateGadflyPlotTheme(plt, d)
+function _update_plot_object(plt::Plot{ImmerseBackend}, plotattributes::KW)
+  updateGadflyGuides(plt, plotattributes)
+  updateGadflyPlotTheme(plt, plotattributes)
 end
 
 
@@ -94,10 +94,10 @@ end
 #
 # function showSubplotObject(subplt::Subplot{ImmerseBackend})
 #   # create the Gtk window with vertical box vsep
-#   d = getattr(subplt,1)
-#   w,h = d[:size]
+#   plotattributes = getattr(subplt,1)
+#   w,h = plotattributes[:size]
 #   vsep = Gtk.GtkBoxLeaf(:v)
-#   win = Gtk.GtkWindowLeaf(vsep, d[:window_title], w, h)
+#   win = Gtk.GtkWindowLeaf(vsep, plotattributes[:window_title], w, h)
 #
 #   figindices = []
 #   row = Gtk.GtkBoxLeaf(:h)

--- a/src/deprecated/backends/winston.jl
+++ b/src/deprecated/backends/winston.jl
@@ -75,10 +75,10 @@ function _create_backend_figure(plt::Plot{WinstonBackend})
     )
 end
 
-copy_remove(d::KW, s::Symbol) = delete!(copy(d), s)
+copy_remove(plotattributes::KW, s::Symbol) = delete!(copy(plotattributes), s)
 
-function addRegressionLineWinston(d::KW, wplt)
-  xs, ys = regressionXY(d[:x], d[:y])
+function addRegressionLineWinston(plotattributes::KW, wplt)
+  xs, ys = regressionXY(plotattributes[:x], plotattributes[:y])
   Winston.add(wplt, Winston.Curve(xs, ys, kind="dotted"))
 end
 
@@ -93,22 +93,22 @@ function getWinstonItems(plt::Plot)
 end
 
 function _series_added(plt::Plot{WinstonBackend}, series::Series)
-    d = series.d
+    plotattributes = series.plotattributes
   window, canvas, wplt = getWinstonItems(plt)
 
   # until we call it normally, do the hack
-  if d[:seriestype] == :bar
-    d = barHack(;d...)
+  if plotattributes[:seriestype] == :bar
+    plotattributes = barHack(;plotattributes...)
   end
 
 
   e = KW()
-  e[:color] = getColor(d[:linecolor])
-  e[:linewidth] = d[:linewidth]
-  e[:kind] = winston_linestyle[d[:linestyle]]
-  e[:symbolkind] = winston_marker[d[:markershape]]
+  e[:color] = getColor(plotattributes[:linecolor])
+  e[:linewidth] = plotattributes[:linewidth]
+  e[:kind] = winston_linestyle[plotattributes[:linestyle]]
+  e[:symbolkind] = winston_marker[plotattributes[:markershape]]
   # markercolor     # same choices as `color`, or :match will set the color to be the same as `color`
-  e[:symbolsize] = d[:markersize] / 5
+  e[:symbolsize] = plotattributes[:markersize] / 5
 
   # pos             # (Int,Int), move the enclosing window to this position
   # screen          # Integer, move enclosing window to this screen number (for multiscreen desktops)
@@ -116,69 +116,69 @@ function _series_added(plt::Plot{WinstonBackend}, series::Series)
 
 
   ## lintype :path, :step, :stepinverted, :sticks, :dots, :none, :histogram2d, :hexbin, :histogram, :bar
-  if d[:seriestype] == :none
-    Winston.add(wplt, Winston.Points(d[:x], d[:y]; copy_remove(e, :kind)..., color=getColor(d[:markercolor])))
+  if plotattributes[:seriestype] == :none
+    Winston.add(wplt, Winston.Points(plotattributes[:x], plotattributes[:y]; copy_remove(e, :kind)..., color=getColor(plotattributes[:markercolor])))
 
-  elseif d[:seriestype] == :path
-    x, y = d[:x], d[:y]
+  elseif plotattributes[:seriestype] == :path
+    x, y = plotattributes[:x], plotattributes[:y]
     Winston.add(wplt, Winston.Curve(x, y; e...))
 
-    fillrange = d[:fillrange]
+    fillrange = plotattributes[:fillrange]
     if fillrange != nothing
       if isa(fillrange, AbstractVector)
         y2 = fillrange
       else
         y2 = Float64[fillrange for yi in y]
       end
-      Winston.add(wplt, Winston.FillBetween(x, y, x, y2, fillcolor=getColor(d[:fillcolor])))
+      Winston.add(wplt, Winston.FillBetween(x, y, x, y2, fillcolor=getColor(plotattributes[:fillcolor])))
     end
 
-  elseif d[:seriestype] == :scatter
-    if d[:markershape] == :none
-      d[:markershape] = :circle
+  elseif plotattributes[:seriestype] == :scatter
+    if plotattributes[:markershape] == :none
+      plotattributes[:markershape] = :circle
     end
 
-  # elseif d[:seriestype] == :step
+  # elseif plotattributes[:seriestype] == :step
   #     fn = Winston.XXX
 
-  # elseif d[:seriestype] == :stepinverted
+  # elseif plotattributes[:seriestype] == :stepinverted
   #     fn = Winston.XXX
 
-  elseif d[:seriestype] == :sticks
-      Winston.add(wplt, Winston.Stems(d[:x], d[:y]; e...))
+  elseif plotattributes[:seriestype] == :sticks
+      Winston.add(wplt, Winston.Stems(plotattributes[:x], plotattributes[:y]; e...))
 
-  # elseif d[:seriestype] == :dots
+  # elseif plotattributes[:seriestype] == :dots
   #     fn = Winston.XXX
 
-  # elseif d[:seriestype] == :histogram2d
+  # elseif plotattributes[:seriestype] == :histogram2d
   #     fn = Winston.XXX
 
-  # elseif d[:seriestype] == :hexbin
+  # elseif plotattributes[:seriestype] == :hexbin
   #     fn = Winston.XXX
 
-  elseif d[:seriestype] == :histogram
-      hst = hist(d[:y], d[:bins])
+  elseif plotattributes[:seriestype] == :histogram
+      hst = hist(plotattributes[:y], plotattributes[:bins])
       Winston.add(wplt, Winston.Histogram(hst...; copy_remove(e, :bins)...))
 
-  # elseif d[:seriestype] == :bar
+  # elseif plotattributes[:seriestype] == :bar
   #     # fn = Winston.XXX
 
   else
-    error("seriestype $(d[:seriestype]) not supported by Winston.")
+    error("seriestype $(plotattributes[:seriestype]) not supported by Winston.")
 
   end
 
 
   # markershape
-  if d[:markershape] != :none
-    Winston.add(wplt, Winston.Points(d[:x], d[:y]; copy_remove(e, :kind)..., color=getColor(d[:markercolor])))
+  if plotattributes[:markershape] != :none
+    Winston.add(wplt, Winston.Points(plotattributes[:x], plotattributes[:y]; copy_remove(e, :kind)..., color=getColor(plotattributes[:markercolor])))
   end
 
 
   # optionally add a regression line
-  d[:smooth] && d[:seriestype] != :histogram && addRegressionLineWinston(d, wplt)
+  plotattributes[:smooth] && plotattributes[:seriestype] != :histogram && addRegressionLineWinston(plotattributes, wplt)
 
-  # push!(plt.seriesargs, d)
+  # push!(plt.seriesargs, plotattributes)
   # plt
 end
 
@@ -192,17 +192,17 @@ const _winstonNames = KW(
     :yscale => :ylog,
   )
 
-function _update_plot_object(plt::Plot{WinstonBackend}, d::KW)
+function _update_plot_object(plt::Plot{WinstonBackend}, plotattributes::KW)
   window, canvas, wplt = getWinstonItems(plt)
   for k in (:xguide, :yguide, :title, :xlims, :ylims)
-    if haskey(d, k)
-      Winston.setattr(wplt, string(get(_winstonNames, k, k)), d[k])
+    if haskey(plotattributes, k)
+      Winston.setattr(wplt, string(get(_winstonNames, k, k)), plotattributes[k])
     end
   end
 
   for k in (:xscale, :yscale)
-    if haskey(d, k)
-      islogscale = d[k] == :log10
+    if haskey(plotattributes, k)
+      islogscale = plotattributes[k] == :log10
       Winston.setattr(wplt, (k == :xscale ? :xlog : :ylog), islogscale)
     end
   end

--- a/src/deprecated/series_args.jl
+++ b/src/deprecated/series_args.jl
@@ -7,7 +7,7 @@
 
 const FuncOrFuncs = Union{Function, AVec{Function}}
 
-all3D(plotattributes::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image), get(d, :seriestype, :none))
+all3D(plotattributes::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image), get(plotattributes, :seriestype, :none))
 
 # missing
 convertToAnyVector(v::Nothing, plotattributes::KW) = Any[nothing], nothing
@@ -22,7 +22,7 @@ convertToAnyVector(v::AVec{T}, plotattributes::KW) where {T<:Number} = Any[v], n
 convertToAnyVector(v::AVec{T}, plotattributes::KW) where {T<:AbstractString} = Any[v], nothing
 
 function convertToAnyVector(v::AMat, plotattributes::KW)
-    if all3D(d)
+    if all3D(plotattributes)
         Any[Surface(v)]
     else
         Any[v[:,i] for i in 1:size(v,2)]
@@ -48,7 +48,7 @@ function convertToAnyVector(v::AVec, plotattributes::KW)
         Any[convert(Vector{Float64}, v)], nothing
     else
         # something else... treat each element as an item
-        vcat(Any[convertToAnyVector(vi, d)[1] for vi in v]...), nothing
+        vcat(Any[convertToAnyVector(vi, plotattributes)[1] for vi in v]...), nothing
         # Any[vi for vi in v], nothing
     end
 end

--- a/src/deprecated/series_args.jl
+++ b/src/deprecated/series_args.jl
@@ -7,21 +7,21 @@
 
 const FuncOrFuncs = Union{Function, AVec{Function}}
 
-all3D(d::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image), get(d, :seriestype, :none))
+all3D(plotattributes::KW) = trueOrAllTrue(st -> st in (:contour, :contourf, :heatmap, :surface, :wireframe, :contour3d, :image), get(d, :seriestype, :none))
 
 # missing
-convertToAnyVector(v::Nothing, d::KW) = Any[nothing], nothing
+convertToAnyVector(v::Nothing, plotattributes::KW) = Any[nothing], nothing
 
 # fixed number of blank series
-convertToAnyVector(n::Integer, d::KW) = Any[zeros(0) for i in 1:n], nothing
+convertToAnyVector(n::Integer, plotattributes::KW) = Any[zeros(0) for i in 1:n], nothing
 
 # numeric vector
-convertToAnyVector(v::AVec{T}, d::KW) where {T<:Number} = Any[v], nothing
+convertToAnyVector(v::AVec{T}, plotattributes::KW) where {T<:Number} = Any[v], nothing
 
 # string vector
-convertToAnyVector(v::AVec{T}, d::KW) where {T<:AbstractString} = Any[v], nothing
+convertToAnyVector(v::AVec{T}, plotattributes::KW) where {T<:AbstractString} = Any[v], nothing
 
-function convertToAnyVector(v::AMat, d::KW)
+function convertToAnyVector(v::AMat, plotattributes::KW)
     if all3D(d)
         Any[Surface(v)]
     else
@@ -30,19 +30,19 @@ function convertToAnyVector(v::AMat, d::KW)
 end
 
 # function
-convertToAnyVector(f::Function, d::KW) = Any[f], nothing
+convertToAnyVector(f::Function, plotattributes::KW) = Any[f], nothing
 
 # surface
-convertToAnyVector(s::Surface, d::KW) = Any[s], nothing
+convertToAnyVector(s::Surface, plotattributes::KW) = Any[s], nothing
 
 # # vector of OHLC
-# convertToAnyVector(v::AVec{OHLC}, d::KW) = Any[v], nothing
+# convertToAnyVector(v::AVec{OHLC}, plotattributes::KW) = Any[v], nothing
 
 # dates
-convertToAnyVector(dts::AVec{D}, d::KW) where {D<:Union{Date,DateTime}} = Any[dts], nothing
+convertToAnyVector(dts::AVec{D}, plotattributes::KW) where {D<:Union{Date,DateTime}} = Any[dts], nothing
 
 # list of things (maybe other vectors, functions, or something else)
-function convertToAnyVector(v::AVec, d::KW)
+function convertToAnyVector(v::AVec, plotattributes::KW)
     if all(x -> typeof(x) <: Number, v)
         # all real numbers wrap the whole vector as one item
         Any[convert(Vector{Float64}, v)], nothing
@@ -53,7 +53,7 @@ function convertToAnyVector(v::AVec, d::KW)
     end
 end
 
-convertToAnyVector(t::Tuple, d::KW) = Any[t], nothing
+convertToAnyVector(t::Tuple, plotattributes::KW) = Any[t], nothing
 
 
 function convertToAnyVector(args...)

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -464,11 +464,11 @@ end
 # constructors
 
 # pass the layout arg through
-function layout_args(d::KW)
+function layout_args(plotattributes::KW)
     layout_args(get(d, :layout, default(:layout)))
 end
 
-function layout_args(d::KW, n_override::Integer)
+function layout_args(plotattributes::KW, n_override::Integer)
     layout, n = layout_args(get(d, :layout, n_override))
     if n != n_override
         error("When doing layout, n ($n) != n_override ($(n_override)).  You're probably trying to force existing plots into a layout that doesn't fit them.")

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -465,11 +465,11 @@ end
 
 # pass the layout arg through
 function layout_args(plotattributes::KW)
-    layout_args(get(d, :layout, default(:layout)))
+    layout_args(get(plotattributes, :layout, default(:layout)))
 end
 
 function layout_args(plotattributes::KW, n_override::Integer)
-    layout, n = layout_args(get(d, :layout, n_override))
+    layout, n = layout_args(get(plotattributes, :layout, n_override))
     if n != n_override
         error("When doing layout, n ($n) != n_override ($(n_override)).  You're probably trying to force existing plots into a layout that doesn't fit them.")
     end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -163,7 +163,7 @@ end
 # this is the core plotting function.  recursively apply recipes to build
 # a list of series KW dicts.
 # note: at entry, we only have those preprocessed args which were passed in... no default values yet
-function _plot!(plt::Plot, d::KW, args::Tuple)
+function _plot!(plt::Plot, plotattributes::KW, args::Tuple)
     d[:plot_object] = plt
 
     if !isempty(args) && !isdefined(Main, :StatPlots) &&

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -34,16 +34,16 @@ bottompad(sp::Subplot) = sp.minpad[4]
 get_subplot(plt::Plot, sp::Subplot) = sp
 get_subplot(plt::Plot, i::Integer) = plt.subplots[i]
 get_subplot(plt::Plot, k) = plt.spmap[k]
-get_subplot(series::Series) = series.d[:subplot]
+get_subplot(series::Series) = series.plotattributes[:subplot]
 
 get_subplot_index(plt::Plot, idx::Integer) = Int(idx)
 get_subplot_index(plt::Plot, sp::Subplot) = findfirst(x -> x === sp, plt.subplots)
 
-series_list(sp::Subplot) = sp.series_list # filter(series -> series.d[:subplot] === sp, sp.plt.series_list)
+series_list(sp::Subplot) = sp.series_list # filter(series -> series.plotattributes[:subplot] === sp, sp.plt.series_list)
 
 function should_add_to_legend(series::Series)
-    series.d[:primary] && series.d[:label] != "" &&
-        !(series.d[:seriestype] in (
+    series.plotattributes[:primary] && series.plotattributes[:label] != "" &&
+        !(series.plotattributes[:seriestype] in (
             :hexbin,:bins2d,:histogram2d,:hline,:vline,
             :contour,:contourf,:contour3d,:surface,:wireframe,
             :heatmap, :pie, :image

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,11 +21,11 @@ Base.isempty(wrapper::InputWrapper) = false
 # -----------------------------------------------------------
 
 mutable struct Series
-    d::KW
+    plotattributes::KW
 end
 
-attr(series::Series, k::Symbol) = series.d[k]
-attr!(series::Series, v, k::Symbol) = (series.d[k] = v)
+attr(series::Series, k::Symbol) = series.plotattributes[k]
+attr!(series::Series, v, k::Symbol) = (series.plotattributes[k] = v)
 
 # -----------------------------------------------------------
 
@@ -48,7 +48,7 @@ Base.show(io::IO, sp::Subplot) = print(io, "Subplot{$(sp[:subplot_index])}")
 # simple wrapper around a KW so we can hold all attributes pertaining to the axis in one place
 mutable struct Axis
     sps::Vector{Subplot}
-    d::KW
+    plotattributes::KW
 end
 
 mutable struct Extrema

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -130,7 +130,7 @@ function replace_image_with_heatmap(z::Array{T}) where T<:Colorant
     # newz, ColorGradient(colors)
 end
 
-function imageHack(d::KW)
+function imageHack(plotattributes::KW)
     is_seriestype_supported(:heatmap) || error("Neither :image or :heatmap are supported!")
     d[:seriestype] = :heatmap
     d[:z], d[:fillcolor] = replace_image_with_heatmap(d[:z].surf)
@@ -328,13 +328,13 @@ function replaceType(vec, val)
   push!(vec, val)
 end
 
-function replaceAlias!(d::KW, k::Symbol, aliases::Dict{Symbol,Symbol})
+function replaceAlias!(plotattributes::KW, k::Symbol, aliases::Dict{Symbol,Symbol})
   if haskey(aliases, k)
     d[aliases[k]] = pop!(d, k)
   end
 end
 
-function replaceAliases!(d::KW, aliases::Dict{Symbol,Symbol})
+function replaceAliases!(plotattributes::KW, aliases::Dict{Symbol,Symbol})
   ks = collect(keys(d))
   for k in ks
       replaceAlias!(d, k, aliases)
@@ -432,7 +432,7 @@ isscalar(::Any)  = false
 is_2tuple(v) = typeof(v) <: Tuple && length(v) == 2
 
 
-isvertical(d::KW) = get(d, :orientation, :vertical) in (:vertical, :v, :vert)
+isvertical(plotattributes::KW) = get(d, :orientation, :vertical) in (:vertical, :v, :vert)
 isvertical(series::Series) = isvertical(series.d)
 
 
@@ -806,7 +806,7 @@ end
 debugshow(x) = show(x)
 debugshow(x::AbstractArray) = print(summary(x))
 
-function dumpdict(d::KW, prefix = "", alwaysshow = false)
+function dumpdict(plotattributes::KW, prefix = "", alwaysshow = false)
   _debugMode.on || alwaysshow || return
   println()
   if prefix != ""
@@ -819,7 +819,7 @@ function dumpdict(d::KW, prefix = "", alwaysshow = false)
   end
   println()
 end
-DD(d::KW, prefix = "") = dumpdict(d, prefix, true)
+DD(plotattributes::KW, prefix = "") = dumpdict(d, prefix, true)
 
 
 function dumpcallstack()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,15 +19,15 @@ A hacky replacement for a histogram when the backend doesn't support histograms 
 Convert it into a bar chart with the appropriate x/y values.
 """
 function histogramHack(; kw...)
-  d = KW(kw)
+  plotattributes = KW(kw)
 
   # we assume that the y kwarg is set with the data to be binned, and nbins is also defined
-  edges, midpoints, buckets, counts = binData(d[:y], d[:bins])
-  d[:x] = midpoints
-  d[:y] = float(counts)
-  d[:seriestype] = :bar
-  d[:fillrange] = d[:fillrange] == nothing ? 0.0 : d[:fillrange]
-  d
+  edges, midpoints, buckets, counts = binData(plotattributes[:y], plotattributes[:bins])
+  plotattributes[:x] = midpoints
+  plotattributes[:y] = float(counts)
+  plotattributes[:seriestype] = :bar
+  plotattributes[:fillrange] = plotattributes[:fillrange] == nothing ? 0.0 : plotattributes[:fillrange]
+  plotattributes
 end
 
 """
@@ -35,10 +35,10 @@ A hacky replacement for a bar graph when the backend doesn't support bars direct
 Convert it into a line chart with fillrange set.
 """
 function barHack(; kw...)
-  d = KW(kw)
-  midpoints = d[:x]
-  heights = d[:y]
-  fillrange = d[:fillrange] == nothing ? 0.0 : d[:fillrange]
+  plotattributes = KW(kw)
+  midpoints = plotattributes[:x]
+  heights = plotattributes[:y]
+  fillrange = plotattributes[:fillrange] == nothing ? 0.0 : plotattributes[:fillrange]
 
   # estimate the edges
   dists = diff(midpoints) * 0.5
@@ -62,11 +62,11 @@ function barHack(; kw...)
     append!(y, [fillrange, heights[i], heights[i], fillrange])
   end
 
-  d[:x] = x
-  d[:y] = y
-  d[:seriestype] = :path
-  d[:fillrange] = fillrange
-  d
+  plotattributes[:x] = x
+  plotattributes[:y] = y
+  plotattributes[:seriestype] = :path
+  plotattributes[:fillrange] = fillrange
+  plotattributes
 end
 
 
@@ -75,33 +75,33 @@ A hacky replacement for a sticks graph when the backend doesn't support sticks d
 Convert it into a line chart that traces the sticks, and a scatter that sets markers at the points.
 """
 function sticksHack(; kw...)
-  dLine = KW(kw)
-  dScatter = copy(dLine)
+  plotattributesLine = KW(kw)
+  plotattributesScatter = copy(plotattributesLine)
 
   # these are the line vertices
   x = Float64[]
   y = Float64[]
-  fillrange = dLine[:fillrange] == nothing ? 0.0 : dLine[:fillrange]
+  fillrange = plotattributesLine[:fillrange] == nothing ? 0.0 : plotattributesLine[:fillrange]
 
   # calculate the vertices
-  yScatter = dScatter[:y]
-  for (i,xi) in enumerate(dScatter[:x])
+  yScatter = plotattributesScatter[:y]
+  for (i,xi) in enumerate(plotattributesScatter[:x])
     yi = yScatter[i]
     for j in 1:3 push!(x, xi) end
     append!(y, [fillrange, yScatter[i], fillrange])
   end
 
   # change the line args
-  dLine[:x] = x
-  dLine[:y] = y
-  dLine[:seriestype] = :path
-  dLine[:markershape] = :none
-  dLine[:fillrange] = nothing
+  plotattributesLine[:x] = x
+  plotattributesLine[:y] = y
+  plotattributesLine[:seriestype] = :path
+  plotattributesLine[:markershape] = :none
+  plotattributesLine[:fillrange] = nothing
 
   # change the scatter args
-  dScatter[:seriestype] = :none
+  plotattributesScatter[:seriestype] = :none
 
-  dLine, dScatter
+  plotattributesLine, plotattributesScatter
 end
 
 function regressionXY(x, y)
@@ -132,8 +132,8 @@ end
 
 function imageHack(plotattributes::KW)
     is_seriestype_supported(:heatmap) || error("Neither :image or :heatmap are supported!")
-    d[:seriestype] = :heatmap
-    d[:z], d[:fillcolor] = replace_image_with_heatmap(d[:z].surf)
+    plotattributes[:seriestype] = :heatmap
+    plotattributes[:z], plotattributes[:fillcolor] = replace_image_with_heatmap(plotattributes[:z].surf)
 end
 # ---------------------------------------------------------------
 
@@ -330,14 +330,14 @@ end
 
 function replaceAlias!(plotattributes::KW, k::Symbol, aliases::Dict{Symbol,Symbol})
   if haskey(aliases, k)
-    d[aliases[k]] = pop!(d, k)
+    plotattributes[aliases[k]] = pop!(plotattributes, k)
   end
 end
 
 function replaceAliases!(plotattributes::KW, aliases::Dict{Symbol,Symbol})
-  ks = collect(keys(d))
+  ks = collect(keys(plotattributes))
   for k in ks
-      replaceAlias!(d, k, aliases)
+      replaceAlias!(plotattributes, k, aliases)
   end
 end
 
@@ -347,7 +347,7 @@ Base.first(c::Colorant) = c
 Base.first(x::Symbol) = x
 
 
-sortedkeys(d::Dict) = sort(collect(keys(d)))
+sortedkeys(plotattributes::Dict) = sort(collect(keys(plotattributes)))
 
 
 const _scale_base = Dict{Symbol, Real}(
@@ -432,8 +432,8 @@ isscalar(::Any)  = false
 is_2tuple(v) = typeof(v) <: Tuple && length(v) == 2
 
 
-isvertical(plotattributes::KW) = get(d, :orientation, :vertical) in (:vertical, :v, :vert)
-isvertical(series::Series) = isvertical(series.d)
+isvertical(plotattributes::KW) = get(plotattributes, :orientation, :vertical) in (:vertical, :v, :vert)
+isvertical(series::Series) = isvertical(series.plotattributes)
 
 
 ticksType(ticks::AVec{T}) where {T<:Real}                      = :ticks
@@ -492,8 +492,8 @@ end
 # this is a helper function to determine whether we need to transpose a surface matrix.
 # it depends on whether the backend matches rows to x (transpose_on_match == true) or vice versa
 # for example: PyPlot sends rows to y, so transpose_on_match should be true
-function transpose_z(d, z, transpose_on_match::Bool = true)
-    if d[:match_dimensions] == transpose_on_match
+function transpose_z(plotattributes, z, transpose_on_match::Bool = true)
+    if plotattributes[:match_dimensions] == transpose_on_match
         # z'
         permutedims(z, [2,1])
     else
@@ -812,14 +812,14 @@ function dumpdict(plotattributes::KW, prefix = "", alwaysshow = false)
   if prefix != ""
     println(prefix, ":")
   end
-  for k in sort(collect(keys(d)))
+  for k in sort(collect(keys(plotattributes)))
     @printf("%14s: ", k)
-    debugshow(d[k])
+    debugshow(plotattributes[k])
     println()
   end
   println()
 end
-DD(plotattributes::KW, prefix = "") = dumpdict(d, prefix, true)
+DD(plotattributes::KW, prefix = "") = dumpdict(plotattributes, prefix, true)
 
 
 function dumpcallstack()
@@ -845,25 +845,25 @@ tovec(v::AbstractVector) = v
 tovec(v::Nothing) = zeros(0)
 
 function getxy(plt::Plot, i::Integer)
-    d = plt.series_list[i].d
-    tovec(d[:x]), tovec(d[:y])
+    plotattributes = plt.series_list[i].plotattributes
+    tovec(plotattributes[:x]), tovec(plotattributes[:y])
 end
 function getxyz(plt::Plot, i::Integer)
-    d = plt.series_list[i].d
-    tovec(d[:x]), tovec(d[:y]), tovec(d[:z])
+    plotattributes = plt.series_list[i].plotattributes
+    tovec(plotattributes[:x]), tovec(plotattributes[:y]), tovec(plotattributes[:z])
 end
 
 function setxy!(plt::Plot, xy::Tuple{X,Y}, i::Integer) where {X,Y}
     series = plt.series_list[i]
-    series.d[:x], series.d[:y] = xy
-    sp = series.d[:subplot]
+    series.plotattributes[:x], series.plotattributes[:y] = xy
+    sp = series.plotattributes[:subplot]
     reset_extrema!(sp)
     _series_updated(plt, series)
 end
 function setxyz!(plt::Plot, xyz::Tuple{X,Y,Z}, i::Integer) where {X,Y,Z}
     series = plt.series_list[i]
-    series.d[:x], series.d[:y], series.d[:z] = xyz
-    sp = series.d[:subplot]
+    series.plotattributes[:x], series.plotattributes[:y], series.plotattributes[:z] = xyz
+    sp = series.plotattributes[:subplot]
     reset_extrema!(sp)
     _series_updated(plt, series)
 end
@@ -912,9 +912,9 @@ Base.push!(series::Series, xi, yi, zi) = (push_x!(series,xi); push_y!(series,yi)
 # -------------------------------------------------------
 
 function attr!(series::Series; kw...)
-    d = KW(kw)
-    preprocessArgs!(d)
-    for (k,v) in d
+    plotattributes = KW(kw)
+    preprocessArgs!(plotattributes)
+    for (k,v) in plotattributes
         if haskey(_series_defaults, k)
             series[k] = v
         else
@@ -926,9 +926,9 @@ function attr!(series::Series; kw...)
 end
 
 function attr!(sp::Subplot; kw...)
-    d = KW(kw)
-    preprocessArgs!(d)
-    for (k,v) in d
+    plotattributes = KW(kw)
+    preprocessArgs!(plotattributes)
+    for (k,v) in plotattributes
         if haskey(_subplot_defaults, k)
             sp[k] = v
         else
@@ -1057,9 +1057,9 @@ mm2px(mm::Real)         = float(px / MM_PER_PX)
 
 
 "Smallest x in plot"
-xmin(plt::Plot) = ignorenan_minimum([ignorenan_minimum(series.d[:x]) for series in plt.series_list])
+xmin(plt::Plot) = ignorenan_minimum([ignorenan_minimum(series.plotattributes[:x]) for series in plt.series_list])
 "Largest x in plot"
-xmax(plt::Plot) = ignorenan_maximum([ignorenan_maximum(series.d[:x]) for series in plt.series_list])
+xmax(plt::Plot) = ignorenan_maximum([ignorenan_maximum(series.plotattributes[:x]) for series in plt.series_list])
 
 "Extrema of x-values in plot"
 ignorenan_extrema(plt::Plot) = (xmin(plt), xmax(plt))


### PR DESCRIPTION
The PR https://github.com/JuliaPlots/RecipesBase.jl/pull/29 and it's associated PRs to several packages changed Plots to internally use `plotattributes` rather than `d` in recipes, for clarity. It was changed in Plots where necessary, but the majority of places in Plots has kept the `d`.
This PR changes every instance of `d` to `plotattributes`, for consistency and clarity of the code. Depends on https://github.com/JuliaPlots/RecipesBase.jl/pull/47