### PR TITLE
Fix for missing as first element

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -193,7 +193,7 @@ _apply_type_recipe(plotattributes, v) = RecipesBase.apply_recipe(plotattributes,
 # This sort of recipe should return a pair of functions... one to convert to number,
 # and one to format tick values.
 function _apply_type_recipe(plotattributes, v::AbstractArray)
-    isempty(v) && return Float64[]
+    isempty(skipmissing(v)) && return Float64[]
     x = first(skipmissing(v))
     args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
     if length(args) == 2 && typeof(args[1]) <: Function && typeof(args[2]) <: Function

--- a/src/series.jl
+++ b/src/series.jl
@@ -194,7 +194,8 @@ _apply_type_recipe(plotattributes, v) = RecipesBase.apply_recipe(plotattributes,
 # and one to format tick values.
 function _apply_type_recipe(plotattributes, v::AbstractArray)
     isempty(v) && return Float64[]
-    args = RecipesBase.apply_recipe(plotattributes, typeof(v[1]), v[1])[1].args
+    x = first(skipmissing(v))
+    args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
     if length(args) == 2 && typeof(args[1]) <: Function && typeof(args[2]) <: Function
         numfunc, formatter = args
         Formatted(map(numfunc, v), formatter)


### PR DESCRIPTION
See https://github.com/JuliaPlots/Plots.jl/issues/1706#issuecomment-443460663
e.g.
```
plot([missing, 1, 2])
plot([missing, missing, missing, "a","b"])
```