### PR TITLE
fix multiple drawing of discrete ticks

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -251,7 +251,7 @@ function get_ticks(axis::Axis)
             # discrete ticks...
             n = length(dvals)
             rng = if ticks == :auto
-                Int[round(Int,i) for i in range(1, stop=n, length=15)]
+                Int[round(Int,i) for i in range(1, stop=n, length=min(n,15))]
             else # if ticks == :all
                 1:n
             end


### PR DESCRIPTION
Changes
```julia
plot(plot(["A", "B"], 1:2)
```
from
![multiticks](https://user-images.githubusercontent.com/16589944/55095476-8362b700-50b8-11e9-9d82-999dec8e8b2b.png)

to
![singleticks](https://user-images.githubusercontent.com/16589944/55095551-9d9c9500-50b8-11e9-8659-dc4f487ca6b1.png)

Note the difference in x grid lines and x tick labels.