### PR TITLE
put radius 0 at the center for polar plots (fix #1813)

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -502,7 +502,7 @@ function axis_limits(axis::Axis, should_widen::Bool = default_should_widen(axis)
             amin, amax = 0, 2pi
         elseif lims == :auto
             #widen max radius so ticks dont overlap with theta axis
-            amin, amax + 0.1 * abs(amax - amin)
+            0, amax + 0.1 * abs(amax - amin)
         else
             amin, amax
         end


### PR DESCRIPTION
Now radius 0 is put at the center by default for polar plots. It can still be changed manually via ylims.
```julia
plot(
	plot([0, π/2, π], [0.5, 0.6, 0.6], proj=:polar, title = "default"),
	plot([0, π/2, π], [0.5, 0.6, 0.6], proj=:polar, ylims = (0.3 , Inf), title = "ylims = (0.3 , Inf)"), label = ""
)
```
![polar](https://user-images.githubusercontent.com/16589944/54279809-436ae280-4596-11e9-9bdb-1cf1d62e4b08.png)