### PR TITLE
Smuggle PyCall and LaTeXStrings through PyPlot

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -526,8 +526,7 @@ const _plotlyjs_scale       = _plotly_scale
 
 function _initialize_backend(::PyPlotBackend)
     @eval Main begin
-        import PyPlot, PyCall
-        import LaTeXStrings
+        import PyPlot
 
         export PyPlot
 
@@ -539,11 +538,8 @@ end
 function add_backend_string(::PyPlotBackend)
     """
     using Pkg
-    Pkg.add("PyPlot")
-    Pkg.add("PyCall")
-    Pkg.add("LaTeXStrings")
     withenv("PYTHON" => "") do
-        Pkg.build("PyCall")
+        Pkg.add("PyPlot")
         Pkg.build("PyPlot")
     end
     """

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1,3 +1,6 @@
+# Do "using PyPlot: PyCall, LaTeXStrings" without dependency warning:
+const PyCall = PyPlot.PyCall
+const LaTeXStrings = PyPlot.LaTeXStrings
 
 # https://github.com/stevengj/PyPlot.jl
 
@@ -187,26 +190,22 @@ function add_pyfixedformatter(cbar, vals::AVec)
     cbar[:update_ticks]()
 end
 
-@require LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f" begin
-    function labelfunc(scale::Symbol, backend::PyPlotBackend)
-        if scale == :log10
-            x -> LaTeXStrings.latexstring("10^{$x}")
-        elseif scale == :log2
-            x -> LaTeXStrings.latexstring("2^{$x}")
-        elseif scale == :ln
-            x -> LaTeXStrings.latexstring("e^{$x}")
-        else
-            string
-        end
+function labelfunc(scale::Symbol, backend::PyPlotBackend)
+    if scale == :log10
+        x -> LaTeXStrings.latexstring("10^{$x}")
+    elseif scale == :log2
+        x -> LaTeXStrings.latexstring("2^{$x}")
+    elseif scale == :ln
+        x -> LaTeXStrings.latexstring("e^{$x}")
+    else
+        string
     end
 end
 
-@require PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0" begin
-    function py_mask_nans(z)
-        # pynp["ma"][:masked_invalid](z)))
-        PyCall.pycall(pynp["ma"][:masked_invalid], Any, z)
-        # pynp["ma"][:masked_where](pynp["isnan"](z),z)
-    end
+function py_mask_nans(z)
+    # pynp["ma"][:masked_invalid](z)))
+    PyCall.pycall(pynp["ma"][:masked_invalid], Any, z)
+    # pynp["ma"][:masked_where](pynp["isnan"](z),z)
 end
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Use the trick similar to https://github.com/JuliaPlots/Plots.jl/issues/1672#issuecomment-436396876 for when initializing PyPlot backend. This way, users only have to do `]add PyPlot` (instead of `]add PyPlot PyCall LaTeXStrings`).

Here is how I checked that it works:

```julia
(v1.0) pkg> rm PyCall

julia> using Plots; pyplot()
Plots.PyPlotBackend()

julia> plot([1,2,3])

julia> using PyCall
ERROR: ArgumentError: Package PyCall not found in current path:
- Run `import Pkg; Pkg.add("PyCall")` to install the PyCall package.

Stacktrace:
 [1] require(::Module, ::Symbol) at ./loading.jl:820
```


fix #1672
fix https://github.com/JuliaPy/PyPlot.jl/issues/389
fix https://github.com/JuliaPy/PyPlot.jl/issues/408