### PR TITLE
changed behaviour of Vector{<:SVector} as input argument; close #1886

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 ---
 ## (current master)
-- changed behaviour of Vectors of length-2 and length-3 StaticVectors
+- Removed StaticArrays dependency and changed behaviour of Vectors of length-2 and length-3 StaticVectors
 
 ## 0.22.1
 - push PlotsDisplay just after REPLDisplay

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ---
 ## (current master)
+- changed behaviour of Vectors of length-2 and length-3 StaticVectors
 
 ## 0.22.1
 - push PlotsDisplay just after REPLDisplay

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,6 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -4,7 +4,6 @@ _current_plots_version = v"0.20.6"
 
 using Reexport
 
-import StaticArrays
 using Dates, Printf, Statistics, Base64, LinearAlgebra, Random
 import SparseArrays: findnz
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -1,12 +1,12 @@
 
 
-const P2 = StaticArrays.SVector{2,Float64}
-const P3 = StaticArrays.SVector{3,Float64}
+const P2 = NTuple{2,Float64}
+const P3 = NTuple{3,Float64}
 
-nanpush!(a::AbstractVector{P2}, b) = (push!(a, P2(NaN,NaN)); push!(a, b))
-nanappend!(a::AbstractVector{P2}, b) = (push!(a, P2(NaN,NaN)); append!(a, b))
-nanpush!(a::AbstractVector{P3}, b) = (push!(a, P3(NaN,NaN,NaN)); push!(a, b))
-nanappend!(a::AbstractVector{P3}, b) = (push!(a, P3(NaN,NaN,NaN)); append!(a, b))
+nanpush!(a::AbstractVector{P2}, b) = (push!(a, (NaN,NaN)); push!(a, b))
+nanappend!(a::AbstractVector{P2}, b) = (push!(a, (NaN,NaN)); append!(a, b))
+nanpush!(a::AbstractVector{P3}, b) = (push!(a, (NaN,NaN,NaN)); push!(a, b))
+nanappend!(a::AbstractVector{P3}, b) = (push!(a, (NaN,NaN,NaN)); append!(a, b))
 compute_angle(v::P2) = (angle = atan(v[2], v[1]); angle < 0 ? 2π - angle : angle)
 
 # -------------------------------------------------------------
@@ -104,7 +104,7 @@ function makecross(; offset = -0.5, radius = 1.0)
 end
 
 
-from_polar(angle, dist) = P2(dist*cos(angle), dist*sin(angle))
+from_polar(angle, dist) = (dist*cos(angle), dist*sin(angle))
 
 function makearrowhead(angle; h = 2.0, w = 0.4)
     tip = from_polar(angle, h)
@@ -754,17 +754,17 @@ end
 
 # -----------------------------------------------------------------------
 "create a BezierCurve for plotting"
-mutable struct BezierCurve{T <: StaticArrays.SVector}
+mutable struct BezierCurve{T <: Tuple}
     control_points::Vector{T}
 end
 
 function (bc::BezierCurve)(t::Real)
-    p = zero(P2)
+    p = zeros(2)
     n = length(bc.control_points)-1
     for i in 0:n
-        p += bc.control_points[i+1] * binomial(n, i) * (1-t)^(n-i) * t^i
+        @. p += bc.control_points[i+1] * binomial(n, i) * (1-t)^(n-i) * t^i
     end
-    p
+    (p...,)
 end
 
 # mean(x::Real, y::Real) = 0.5*(x+y) #commented out as I cannot see this used anywhere and it overwrites a Base method with different functionality

--- a/src/series.jl
+++ b/src/series.jl
@@ -547,7 +547,7 @@ end
 #
 #
 # # --------------------------------------------------------------------
-# # Lists of tuples and StaticArrays
+# # Lists of tuples
 # # --------------------------------------------------------------------
 #
 # # if we get an unhandled tuple, just splat it in
@@ -566,17 +566,6 @@ end
 # these might be points+velocity, or OHLC or something else
 @recipe f(xyuv::AVec{Tuple{R1,R2,R3,R4}}) where {R1<:Number,R2<:Number,R3<:Number,R4<:Number} = get(plotattributes,:seriestype,:path)==:ohlc ? OHLC[OHLC(t...) for t in xyuv] : unzip(xyuv)
 @recipe f(xyuv::Tuple{R1,R2,R3,R4}) where {R1<:Number,R2<:Number,R3<:Number,R4<:Number}       = [xyuv[1]], [xyuv[2]], [xyuv[3]], [xyuv[4]]
-
-
-#
-# # 2D StaticArrays
-@recipe f(xy::AVec{StaticArrays.SVector{2,T}}) where {T<:Number} = unzip(xy)
-@recipe f(xy::StaticArrays.SVector{2,T}) where {T<:Number}       = [xy[1]], [xy[2]]
-
-#
-# # 3D StaticArrays
-@recipe f(xyz::AVec{StaticArrays.SVector{3,T}}) where {T<:Number} = unzip(xyz)
-@recipe f(xyz::StaticArrays.SVector{3,T}) where {T<:Number}       = [xyz[1]], [xyz[2]], [xyz[3]]
 
 #
 # # --------------------------------------------------------------------

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -287,15 +287,6 @@ unzip(xy::AVec{Tuple{X,Y}}) where {X,Y}              = [t[1] for t in xy], [t[2]
 unzip(xyz::AVec{Tuple{X,Y,Z}}) where {X,Y,Z}         = [t[1] for t in xyz], [t[2] for t in xyz], [t[3] for t in xyz]
 unzip(xyuv::AVec{Tuple{X,Y,U,V}}) where {X,Y,U,V}    = [t[1] for t in xyuv], [t[2] for t in xyuv], [t[3] for t in xyuv], [t[4] for t in xyuv]
 
-unzip(xy::AVec{StaticArrays.SVector{2,T}}) where {T}  = T[t[1] for t in xy], T[t[2] for t in xy]
-unzip(xy::StaticArrays.SVector{2,T}) where {T}        = T[xy[1]], T[xy[2]]
-
-unzip(xyz::AVec{StaticArrays.SVector{3,T}}) where {T} = T[t[1] for t in xyz], T[t[2] for t in xyz], T[t[3] for t in xyz]
-unzip(xyz::StaticArrays.SVector{3,T}) where {T}       = T[xyz[1]], T[xyz[2]], T[xyz[3]]
-
-unzip(xyuv::AVec{StaticArrays.SVector{4,T}}) where {T} = T[t[1] for t in xyuv], T[t[2] for t in xyuv], T[t[3] for t in xyuv], T[t[4] for t in xyuv]
-unzip(xyuv::StaticArrays.SVector{4,T}) where {T}       = T[xyuv[1]], T[xyuv[2]], T[xyuv[3]], T[xyuv[4]]
-
 # given 2-element lims and a vector of data x, widen lims to account for the extrema of x
 function _expand_limits(lims, x)
   try


### PR DESCRIPTION
No longer treats Vectors of length-2 or length-3 StaticVectors as a list of points. This is by request from @JeffBezanson to not change the behaviour of StaticVectors outside the domain of an AbstractVector (#1886)