### PR TITLE
WIP clamp greyscale images to (0,1)

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -323,12 +323,14 @@ end
 
 
 # # images - grays
+clamp_greys(mat::AMat{T}) where T<:Gray = Gray.(clamp!([m.val for m in mat], 0, 1))
 
 @recipe function f(mat::AMat{T}) where T<:Gray
     n, m = size(mat)
     if is_seriestype_supported(:image)
         seriestype := :image
         yflip --> true
+        any(x-> x.val<0 || x.val >1, mat) && (mat = clamp_greys(mat))
         SliceIt, 1:m, 1:n, Surface(mat)
     else
         seriestype := :heatmap

--- a/src/series.jl
+++ b/src/series.jl
@@ -335,7 +335,7 @@ end
         yflip --> true
         cbar --> false
         fillcolor --> ColorGradient([:black, :white])
-        SliceIt, 1:m, 1:n, Surface(convert(Matrix{Float64}, mat))
+        SliceIt, 1:m, 1:n, Surface(clamp!(convert(Matrix{Float64}, mat), 0., 1.))
     end
 end
 


### PR DESCRIPTION
So far only works for the heatmap version for those backends that don't support images natively. GR or PyPlot need special behaviour