### PR TITLE
Add vline to PGFPlots.

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -457,7 +457,7 @@ const _pgfplots_attr = merge_with_base_supported([
 ])
 const _pgfplots_seriestype = [:path, :path3d, :scatter, :steppre, :stepmid, :steppost, :histogram2d, :ysticks, :xsticks, :contour, :shape, :straightline,]
 const _pgfplots_style = [:auto, :solid, :dash, :dot, :dashdot, :dashdotdot]
-const _pgfplots_marker = [:none, :auto, :circle, :rect, :diamond, :utriangle, :dtriangle, :cross, :xcross, :star5, :pentagon, :hline] #vcat(_allMarkers, Shape)
+const _pgfplots_marker = [:none, :auto, :circle, :rect, :diamond, :utriangle, :dtriangle, :cross, :xcross, :star5, :pentagon, :hline, :vline] #vcat(_allMarkers, Shape)
 const _pgfplots_scale = [:identity, :ln, :log2, :log10]
 
 # ------------------------------------------------------------------------------

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -26,7 +26,8 @@ const _pgfplots_markers = KW(
     :star6 => "asterisk",
     :diamond => "diamond*",
     :pentagon => "pentagon*",
-    :hline => "-"
+    :hline => "-",
+    :vline => "|"
 )
 
 const _pgfplots_legend_pos = KW(


### PR DESCRIPTION
This enables proper vertical error bars.