### PR TITLE
fix plotattr

### DIFF
--- a/src/plotattr.jl
+++ b/src/plotattr.jl
@@ -50,8 +50,13 @@ function plotattr(attrtype::Symbol, attribute::AbstractString)
 
     desc = get(_arg_desc, attribute, "")
     first_period_idx = findfirst(isequal('.'), desc)
-    typedesc = desc[1:first_period_idx-1]
-    desc = strip(desc[first_period_idx+1:end])
+    if isnothing(first_period_idx) 
+        typedesc = ""
+        desc = strip(desc)
+    else
+        typedesc = desc[1:first_period_idx-1]
+        desc = strip(desc[first_period_idx+1:end])
+    end
     als = keys(filter(x->x[2]==attribute, _keyAliases)) |> collect |> sort
     als = join(map(string,als), ", ")
     def = _attribute_defaults[attrtype][attribute]


### PR DESCRIPTION
`plotattr` would fail when the description did not have a period (`.`) in it, e.g. for `ticks`. This seemed safer than to edit the argument descriptions