### PR TITLE
Feature Request: Add `showlegend` option to allow a series to opt out of being in the legend

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -279,6 +279,7 @@ const _series_defaults = KW(
     :series_annotations => nothing,       # a list of annotations which apply to the coordinates of this series
     :primary            => true,     # when true, this "counts" as a series for color selection, etc.  the main use is to allow
                                      #     one logical series to be broken up (path and markers, for example)
+    :showlegend         => true,     # when false, this series will be left out of the generated legend.
     :hover              => nothing,  # text to display when hovering over the data points
     :stride             => (1,1),    # array stride for wireframe/surface, the first element is the row stride and the second is the column stride.
 )

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -47,7 +47,7 @@ function should_add_to_legend(series::Series)
             :hexbin,:bins2d,:histogram2d,:hline,:vline,
             :contour,:contourf,:contour3d,:surface,:wireframe,
             :heatmap, :pie, :image
-        ))
+        )) && series.plotattributes[:showlegend] == true
 end
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
We wanted this when we had three subplots all sharing a legend, and didn't want to have the same keys show up in the shared legend three times. So we have one of the series on one of the subplots set `showlegend = true`, and the others set `showlegend = false`.


Does this seem like a useful option to include? I named it `showlegend` to match the _plotly_ setting with the same name, but I actually think maybe something like `addtolegend` or `include_in_legend` or something _might_ be better?

Anyway, I just wanted to push this up to get your feedback on it, since we found it useful locally in our work! :)