### PR TITLE
Fix incremental compilation warnings (fix #1692, fix #1734)

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -170,6 +170,10 @@ include("backends.jl")
 include("output.jl")
 include("init.jl")
 
+include("backends/plotly.jl")
+include("backends/gr.jl")
+include("backends/web.jl")
+
 # ---------------------------------------------------------
 
 @shorthands scatter

--- a/src/init.jl
+++ b/src/init.jl
@@ -16,10 +16,6 @@ function __init__()
         pushdisplay(PlotsDisplay())
     end)
 
-    include(joinpath(@__DIR__, "backends", "plotly.jl"))
-    include(joinpath(@__DIR__, "backends", "gr.jl"))
-    include(joinpath(@__DIR__, "backends", "web.jl"))
-
     @require GLVisualize = "4086de5b-f4b6-55f3-abb0-b8c73827585f" include(joinpath(@__DIR__, "backends", "glvisualize.jl"))
     @require HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" include(joinpath(@__DIR__, "backends", "hdf5.jl"))
     @require InspectDR = "d0351b0e-4b05-5898-87b3-e2a8edfddd1d" include(joinpath(@__DIR__, "backends", "inspectdr.jl"))


### PR DESCRIPTION
They are caused by using `@eval` in `__init__()`. cf. https://github.com/JuliaInterop/RCall.jl/issues/238#issuecomment-377846786