### PR TITLE
GR: use correct attribute for axis color

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -855,12 +855,12 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
         # axis lines
         if xaxis[:showaxis]
-            gr_set_line(1, :solid, xaxis[:foreground_color_axis])
+            gr_set_line(1, :solid, xaxis[:foreground_color_border])
             GR.setclip(0)
             gr_polyline(coords(xspine_segs)...)
         end
         if yaxis[:showaxis]
-            gr_set_line(1, :solid, yaxis[:foreground_color_axis])
+            gr_set_line(1, :solid, yaxis[:foreground_color_border])
             GR.setclip(0)
             gr_polyline(coords(yspine_segs)...)
         end


### PR DESCRIPTION
```julia
using Plots
using StatPlots, DataFrames

test = DataFrame(
    x = rand(20),
    y = rand(20),
    grp = rand(["g 1"; "g 2"], 20)
 )

gr()
@df test scatter(:x, :y, group=:grp, xlab="x", ylab="y",
                  foreground_color_axis=:blue,
                  foreground_color_border=:green)
```
Before:

![scatter_gr_before](https://user-images.githubusercontent.com/6280307/46905579-38802900-cef6-11e8-9f90-1e844584dce9.png)

After:
![scatter_gr_after](https://user-images.githubusercontent.com/6280307/46905640-015e4780-cef7-11e8-867b-0e4333efae4c.png)

Now it matches behavior for `pyplot()`, I can't reproduce right now, because my `PyCall.jl` doesn't build.

This will be helpful for JuliaPlots/PlotThemes.jl/pull/30

As an aside, the attribute names could be changed so something more intuitive, IMO.