### PR TITLE
fix recipe error

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -784,7 +784,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             tbx, tby = gr_inqtext(0, 0, string(lab))
             legendw = max(legendw, tbx[3] - tbx[1])
         end
-        
+
         GR.setscale(1)
         GR.selntran(1)
         GR.restorestate()
@@ -1139,7 +1139,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         end
 
         if st in (:path, :scatter, :straightline)
-            if length(x) > 1
+            if x != nothing && length(x) > 1
                 lz = series[:line_z]
                 segments = iter_segments(series)
                 # do area fill

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -216,13 +216,15 @@ end
 # ---------------------------------------------------------------------------
 
 function fix_xy_lengths!(plt::Plot{PyPlotBackend}, series::Series)
-    x, y = series[:x], series[:y]
-    nx, ny = length(x), length(y)
-    if !isa(get(series.plotattributes, :z, nothing), Surface) && nx != ny
-        if nx < ny
-            series[:x] = Float64[x[mod1(i,nx)] for i=1:ny]
-        else
-            series[:y] = Float64[y[mod1(i,ny)] for i=1:nx]
+    if series[:x] != nothing
+        x, y = series[:x], series[:y]
+        nx, ny = length(x), length(y)
+        if !isa(get(series.plotattributes, :z, nothing), Surface) && nx != ny
+            if nx < ny
+                series[:x] = Float64[x[mod1(i,nx)] for i=1:ny]
+            else
+                series[:y] = Float64[y[mod1(i,ny)] for i=1:nx]
+            end
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -194,7 +194,9 @@ end
 
 function iter_segments(series::Series)
     x, y, z = series[:x], series[:y], series[:z]
-    if has_attribute_segments(series)
+    if x == nothing
+        return UnitRange{Int}[]
+    elseif has_attribute_segments(series)
         if series[:seriestype] in (:scatter, :scatter3d)
             return [[i] for i in 1:length(y)]
         else


### PR DESCRIPTION
```julia
using Plots

struct MyStruct end

@recipe function f(s::MyStruct)
  @series begin
      rand(10)
  end
  ()
end

plot(MyStruct())
```
resulted in an error for GR, PyPlot, Plotly and PGFPlots, because `series[:x] == nothing` and the backend code could not deal with this.

```julia
julia> plot(MyStruct())
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: MethodError: no method matching length(::Nothing)
Closest candidates are:
  length(::Core.SimpleVector) at essentials.jl:561
  length(::Base.MethodList) at reflection.jl:801
  length(::Core.MethodTable) at reflection.jl:875
  ...
Stacktrace:
 [1] gr_display(::Plots.Subplot{Plots.GRBackend}, ::Measures.Length{:mm,Float64}, ::Measures.Length{:mm,Float64}, ::Array{Float64,1}) at C:\Users\Daniel\.julia\dev\Plots\src\backends\gr.jl:1142
 [2] gr_display(::Plots.Plot{Plots.GRBackend}, ::String) at C:\Users\Daniel\.julia\dev\Plots\src\backends\gr.jl:631
 [3] _show(::IOContext{Base64.Base64EncodePipe}, ::MIME{Symbol("image/png")}, ::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\backends\gr.jl:1469
 [4] _showjuno at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:260 [inlined]
 [5] showjuno(::IOContext{Base64.Base64EncodePipe}, ::MIME{Symbol("image/png")}, ::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:244
 [6] show(::IOContext{Base64.Base64EncodePipe}, ::MIME{Symbol("image/png")}, ::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:195
 [7] #base64encode#3(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Function, ::Function, ::MIME{Symbol("image/png")}, ::Vararg{Any,N} where N) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\encode.jl:208
 [8] #base64encode at .\none:0 [inlined]
 [9] _binstringmime at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:41 [inlined]
 [10] #stringmime#6(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Function, ::MIME{Symbol("image/png")}, ::Plots.Plot{Plots.GRBackend}) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:38
 [11] (::getfield(Base64, Symbol("#kw##stringmime")))(::NamedTuple{(:context,),Tuple{IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}}}, ::typeof(Base64.stringmime), ::MIME{Symbol("image/png")}, ::Plots.Plot{Plots.GRBackend}) at .\none:0
 [12] #stringmime#7(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Function, ::String, ::Plots.Plot{Plots.GRBackend}) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:39
 [13] #stringmime at .\none:0 [inlined]
 [14] displayinplotpane(::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\packages\Atom\E4PBh\src\display\showdisplay.jl:68
 [15] display(::Atom.JunoDisplay, ::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\packages\Atom\E4PBh\src\display\showdisplay.jl:102
 [16] display(::Any) at .\multimedia.jl:287
 [17] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [18] invokelatest at .\essentials.jl:741 [inlined]
 [19] print_response(::IO, ::Any, ::Any, ::Bool, ::Bool, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:155
 [20] print_response(::REPL.AbstractREPL, ::Any, ::Any, ::Bool, ::Bool) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:140
 [21] (::getfield(REPL, Symbol("#do_respond#38")){Bool,getfield(Atom, Symbol("##172#173")),REPL.LineEditREPL,REPL.LineEdit.Prompt})(::Any, ::Any, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:714
 [22] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [23] invokelatest at .\essentials.jl:741 [inlined]
 [24] run_interface(::REPL.Terminals.TextTerminal, ::REPL.LineEdit.ModalInterface, ::REPL.LineEdit.MIState) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\LineEdit.jl:2273
 [25] run_frontend(::REPL.LineEditREPL, ::REPL.REPLBackendRef) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:1035
 [26] run_repl(::REPL.AbstractREPL, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:192
 [27] (::getfield(Base, Symbol("##734#736")){Bool,Bool,Bool,Bool})(::Module) at .\client.jl:362
 [28] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [29] invokelatest at .\essentials.jl:741 [inlined]
 [30] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at .\client.jl:346
 [31] exec_options(::Base.JLOptions) at .\client.jl:284
 [32] _start() at .\client.jl:436
```

This fixes the issue.