### PR TITLE
Fix representation of zero-valued bins on step-histograms with log-y axis

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -545,6 +545,8 @@ function _stepbins_path(edge, weights, baseline::Real, xscale::Symbol, yscale::S
             if !isnan(last_w)
                 push!(x, a)
                 push!(y, baseline)
+                push!(x, NaN)
+                push!(y, NaN)
             end
         else
             if isnan(last_w)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -538,7 +538,7 @@ function _stepbins_path(edge, weights, baseline::Real, xscale::Symbol, yscale::S
         w, it_state_w = it_tuple_w
 
         if (log_scale_x && a ≈ 0)
-            a = b/_logScaleBases[xscale]^3
+            a = oftype(a, b/_logScaleBases[xscale]^3)
         end
 
         if isnan(w)
@@ -559,8 +559,8 @@ function _stepbins_path(edge, weights, baseline::Real, xscale::Symbol, yscale::S
             push!(y, w)
         end
 
-        a = b
-        last_w = w
+        a = oftype(a, b)
+        last_w = oftype(last_w, w)
 
         it_tuple_e = iterate(edge, it_state_e)
         it_tuple_w = iterate(weights, it_state_w)


### PR DESCRIPTION
Zero-values bins are at minus infinity on y-logscale, so they shouldn't be drawn.

Before:

```julia
julia> stephist(vcat(randn(10^5).-10, randn(10^5).+10), normalize = true, bins = 500, yscale = :log10)
```

![loghist-sep-peaks-before](https://user-images.githubusercontent.com/546147/60399035-44347e00-9b5f-11e9-8887-0e6d6d313632.png)

After:

![loghist-sep-peaks-after](https://user-images.githubusercontent.com/546147/60399038-4b5b8c00-9b5f-11e9-99d9-00cfb328868c.png)
