### PR TITLE
WIP: Fix `-->` ignored in series recipes (Fixes #1639) 

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1536,7 +1536,13 @@ function _replace_linewidth(d::KW)
     end
 end
 
-function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
+function _slice_kw!(d::KW, commandIndex::Int)
+    for (k,v) in d
+        slice_arg!(d, d, k, v, commandIndex, false)
+    end
+end
+
+function _add_defaults!(d::KW, commandIndex::Int)
     # add default values to our dictionary, being careful not to delete what we just added!
     for (k,v) in _series_defaults
         slice_arg!(d, d, k, v, commandIndex, false)

--- a/src/args.jl
+++ b/src/args.jl
@@ -1536,7 +1536,7 @@ function _replace_linewidth(d::KW)
     end
 end
 
-function _slice_kw!(d::KW, commandIndex::Int)
+function _slice_attribute_cycles!(d::KW, commandIndex::Int)
     for (k,v) in d
         slice_arg!(d, d, k, v, commandIndex, false)
     end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -221,8 +221,7 @@ function _plot!(plt::Plot, d::KW, args::Tuple)
         # # we update subplot args in case something like the color palatte is part of the recipe
         # _update_subplot_args(plt, sp, kw, idx, true)
         
-        # select from attribute cycles
-        _slice_kw!(kw, command_idx(kw_list,kw))
+        _slice_attribute_cycles!(kw, command_idx(kw_list,kw))
 
         # now we have a fully specified series, with colors chosen.   we must recursively handle
         # series recipes, which dispatch on seriestype.  If a backend does not natively support a seriestype,


### PR DESCRIPTION
#1639 
Quick fix, still need to tidy a bit. I haven't used recipes much so I'm not quite sure what some odd cases could break this. So help with testing would be appreciated.

```
@recipe function g(::Type{Val{:testhist}}, x, y, z)
        markercolor := :red
        seriestype := :scatter
        ()
end

@recipe function f(::Type{Val{:testhist2}}, x, y, z)
        markercolor --> :red
         seriestype := :scatter
         ()
end

plot(rand(10,2), st = [:testhist :testhist2], layout = 2)
```

![image](https://user-images.githubusercontent.com/22132297/44627683-c2196e80-a929-11e8-822f-faaaffe60f54.png)
