### PR TITLE
replace StaticArrays with GeometryTypes (fix #1886)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,14 @@
 ---
 ## (current master)
 
+## 0.25.0
+- Replace StaticArrays with GeometryTypes
+- Contour fixes for GR
+
 ## 0.24.0
 - Update to the new PyCall and PyPlot API
+- fix drawing of ticks
+- fix y label position with GR
 
 ## 0.23.2
 - pyplot fixes

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ RecipesBase 0.6.0
 PlotUtils 0.4.1
 PlotThemes 0.1.3
 Reexport
-StaticArrays 0.5
+GeometryTypes
 FixedPointNumbers 0.3
 Measures
 Showoff

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -4,7 +4,7 @@ _current_plots_version = v"0.24.0"
 
 using Reexport
 
-import StaticArrays
+import GeometryTypes
 using Dates, Printf, Statistics, Base64, LinearAlgebra, Random
 import SparseArrays: findnz
 

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -1,6 +1,6 @@
 module Plots
 
-_current_plots_version = v"0.24.0"
+_current_plots_version = v"0.25.0"
 
 using Reexport
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -1,7 +1,7 @@
 
 
-const P2 = StaticArrays.SVector{2,Float64}
-const P3 = StaticArrays.SVector{3,Float64}
+const P2 = GeometryTypes.Point2{Float64}
+const P3 = GeometryTypes.Point3{Float64}
 
 nanpush!(a::AbstractVector{P2}, b) = (push!(a, P2(NaN,NaN)); push!(a, b))
 nanappend!(a::AbstractVector{P2}, b) = (push!(a, P2(NaN,NaN)); append!(a, b))
@@ -261,13 +261,13 @@ end
 Create a Font from a list of features. Values may be specified either as
 arguments (which are distinguished by type/value) or as keyword arguments.
 # Arguments
-- `family`: AbstractString. "serif" or "sans-serif" or "monospace" 
+- `family`: AbstractString. "serif" or "sans-serif" or "monospace"
 - `pointsize`: Integer. Size of font in points
 - `halign`: Symbol. Horizontal alignment (:hcenter, :left, or :right)
 - `valign`: Symbol. Vertical aligment (:vcenter, :top, or :bottom)
 - `rotation`: Real. Angle of rotation for text in degrees (use a non-integer type)
 - `color`: Colorant or Symbol
-# Examples 
+# Examples
 ```julia-repl
 julia> font(8)
 julia> font(family="serif",halign=:center,rotation=45.0)
@@ -388,8 +388,8 @@ PlotText(str) = PlotText(string(str), font())
 """
     text(string, args...; kw...)
 
-Create a PlotText object wrapping a string with font info, for plot annotations. 
-`args` and `kw` are passed to `font`. 
+Create a PlotText object wrapping a string with font info, for plot annotations.
+`args` and `kw` are passed to `font`.
 """
 text(t::PlotText) = t
 text(t::PlotText, font::Font) = PlotText(t.str, font)
@@ -779,7 +779,7 @@ end
 
 # -----------------------------------------------------------------------
 "create a BezierCurve for plotting"
-mutable struct BezierCurve{T <: StaticArrays.SVector}
+mutable struct BezierCurve{T <: GeometryTypes.Point}
     control_points::Vector{T}
 end
 
@@ -791,9 +791,6 @@ function (bc::BezierCurve)(t::Real)
     end
     p
 end
-
-# mean(x::Real, y::Real) = 0.5*(x+y) #commented out as I cannot see this used anywhere and it overwrites a Base method with different functionality
-# mean{N,T<:Real}(ps::StaticArrays.SVector{N,T}...) = sum(ps) / length(ps) # I also could not see this used anywhere, and it's type piracy - implementing a NaNMath version for this would just involve converting to a standard array
 
 @deprecate curve_points coords
 

--- a/src/series.jl
+++ b/src/series.jl
@@ -554,7 +554,7 @@ end
 #
 #
 # # --------------------------------------------------------------------
-# # Lists of tuples and StaticArrays
+# # Lists of tuples and GeometryTypes.Points
 # # --------------------------------------------------------------------
 #
 # # if we get an unhandled tuple, just splat it in
@@ -576,14 +576,14 @@ end
 
 
 #
-# # 2D StaticArrays
-@recipe f(xy::AVec{StaticArrays.SVector{2,T}}) where {T<:Number} = unzip(xy)
-@recipe f(xy::StaticArrays.SVector{2,T}) where {T<:Number}       = [xy[1]], [xy[2]]
+# # 2D Points
+@recipe f(xy::AVec{GeometryTypes.Point{2,T}}) where {T<:Number} = unzip(xy)
+@recipe f(xy::GeometryTypes.Point{2,T}) where {T<:Number}       = [xy[1]], [xy[2]]
 
 #
-# # 3D StaticArrays
-@recipe f(xyz::AVec{StaticArrays.SVector{3,T}}) where {T<:Number} = unzip(xyz)
-@recipe f(xyz::StaticArrays.SVector{3,T}) where {T<:Number}       = [xyz[1]], [xyz[2]], [xyz[3]]
+# # 3D Points
+@recipe f(xyz::AVec{GeometryTypes.Point{3,T}}) where {T<:Number} = unzip(xyz)
+@recipe f(xyz::GeometryTypes.Point{3,T}) where {T<:Number}       = [xyz[1]], [xyz[2]], [xyz[3]]
 
 #
 # # --------------------------------------------------------------------

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -290,14 +290,14 @@ unzip(xy::AVec{Tuple{X,Y}}) where {X,Y}              = [t[1] for t in xy], [t[2]
 unzip(xyz::AVec{Tuple{X,Y,Z}}) where {X,Y,Z}         = [t[1] for t in xyz], [t[2] for t in xyz], [t[3] for t in xyz]
 unzip(xyuv::AVec{Tuple{X,Y,U,V}}) where {X,Y,U,V}    = [t[1] for t in xyuv], [t[2] for t in xyuv], [t[3] for t in xyuv], [t[4] for t in xyuv]
 
-unzip(xy::AVec{StaticArrays.SVector{2,T}}) where {T}  = T[t[1] for t in xy], T[t[2] for t in xy]
-unzip(xy::StaticArrays.SVector{2,T}) where {T}        = T[xy[1]], T[xy[2]]
+unzip(xy::AVec{GeometryTypes.Point{2,T}}) where {T}  = T[t[1] for t in xy], T[t[2] for t in xy]
+unzip(xy::GeometryTypes.Point{2,T}) where {T}        = T[xy[1]], T[xy[2]]
 
-unzip(xyz::AVec{StaticArrays.SVector{3,T}}) where {T} = T[t[1] for t in xyz], T[t[2] for t in xyz], T[t[3] for t in xyz]
-unzip(xyz::StaticArrays.SVector{3,T}) where {T}       = T[xyz[1]], T[xyz[2]], T[xyz[3]]
+unzip(xyz::AVec{GeometryTypes.Point{3,T}}) where {T} = T[t[1] for t in xyz], T[t[2] for t in xyz], T[t[3] for t in xyz]
+unzip(xyz::GeometryTypes.Point{3,T}) where {T}       = T[xyz[1]], T[xyz[2]], T[xyz[3]]
 
-unzip(xyuv::AVec{StaticArrays.SVector{4,T}}) where {T} = T[t[1] for t in xyuv], T[t[2] for t in xyuv], T[t[3] for t in xyuv], T[t[4] for t in xyuv]
-unzip(xyuv::StaticArrays.SVector{4,T}) where {T}       = T[xyuv[1]], T[xyuv[2]], T[xyuv[3]], T[xyuv[4]]
+unzip(xyuv::AVec{GeometryTypes.Point{4,T}}) where {T} = T[t[1] for t in xyuv], T[t[2] for t in xyuv], T[t[3] for t in xyuv], T[t[4] for t in xyuv]
+unzip(xyuv::GeometryTypes.Point{4,T}) where {T}       = T[xyuv[1]], T[xyuv[2]], T[xyuv[3]], T[xyuv[4]]
 
 # given 2-element lims and a vector of data x, widen lims to account for the extrema of x
 function _expand_limits(lims, x)
@@ -592,15 +592,15 @@ function colorbar_style(series::Series)
         @warn "Non-boolean colorbar_entry ignored."
         colorbar_entry = true
     end
-    
+
     if !colorbar_entry
         nothing
-    elseif isfilledcontour(series) 
+    elseif isfilledcontour(series)
         cbar_fill
     elseif iscontour(series)
         cbar_lines
-    elseif series[:seriestype] ∈ (:heatmap,:surface) || 
-            any(series[z] !== nothing for z ∈ [:marker_z,:line_z,:fill_z]) 
+    elseif series[:seriestype] ∈ (:heatmap,:surface) ||
+            any(series[z] !== nothing for z ∈ [:marker_z,:line_z,:fill_z])
         cbar_gradient
     else
         nothing
@@ -626,7 +626,7 @@ function contour_levels(series::Series, clims)
     levels
 end
 
-  
+
 
 for comp in (:line, :fill, :marker)
 


### PR DESCRIPTION
This supercedes #1892 and closes #1886.
StaticArrays will be interpreted like any other AbstractArrays and `GeometryTypes.Point`s are used instead for 2D and 3D points.