### PR TITLE
allow specifying the color gradient for z values in pyplot (fix #2041)

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1296,10 +1296,6 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
         handles = []
         for series in series_list(sp)
             if should_add_to_legend(series)
-
-                lc = get_linecolor(series, clims)
-                lc = isa(lc, ColorGradient) ? lc[0.5] : lc
-
                 # add a line/marker and a label
                 push!(handles, if series[:seriestype] == :shape || series[:fillrange] != nothing
                     pypatches."Patch"(

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -467,7 +467,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     handle = ax."plot"((arg[rng] for arg in xyargs)...;
                         label = i == 1 ? series[:label] : "",
                         zorder = series[:series_plotindex],
-                        color = py_color(get_linecolor(series, clims, i), get_linealpha(series, i)),
+                        color = py_color(single_color(get_linecolor(series, clims, i)), get_linealpha(series, i)),
                         linewidth = py_thickness_scale(plt, get_linewidth(series, i)),
                         linestyle = py_linestyle(st, get_linestyle(series, i)),
                         solid_capstyle = "round",
@@ -1296,22 +1296,26 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
         handles = []
         for series in series_list(sp)
             if should_add_to_legend(series)
+
+                lc = get_linecolor(series, clims)
+                lc = isa(lc, ColorGradient) ? lc[0.5] : lc
+
                 # add a line/marker and a label
                 push!(handles, if series[:seriestype] == :shape || series[:fillrange] != nothing
                     pypatches."Patch"(
-                        edgecolor = py_color(get_linecolor(series, clims), get_linealpha(series)),
-                        facecolor = py_color(get_fillcolor(series, clims), get_fillalpha(series)),
+                        edgecolor = py_color(single_color(get_linecolor(series, clims)), get_linealpha(series)),
+                        facecolor = py_color(single_color(get_fillcolor(series, clims)), get_fillalpha(series)),
                         linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
                         linestyle = py_linestyle(series[:seriestype], get_linestyle(series))
                     )
                 elseif series[:seriestype] in (:path, :straightline, :scatter)
                     PyPlot.plt."Line2D"((0,1),(0,0),
-                        color = py_color(get_linecolor(series, clims), get_linealpha(series)),
+                        color = py_color(single_color(get_linecolor(series, clims)), get_linealpha(series)),
                         linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
                         linestyle = py_linestyle(:path, get_linestyle(series)),
                         marker = py_marker(first(series[:markershape])),
-                        markeredgecolor = py_color(get_markerstrokecolor(series), get_markerstrokealpha(series)),
-                        markerfacecolor = series[:marker_z] == nothing ? py_color(get_markercolor(series, clims), get_markeralpha(series)) : py_color(series[:markercolor][0.5])
+                        markeredgecolor = py_color(single_color(get_markerstrokecolor(series)), get_markerstrokealpha(series)),
+                        markerfacecolor = py_color(single_color(get_markercolor(series, clims)), get_markeralpha(series))
                     )
                 else
                     series[:serieshandle][1]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -625,6 +625,9 @@ for comp in (:line, :fill, :marker)
     end
 end
 
+single_color(c, v = 0.5) = c
+single_color(grad::ColorGradient, v = 0.5) = grad[v]
+
 function get_linewidth(series, i::Int = 1)
     _cycle(series[:linewidth], i)
 end


### PR DESCRIPTION
cf. #2041
Before we had:
```julia
julia> using Plots; pyplot()
Plots.PyPlotBackend()

julia> plot(1:10, 1:10, line_z = 1:10, c = :viridis)
Error showing value of type Plots.Plot{Plots.PyPlotBackend}:
ERROR: MethodError: no method matching py_color(::ColorGradient, ::Nothing)
Closest candidates are:
  py_color(::ColorGradient) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:67
  py_color(::Colorant, ::Any) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:68
  py_color(::Any) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:64
Stacktrace:
 [1] py_add_legend(::Plots.Plot{Plots.PyPlotBackend}, ::Plots.Subplot{Plots.PyPlotBackend}, ::PyCall.PyObject) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:1308
 [2] _before_layout_calcs(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:1171
 [3] prepare_output(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\plot.jl:254
 [4] showjuno(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:243
 [5] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:195
 [6] __binrepr at .\multimedia.jl:129 [inlined]
 [7] _textrepr at .\multimedia.jl:119 [inlined]
 [8] #stringmime#6 at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:38 [inlined]
 [9] (::getfield(Base64, Symbol("#kw##stringmime")))(::NamedTuple{(:context,),Tuple{IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}}}, ::typeof(Base64.stringmime), ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at .\none:0
 [10] #stringmime#7(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Function, ::String, ::Plots.Plot{Plots.PyPlotBackend}) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:39
 [11] #stringmime at .\none:0 [inlined]
 [12] displayinplotpane(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\packages\Atom\cR6bU\src\display\showdisplay.jl:55
 [13] display(::Atom.JunoDisplay, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\packages\Atom\cR6bU\src\display\showdisplay.jl:102
 [14] display(::Any) at .\multimedia.jl:287
 [15] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [16] invokelatest at .\essentials.jl:741 [inlined]
 [17] print_response(::IO, ::Any, ::Any, ::Bool, ::Bool, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:155
 [18] print_response(::REPL.AbstractREPL, ::Any, ::Any, ::Bool, ::Bool) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:140
 [19] (::getfield(REPL, Symbol("#do_respond#38")){Bool,getfield(Atom, Symbol("##172#173")),REPL.LineEditREPL,REPL.LineEdit.Prompt})(::Any, ::Any, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:714
 [20] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [21] invokelatest at .\essentials.jl:741 [inlined]
 [22] run_interface(::REPL.Terminals.TextTerminal, ::REPL.LineEdit.ModalInterface, ::REPL.LineEdit.MIState) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\LineEdit.jl:2273
 [23] run_frontend(::REPL.LineEditREPL, ::REPL.REPLBackendRef) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:1035
 [24] run_repl(::REPL.AbstractREPL, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:192
 [25] (::getfield(Base, Symbol("##734#736")){Bool,Bool,Bool,Bool})(::Module) at .\client.jl:362
 [26] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [27] invokelatest at .\essentials.jl:741 [inlined]
 [28] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at .\client.jl:346
 [29] exec_options(::Base.JLOptions) at .\client.jl:284
 [30] _start() at .\client.jl:436
```
```julia
julia> scatter(1:10, 1:10, marker_z = 1:10, c = :viridis)
Error showing value of type Plots.Plot{Plots.PyPlotBackend}:
ERROR: MethodError: no method matching py_color(::ColorGradient, ::Nothing)
Closest candidates are:
  py_color(::ColorGradient) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:67
  py_color(::Colorant, ::Any) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:68
  py_color(::Any) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:64
Stacktrace:
 [1] py_add_legend(::Plots.Plot{Plots.PyPlotBackend}, ::Plots.Subplot{Plots.PyPlotBackend}, ::PyCall.PyObject) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:1308
 [2] _before_layout_calcs(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:1171
 [3] prepare_output(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\plot.jl:254
 [4] showjuno(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:243
 [5] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:195
 [6] __binrepr at .\multimedia.jl:129 [inlined]
 [7] _textrepr at .\multimedia.jl:119 [inlined]
 [8] #stringmime#6 at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:38 [inlined]
 [9] (::getfield(Base64, Symbol("#kw##stringmime")))(::NamedTuple{(:context,),Tuple{IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}}}, ::typeof(Base64.stringmime), ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at .\none:0
 [10] #stringmime#7(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Function, ::String, ::Plots.Plot{Plots.PyPlotBackend}) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:39
 [11] #stringmime at .\none:0 [inlined]
 [12] displayinplotpane(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\packages\Atom\cR6bU\src\display\showdisplay.jl:55
 [13] display(::Atom.JunoDisplay, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\packages\Atom\cR6bU\src\display\showdisplay.jl:102
 [14] display(::Any) at .\multimedia.jl:287
 [15] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [16] invokelatest at .\essentials.jl:741 [inlined]
 [17] print_response(::IO, ::Any, ::Any, ::Bool, ::Bool, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:155
 [18] print_response(::REPL.AbstractREPL, ::Any, ::Any, ::Bool, ::Bool) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:140
 [19] (::getfield(REPL, Symbol("#do_respond#38")){Bool,getfield(Atom, Symbol("##172#173")),REPL.LineEditREPL,REPL.LineEdit.Prompt})(::Any, ::Any, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:714
 [20] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [21] invokelatest at .\essentials.jl:741 [inlined]
 [22] run_interface(::REPL.Terminals.TextTerminal, ::REPL.LineEdit.ModalInterface, ::REPL.LineEdit.MIState) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\LineEdit.jl:2273
 [23] run_frontend(::REPL.LineEditREPL, ::REPL.REPLBackendRef) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:1035
 [24] run_repl(::REPL.AbstractREPL, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:192
 [25] (::getfield(Base, Symbol("##734#736")){Bool,Bool,Bool,Bool})(::Module) at .\client.jl:362
 [26] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [27] invokelatest at .\essentials.jl:741 [inlined]
 [28] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at .\client.jl:346
 [29] exec_options(::Base.JLOptions) at .\client.jl:284
 [30] _start() at .\client.jl:436
```
```julia
julia> plot(1:10, 1:10, fill_z = 1:10, fillrange = 0, c = :viridis)
Error showing value of type Plots.Plot{Plots.PyPlotBackend}:
ERROR: MethodError: no method matching py_color(::ColorGradient, ::Nothing)
Closest candidates are:
  py_color(::ColorGradient) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:67
  py_color(::Colorant, ::Any) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:68
  py_color(::Any) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:64
Stacktrace:
 [1] py_add_series(::Plots.Plot{Plots.PyPlotBackend}, ::Plots.Series) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:467
 [2] _before_layout_calcs(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\backends\pyplot.jl:975
 [3] prepare_output(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\plot.jl:254
 [4] showjuno(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:243
 [5] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:195
 [6] __binrepr at .\multimedia.jl:129 [inlined]
 [7] _textrepr at .\multimedia.jl:119 [inlined]
 [8] #stringmime#6 at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:38 [inlined]
 [9] (::getfield(Base64, Symbol("#kw##stringmime")))(::NamedTuple{(:context,),Tuple{IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}}}, ::typeof(Base64.stringmime), ::MIME{Symbol("image/svg+xml")}, ::Plots.Plot{Plots.PyPlotBackend}) at .\none:0
 [10] #stringmime#7(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Function, ::String, ::Plots.Plot{Plots.PyPlotBackend}) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Base64\src\Base64.jl:39
 [11] #stringmime at .\none:0 [inlined]
 [12] displayinplotpane(::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\packages\Atom\cR6bU\src\display\showdisplay.jl:55
 [13] display(::Atom.JunoDisplay, ::Plots.Plot{Plots.PyPlotBackend}) at C:\Users\Daniel\.julia\packages\Atom\cR6bU\src\display\showdisplay.jl:102
 [14] display(::Any) at .\multimedia.jl:287
 [15] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [16] invokelatest at .\essentials.jl:741 [inlined]
 [17] print_response(::IO, ::Any, ::Any, ::Bool, ::Bool, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:155
 [18] print_response(::REPL.AbstractREPL, ::Any, ::Any, ::Bool, ::Bool) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:140
 [19] (::getfield(REPL, Symbol("#do_respond#38")){Bool,getfield(Atom, Symbol("##172#173")),REPL.LineEditREPL,REPL.LineEdit.Prompt})(::Any, ::Any, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:714
 [20] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [21] invokelatest at .\essentials.jl:741 [inlined]
 [22] run_interface(::REPL.Terminals.TextTerminal, ::REPL.LineEdit.ModalInterface, ::REPL.LineEdit.MIState) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\LineEdit.jl:2273
 [23] run_frontend(::REPL.LineEditREPL, ::REPL.REPLBackendRef) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:1035
 [24] run_repl(::REPL.AbstractREPL, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:192
 [25] (::getfield(Base, Symbol("##734#736")){Bool,Bool,Bool,Bool})(::Module) at .\client.jl:362
 [26] #invokelatest#1 at .\essentials.jl:742 [inlined]
 [27] invokelatest at .\essentials.jl:741 [inlined]
 [28] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at .\client.jl:346
 [29] exec_options(::Base.JLOptions) at .\client.jl:284
 [30] _start() at .\client.jl:436
```
Now we get the following figures:
![pyplot_line](https://user-images.githubusercontent.com/16589944/60175235-386d5280-9813-11e9-9fcb-21335c7a33ac.png)
![pyplot_marker](https://user-images.githubusercontent.com/16589944/60175238-3acfac80-9813-11e9-9b40-f351311dc6a7.png)
![pyplot_fill](https://user-images.githubusercontent.com/16589944/60175240-3d320680-9813-11e9-9c6e-3de892d07a7d.png)

cc: @BoundaryValueProblems 