### PR TITLE
Minor formatting fix

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -149,7 +149,7 @@ function pickDefaultBackend()
                 @warn("You have set `PLOTS_DEFAULT_BACKEND=$env_default` but `$(backend_package_name(sym))` is not loaded.")
             end
         else
-            @warn("You have set PLOTS_DEFAULT_BACKEND=$env_default but it is not a valid backend package.  Choose from:\n\t",
+            @warn("You have set PLOTS_DEFAULT_BACKEND=$env_default but it is not a valid backend package.  Choose from:\n\t" *
                  join(sort(_backends), "\n\t"))
         end
     end


### PR DESCRIPTION
Before this change:

```
julia> using Plots

julia> ENV["PLOTS_DEFAULT_BACKEND"] = "abc"
"abc"

julia> Plots.pickDefaultBackend()
┌ Warning: You have set PLOTS_DEFAULT_BACKEND=abc but it is not a valid backend package.  Choose from:
│
│   join(sort(_backends), "\n\t") = "glvisualize\n\tgr\n\thdf5\n\tinspectdr\n\tpgfplots\n\tplotly\n\tplotlyjs\n\tpyplot\n\tunicodeplots"
└ @ Plots ~/.julia/dev/Plots/src/backends.jl:152
Plots.GRBackend()
```

After:

```
julia> using Plots

julia> ENV["PLOTS_DEFAULT_BACKEND"] = "abc"
"abc"

julia> Plots.pickDefaultBackend()
┌ Warning: You have set PLOTS_DEFAULT_BACKEND=abc but it is not a valid backend package.  Choose from:
│ 	glvisualize
│ 	gr
│ 	hdf5
│ 	inspectdr
│ 	pgfplots
│ 	plotly
│ 	plotlyjs
│ 	pyplot
│ 	unicodeplots
└ @ Plots ~/.julia/dev/Plots/src/backends.jl:152
Plots.GRBackend()
```