### PR TITLE
don't let `marker = true` set the marker size to 1 (fix #1994)

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -737,6 +737,10 @@ function processMarkerArg(plotattributes::KW, arg)
     elseif allAlphas(arg)
         plotattributes[:markeralpha] = arg
 
+    # bool
+    elseif typeof(arg) <: Bool
+        plotattributes[:markershape] = arg ? :auto : :none
+
     # markersize
     elseif allReals(arg)
         plotattributes[:markersize] = arg

--- a/src/args.jl
+++ b/src/args.jl
@@ -739,7 +739,7 @@ function processMarkerArg(plotattributes::KW, arg)
 
     # bool
     elseif typeof(arg) <: Bool
-        plotattributes[:markershape] = arg ? :auto : :none
+        plotattributes[:markershape] = arg ? :circle : :none
 
     # markersize
     elseif allReals(arg)


### PR DESCRIPTION
`marker` is a magic argument, i.e. argument meanings are guessed by their type. `Bool <: Real` and hence `true` and `false` are interpreted as `markersize`. This PR fixes this by explicitely checking for `Bool`.