### PR TITLE
Fallback to non gr3 surface call

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1058,7 +1058,11 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 if length(x) == length(y) == length(z)
                     GR.trisurface(x, y, z)
                 else
-                    GR.gr3.surface(x, y, z, GR.OPTION_COLORED_MESH)
+                    try
+                        GR.gr3.surface(x, y, z, GR.OPTION_COLORED_MESH)
+                    catch
+                        GR.surface(x, y, z, GR.OPTION_COLORED_MESH)
+                    end
                 end
             else
                 GR.setfillcolorind(0)


### PR DESCRIPTION
Taking an idea from @FlorianRhiem in this issue https://github.com/jheinen/GR.jl/issues/159, I figured I would fall back to GR if GR3 had an error. With this change, I was able to solve my issue in https://github.com/JuliaPlots/Plots.jl/issues/1781