### PR TITLE
don't draw ticks twice in gr for framestyle in (:zerolines, :grid)

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -837,7 +837,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         if xaxis[:showaxis]
             if sp[:framestyle] in (:zerolines, :grid)
                 gr_set_line(1, :solid, xaxis[:foreground_color_grid])
-                gr_set_transparency(xaxis[:gridalpha])
+                gr_set_transparency(xaxis[:tick_direction] == :out ? xaxis[:gridalpha] : 0)
             else
                 gr_set_line(1, :solid, xaxis[:foreground_color_axis])
             end
@@ -847,7 +847,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         if  yaxis[:showaxis]
             if sp[:framestyle] in (:zerolines, :grid)
                 gr_set_line(1, :solid, yaxis[:foreground_color_grid])
-                gr_set_transparency(yaxis[:gridalpha])
+                gr_set_transparency(yaxis[:tick_direction] == :out ? yaxis[:gridalpha] : 0)
             else
                 gr_set_line(1, :solid, yaxis[:foreground_color_axis])
             end


### PR DESCRIPTION
changes
```julia
scatter(randn(10), randn(10), framestyle = :zerolines)
```
from
![zerolinesold](https://user-images.githubusercontent.com/16589944/55223986-bcfa0600-520f-11e9-9951-ed5e59620efa.png)
to
![zerolinesnew](https://user-images.githubusercontent.com/16589944/55223992-c1262380-520f-11e9-92a1-da5f83ba5d5b.png)
You have to take a close look at the ticks.
Admittedly a very subtle difference, but it annoyed me 🙂 