### PR TITLE
Add option :tex_output_standalone for standalone documentclass

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -63,6 +63,7 @@ const _arg_desc = KW(
 :link                     => "Symbol.  How/whether to link axis limits between subplots. Values: `:none`, `:x` (x axes are linked by columns), `:y` (y axes are linked by rows), `:both` (x and y are linked), `:all` (every subplot is linked together regardless of layout position).",
 :overwrite_figure         => "Bool.  Should we reuse the same GUI window/figure when plotting (true) or open a new one (false).",
 :html_output_format       => "Symbol.  When writing html output, what is the format?  `:png` and `:svg` are currently supported.",
+:tex_output_standalone    => "Bool. When writing tex output, should the source include a preamble for a standalone document class.",
 :inset_subplots           => "nothing or vector of 2-tuple (parent,bbox).  optionally pass a vector of (parent,bbox) tuples which are the parent layout and the relative bounding box of inset subplots",
 :dpi 			  => "Number.  Dots Per Inch of output figures",
 :thickness_scaling        => "Number. Scale for the thickness of all line elements like lines, borders, axes, grid lines, ... defaults to 1.",

--- a/src/args.jl
+++ b/src/args.jl
@@ -298,6 +298,7 @@ const _plot_defaults = KW(
     :link                        => :none,
     :overwrite_figure            => true,
     :html_output_format          => :auto,
+    :tex_output_standalone       => false,
     :inset_subplots              => nothing,   # optionally pass a vector of (parent,bbox) tuples which are
                                                # the parent layout and the relative bounding box of inset subplots
     :dpi                         => DPI,        # dots per inch for images, etc

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -564,7 +564,7 @@ end
 
 function _show(io::IO, mime::MIME"application/x-tex", plt::Plot{PGFPlotsBackend})
     fn = tempname()*".tex"
-    PGFPlots.save(fn, backend_object(plt), include_preamble=false)
+    PGFPlots.save(fn, backend_object(plt), include_preamble=plt.attr[:tex_output_standalone])
     write(io, read(open(fn), String))
 end
 


### PR DESCRIPTION
Add option :tex_output_standalone to set the 'include_preamble' argument in the PGFPlots backend. It allows creating a .tex file with a standalone document class, so it can be compiled on its own.