### PR TITLE
Display in svg format in Juno if :html_output_format is :auto

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -250,7 +250,7 @@ function showjuno(io::IO, m, plt)
 end
 
 function _showjuno(io::IO, m::MIME"image/svg+xml", plt)
-  if Symbol(plt.attr[:html_output_format]) ≠ :svg
+  if !(plt.attr[:html_output_format] in (:auto, :svg))
     throw(MethodError(show, (typeof(m), typeof(plt))))
   else
     _show(io, m, plt)


### PR DESCRIPTION
I think Juno should display a plot if :html_output_format is set to :auto and the backend supports :svg.

However, I'm a bit unsure on how :html_output_format is/should be handled. Should it be used only when a MIME of text/html is requested, or even when just a display(plt) is called? (Is it format or *html* format?)

Also not sure what would happen if :html_output_format was set to :auto and a backend didn't support :svg (I don't think such a backend exists currently)? Would the error be caught and a different MIME tried automatically?