### PR TITLE
Performance improvements

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -338,7 +338,11 @@ end
 
 
 # draw the markers, one at a time
-function gr_draw_markers(series::Series, x, y, msize, mz)
+function gr_draw_markers(series::Series, x, y, clims, msize = series[:markersize])
+
+    isempty(x) && return
+    GR.setfillintstyle(GR.INTSTYLE_SOLID)
+
     shapes = series[:markershape]
     if shapes != :none
         for i=1:length(x)
@@ -355,19 +359,12 @@ function gr_draw_markers(series::Series, x, y, msize, mz)
 
             # draw the shape - don't draw filled area if marker shape is 1D
             if !(shape in (:hline, :vline, :+, :x))
-                cfunc(get_markercolor(series, i))
+                cfunc(get_markercolor(series, clims, i))
                 gr_set_transparency(get_markeralpha(series, i))
                 gr_draw_marker(x[i], y[i], msi, shape)
             end
         end
     end
-end
-
-function gr_draw_markers(series::Series, x, y, clims)
-    isempty(x) && return
-    mz = normalize_zvals(series[:marker_z], clims)
-    GR.setfillintstyle(GR.INTSTYLE_SOLID)
-    gr_draw_markers(series, x, y, series[:markersize], mz)
 end
 
 # ---------------------------------------------------------
@@ -1038,7 +1035,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     GR.setfillintstyle(GR.INTSTYLE_SOLID)
                     fr_from, fr_to = (is_2tuple(frng) ? frng : (y, frng))
                     for (i, rng) in enumerate(segments)
-                        gr_set_fillcolor(get_fillcolor(series, i))
+                        gr_set_fillcolor(get_fillcolor(series, clims, i))
                         fx = _cycle(x, vcat(rng, reverse(rng)))
                         fy = vcat(_cycle(fr_from,rng), _cycle(fr_to,reverse(rng)))
                         gr_set_transparency(get_fillalpha(series, i))
@@ -1049,7 +1046,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 # draw the line(s)
                 if st in (:path, :straightline)
                     for (i, rng) in enumerate(segments)
-                        gr_set_line(get_linewidth(series, i), get_linestyle(series, i), get_linecolor(series, i)) #, series[:linealpha])
+                        gr_set_line(get_linewidth(series, i), get_linestyle(series, i), get_linecolor(series, clims, i)) #, series[:linealpha])
                         gr_set_transparency(get_linealpha(series, i))
                         arrowside = isa(series[:arrow], Arrow) ? series[:arrow].side : :none
                         gr_polyline(x[rng], y[rng]; arrowside = arrowside)
@@ -1129,7 +1126,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     lz = series[:line_z]
                     segments = iter_segments(series)
                     for (i, rng) in enumerate(segments)
-                        gr_set_line(get_linewidth(series, i), get_linestyle(series, i), get_linecolor(series, i)) #, series[:linealpha])
+                        gr_set_line(get_linewidth(series, i), get_linestyle(series, i), get_linecolor(series, clims, i)) #, series[:linealpha])
                         gr_set_transparency(get_linealpha(series, i))
                         GR.polyline3d(x[rng], y[rng], z[rng])
                     end
@@ -1201,12 +1198,12 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     xseg, yseg = x[rng], y[rng]
 
                     # draw the interior
-                    gr_set_fill(get_fillcolor(series, i))
+                    gr_set_fill(get_fillcolor(series, clims, i))
                     gr_set_transparency(get_fillalpha(series, i))
                     GR.fillarea(xseg, yseg)
 
                     # draw the shapes
-                    gr_set_line(get_linewidth(series, i), get_linestyle(series, i), get_linecolor(series, i))
+                    gr_set_line(get_linewidth(series, i), get_linestyle(series, i), get_linecolor(series, clims, i))
                     gr_set_transparency(get_linealpha(series, i))
                     GR.polyline(xseg, yseg)
                 end
@@ -1298,10 +1295,10 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             for series in series_list(sp)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
-                gr_set_line(get_linewidth(series), get_linestyle(series), get_linecolor(series)) #, series[:linealpha])
+                gr_set_line(get_linewidth(series), get_linestyle(series), get_linecolor(series, clims)) #, series[:linealpha])
 
                 if (st == :shape || series[:fillrange] != nothing) && series[:ribbon] == nothing
-                    gr_set_fill(get_fillcolor(series)) #, series[:fillalpha])
+                    gr_set_fill(get_fillcolor(series, clims)) #, series[:fillalpha])
                     l, r = xpos-0.07, xpos-0.01
                     b, t = ypos-0.4dy, ypos+0.4dy
                     x = [l, r, r, l, l]
@@ -1309,7 +1306,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     gr_set_transparency(get_fillalpha(series))
                     gr_polyline(x, y, GR.fillarea)
                     gr_set_transparency(get_linealpha(series))
-                    gr_set_line(get_linewidth(series), get_linestyle(series), get_linecolor(series))
+                    gr_set_line(get_linewidth(series), get_linestyle(series), get_linecolor(series, clims))
                     st == :shape && gr_polyline(x, y)
                 end
 
@@ -1323,7 +1320,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 end
 
                 if series[:markershape] != :none
-                    gr_draw_markers(series, xpos - .035, ypos, 6, nothing)
+                    gr_draw_markers(series, xpos - .035, ypos, clims, 6)
                 end
 
                 if typeof(series[:label]) <: Array

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -619,18 +619,18 @@ end
 
 for comp in (:line, :fill, :marker)
 
-    compcolor = Symbol(comp, :color)
+    compcolor = string(comp, :color)
     get_compcolor = Symbol(:get_, compcolor)
-    comp_z = Symbol(comp, :_z)
+    comp_z = string(comp, :_z)
 
-    compalpha = Symbol(comp, :alpha)
+    compalpha = string(comp, :alpha)
     get_compalpha = Symbol(:get_, compalpha)
 
     @eval begin
 
         function $get_compcolor(series, cmin::Real, cmax::Real, i::Int = 1)
-            c = series[$Symbol(compcolor)]
-            z = series[$Symbol(comp_z)]
+            c = series[$Symbol($compcolor)]
+            z = series[$Symbol($comp_z)]
             if z == nothing
                 isa(c, ColorGradient) ? c : plot_color(_cycle(c, i))
             else
@@ -639,17 +639,17 @@ for comp in (:line, :fill, :marker)
             end
         end
 
-        $get_compcolor(series, clims, i::Int = i) = $get_compcolor(series, clims[1], clims[2], i)
+        $get_compcolor(series, clims, i::Int = 1) = $get_compcolor(series, clims[1], clims[2], i)
 
         function $get_compcolor(series, i::Int = 1)
-            if series[$Symbol(comp_z)] == nothing
+            if series[$Symbol($comp_z)] == nothing
                 $get_compcolor(series, 0, 1, i)
             else
                 $get_compcolor(series, get_clims(series[:subplot]), i)
             end
         end
 
-        $get_compalpha(series, i::Int = 1) = _cycle(series[$compalpha], i)
+        $get_compalpha(series, i::Int = 1) = _cycle(series[$Symbol($compalpha)], i)
     end
 end
 


### PR DESCRIPTION
This improves the performance of large scatter plots with `marker_z`. See https://github.com/JuliaPlots/Plots.jl/pull/1511#discussion_r212554048.
Consider
```julia
n = 100000
x, y = randn(n), randn(n)
z = sqrt.(x.^2 + y.^2)
```
This changes the output of the second
```julia
@time display(scatter(x, y, mz = z))
```
call from
```
44.086065 seconds (3.41 M allocations: 231.762 MiB, 0.19% gc time)
```
to
```
2.927478 seconds (2.21 M allocations: 207.285 MiB, 15.22% gc time)
```

cc @mkborregaard 