### PR TITLE
Reinstate scatter-based spy implementation; fix #1682

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1042,7 +1042,7 @@ end
         markershape := :circle
     end
     if plotattributes[:markersize] == default(:markersize)
-        markersize := 1
+        markersize := 1.5
     end
     markerstrokewidth := 0
     marker_z := zs

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1024,9 +1024,13 @@ end
     @assert length(g.args) == 1 && typeof(g.args[1]) <: AbstractMatrix
     seriestype := :spy
     mat = g.args[1]
-    if length(unique(mat[mat .!= 0])) < 2
+    lunique = length(unique(mat[mat .!= 0]))
+    if lunique == 2
         legend --> nothing
         seriescolor --> cgrad([invisible(), fg_color(plotattributes)])
+    elseif lunique < 2
+        legend --> nothing
+        seriescolor --> fg_color(plotattributes)
     end
     n,m = size(mat)
     Plots.SliceIt, 1:m, 1:n, Surface(mat)
@@ -1045,7 +1049,7 @@ end
         markersize := 1.5
     end
     markerstrokewidth := 0
-    marker_z := zs
+    #marker_z := zs
     label := ""
     x := cs
     y := rs

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1035,21 +1035,23 @@ end
 @recipe function f(::Type{Val{:spy}}, x,y,z)
     yflip := true
     aspect_ratio := 1
-
     rs, cs, zs = findnz(z.surf)
-    newz = fill(NaN, size(z)...)
-
-    for i in eachindex(zs)
-        newz[rs[i],cs[i]] = zs[i]
+    xlim := ignorenan_extrema(cs)
+    ylim := ignorenan_extrema(rs)
+    if plotattributes[:markershape] == :none
+        markershape := :circle
     end
-
-    seriestype := :heatmap
+    if plotattributes[:markersize] == default(:markersize)
+        markersize := 1
+    end
+    markerstrokewidth := 0
+    marker_z := zs
+    label := ""
+    x := cs
+    y := rs
+    z := nothing
+    seriestype := :scatter
     grid --> false
-    framestyle --> :box
-
-    x := x
-    y := y
-    z := Surface(newz)
     ()
 end
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1024,14 +1024,6 @@ end
     @assert length(g.args) == 1 && typeof(g.args[1]) <: AbstractMatrix
     seriestype := :spy
     mat = g.args[1]
-    lunique = length(unique(mat[mat .!= 0]))
-    if lunique == 2
-        legend --> nothing
-        seriescolor --> cgrad([invisible(), fg_color(plotattributes)])
-    elseif lunique < 2
-        legend --> nothing
-        seriescolor --> fg_color(plotattributes)
-    end
     n,m = size(mat)
     Plots.SliceIt, 1:m, 1:n, Surface(mat)
 end
@@ -1046,7 +1038,7 @@ end
         markershape := :circle
     end
     if plotattributes[:markersize] == default(:markersize)
-        markersize := 1.5
+        markersize := 1
     end
     markerstrokewidth := 0
     #marker_z := zs

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1041,7 +1041,7 @@ end
         markersize := 1
     end
     markerstrokewidth := 0
-    #marker_z := zs
+    marker_z := zs
     label := ""
     x := cs
     y := rs


### PR DESCRIPTION
Turns out to be much faster for very big matrices. And - there's always `heatmap` for those that prefer that style.