### PR TITLE
RFC WIP: sort x axis in group_as_matrix

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -636,7 +636,7 @@ group_as_matrix(t) = false
             x = g.args[1]
             last_args = g.args[2:end]
         end
-        x_u = unique(x)
+        x_u = unique(sort(x))
         x_ind = Dict(zip(x_u, 1:length(x_u)))
         for (key,val) in plotattributes
             if splittable_kw(key, val, lengthGroup)


### PR DESCRIPTION
This probably deserves some discussion, see [this discourse thread](https://discourse.julialang.org/t/statplots-groupedbar-order-x-axis/13912/13)

The question is whether in StatPlots `groupedbar` (and whatever recipe uses `group_as_matrix`) should by default sort the `x` axis. Currently the `x` axis is ordered according to the order in which entries occur in the original vector, whereas with this PR they are sorted. What do you think?