### PR TITLE
Add option to change guide positions

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -111,6 +111,7 @@ const _arg_desc = KW(
 
 # axis args
 :guide     				  => "String. Axis guide (label).",
+:guide_position		  => "Symbol. Position of axis guides: :top, :bottom, :left or :right",
 :lims      				  => "NTuple{2,Number} or Symbol. Force axis limits.  Only finite values are used (you can set only the right limit with `xlims = (-Inf, 2)` for example). `:round` widens the limit to the nearest round number ie. [0.1,3.6]=>[0.0,4.0]",
 :ticks     				  => "Vector of numbers (set the tick values), Tuple of (tickvalues, ticklabels), or `:auto`",
 :scale     				  => "Symbol. Scale of the axis: `:none`, `:ln`, `:log2`, `:log10`",

--- a/src/args.jl
+++ b/src/args.jl
@@ -350,6 +350,7 @@ const _subplot_defaults = KW(
 
 const _axis_defaults = KW(
     :guide     => "",
+    :guide_position => :auto,
     :lims      => :auto,
     :ticks     => :auto,
     :scale     => :identity,

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -17,7 +17,7 @@ const _gr_attr = merge_with_base_supported([
     :bins,
     :layout,
     :title, :window_title,
-    :guide, :lims, :ticks, :scale, :flip,
+    :guide, :guide_position, :lims, :ticks, :scale, :flip,
     :match_dimensions,
     :titlefontfamily, :titlefontsize, :titlefonthalign, :titlefontvalign,
     :titlefontrotation, :titlefontcolor,
@@ -962,15 +962,25 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
     if xaxis[:guide] != ""
         gr_set_font(guidefont(xaxis))
-        GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_BOTTOM)
-        gr_text(gr_view_xcenter(), viewport_subplot[3], xaxis[:guide])
+        if xaxis[:guide_position] == :top
+            GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_TOP)
+            gr_text(gr_view_xcenter(), viewport_subplot[4], xaxis[:guide])
+        else
+            GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_BOTTOM)
+            gr_text(gr_view_xcenter(), viewport_subplot[3], xaxis[:guide])
+        end
     end
 
     if yaxis[:guide] != ""
         gr_set_font(guidefont(yaxis))
-        GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_TOP)
         GR.setcharup(-1, 0)
-        gr_text(viewport_subplot[1], gr_view_ycenter(), yaxis[:guide])
+        if yaxis[:guide_position] == :left
+            GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_BOTTOM)
+            gr_text(viewport_subplot[2], gr_view_ycenter(), yaxis[:guide])
+        else
+            GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_TOP)
+            gr_text(viewport_subplot[1], gr_view_ycenter(), yaxis[:guide])
+        end
     end
     GR.restorestate()
 

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -20,7 +20,7 @@ const _pgfplots_attr = merge_with_base_supported([
     # :bar_width, :bar_edges,
     :title,
     # :window_title,
-    :guide, :lims, :ticks, :scale, :flip, :rotation,
+    :guide, :guide_position, :lims, :ticks, :scale, :flip, :rotation,
     :tickfont, :guidefont, :legendfont,
     :grid, :legend,
     :colorbar, :colorbar_title,
@@ -364,9 +364,17 @@ function pgf_axis(sp::Subplot, letter)
     # axis guide
     kw[Symbol(letter,:label)] = axis[:guide]
 
+    # axis label position
+    labelpos = ""
+    if letter == :x && axis[:guide_position] == :top
+        labelpos = "at={(0.5,1)},above,"
+    elseif letter == :y && axis[:guide_position] == :right
+        labelpos = "at={(1,0.5)},below,"
+    end
+
     # Add label font
     cstr, α = pgf_color(plot_color(axis[:guidefontcolor]))
-    push!(style, string(letter, "label style = {font = ", pgf_font(axis[:guidefontsize], pgf_thickness_scaling(sp)), ", color = ", cstr, ", draw opacity = ", α, ", rotate = ", axis[:guidefontrotation], "}"))
+    push!(style, string(letter, "label style = {", labelpos ,"font = ", pgf_font(axis[:guidefontsize], pgf_thickness_scaling(sp)), ", color = ", cstr, ", draw opacity = ", α, ", rotate = ", axis[:guidefontrotation], "}"))
 
     # flip/reverse?
     axis[:flip] && push!(style, "$letter dir=reverse")

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -14,7 +14,7 @@ const _pyplot_attr = merge_with_base_supported([
     :bins, :bar_width, :bar_edges, :bar_position,
     :title, :title_location, :titlefont,
     :window_title,
-    :guide, :lims, :ticks, :scale, :flip, :rotation,
+    :guide, :guide_position, :lims, :ticks, :scale, :flip, :rotation,
     :titlefontfamily, :titlefontsize, :titlefontcolor,
     :legendfontfamily, :legendfontsize, :legendfontcolor,
     :tickfontfamily, :tickfontsize, :tickfontcolor,
@@ -1052,6 +1052,9 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 pyaxis[:set_label_position](pos)     # the guides
                 pyaxis[:set_ticks_position]("both")  # the hash marks
                 pyaxis[Symbol(:tick_, pos)]()        # the tick labels
+            end
+            if axis[:guide_position] != :auto && letter != :z
+                pyaxis[:set_label_position](axis[:guide_position])
             end
             py_set_scale(ax, axis)
             axis[:ticks] != :native ? py_set_lims(ax, axis) : nothing


### PR DESCRIPTION
This PR adds the option to change guide position in the PyPlot backend
```julia
plot(rand(10), yguide="rand", xguide="index", yguide_position=:right, xguide_position=:top)
```
![test](https://user-images.githubusercontent.com/847898/45479863-e6f24c00-b747-11e8-95fd-c1a97ef10693.png)
