### PR TITLE
Add attribute draw_arrow for axes.

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -150,4 +150,5 @@ const _arg_desc = KW(
 :tick_direction           => "Symbol.  Direction of the ticks. `:in` or `:out`",
 :showaxis                 => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`",
 :widen                    => "Bool. Widen the axis limits by a small factor to avoid cut-off markers and lines at the borders. Defaults to `true`.",
+:draw_arrow               => "Bool. Draw arrow at the end of the axis.",
 )

--- a/src/args.jl
+++ b/src/args.jl
@@ -392,6 +392,7 @@ const _axis_defaults = KW(
     :minorgrid                => false,
     :showaxis                 => true,
     :widen                    => true,
+    :draw_arrow               => false,
 )
 
 const _suppress_warnings = Set{Symbol}([

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -399,8 +399,12 @@ function pgf_axis(sp::Subplot, letter)
     # framestyle
     if framestyle in (:axes, :origin)
         axispos = framestyle == :axes ? "left" : "middle"
-        # the * after lines disables the arrows at the axes
-        push!(style, string("axis lines* = ", axispos))
+        if axis[:draw_arrow]
+            push!(style, string("axis ", letter, " line = ", axispos))
+        else
+            # the * after line disables the arrow at the axis
+            push!(style, string("axis ", letter, " line* = ", axispos))
+        end
     end
 
     if framestyle == :zerolines


### PR DESCRIPTION
The draw_arrow attribute enables drawing an arrow at the end of an axis.
Currently supported only by the PGFPlots backend.

Resolves #1348 for the PGFPlots backend.