### PR TITLE
Add LaTeX output for pyplot backend.

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1332,7 +1332,8 @@ const _pyplot_mimeformats = Dict(
     "application/pdf"         => "pdf",
     "image/png"               => "png",
     "application/postscript"  => "ps",
-    "image/svg+xml"           => "svg"
+    "image/svg+xml"           => "svg",
+    "application/x-tex"       => "pgf"
 )
 
 


### PR DESCRIPTION
Actually matplotlib supports outputting LaTeX via pgf:
https://matplotlib.org/users/pgf.html

This fixes #1198.