### PR TITLE
allow missing in line_z, fill_z and marker_z (fix #2083)

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -527,9 +527,9 @@ function get_clims(sp::Subplot)
     z_colored_series = (:contour, :contour3d, :heatmap, :histogram2d, :surface)
     for series in series_list(sp)
         for vals in (series[:seriestype] in z_colored_series ? series[:z] : nothing, series[:line_z], series[:marker_z], series[:fill_z])
-            if (typeof(vals) <: AbstractSurface) && (eltype(vals.surf) <: Real)
+            if (typeof(vals) <: AbstractSurface) && (eltype(vals.surf) <: Union{Missing, Real})
                 zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals.surf)...)
-            elseif (vals != nothing) && (eltype(vals) <: Real)
+            elseif (vals != nothing) && (eltype(vals) <: Union{Missing, Real})
                 zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals)...)
             end
         end
@@ -654,7 +654,7 @@ function has_attribute_segments(series::Series)
     end
     series[:seriestype] == :shape && return false
     # ... else we check relevant attributes if they have multiple inputs
-    return any((typeof(series[attr]) <: AbstractVector && length(series[attr]) > 1) for attr in [:seriescolor, :seriesalpha, :linecolor, :linealpha, :linewidth, :fillcolor, :fillalpha, :markercolor, :markeralpha, :markerstrokecolor, :markerstrokealpha]) || any(typeof(series[attr]) <: AbstractArray{<:Real} for attr in (:line_z, :fill_z, :marker_z))
+    return any((typeof(series[attr]) <: AbstractVector && length(series[attr]) > 1) for attr in [:seriescolor, :seriesalpha, :linecolor, :linealpha, :linewidth, :fillcolor, :fillalpha, :markercolor, :markeralpha, :markerstrokecolor, :markerstrokealpha]) || any(typeof(series[attr]) <: AbstractArray for attr in (:line_z, :fill_z, :marker_z))
 end
 
 # ---------------------------------------------------------------


### PR DESCRIPTION
See #2083 
```julia
using StatsPlots, DataFrames

N = 10
good_z = 100 * rand(N)
bad_z = Array{Union{Missing,Float64}}(good_z)

df = DataFrame(x=rand(N),
    y=rand(N),
    good_z = good_z,
    bad_z = bad_z)
p1 = scatter(df.x, df.y, marker_z=df.good_z) # good
p2 = scatter(df.x, df.y, marker_z=df.bad_z) # bad: all colors equal
p3 = @df df scatter(:x, :y, zcolor=:bad_z) # good in Plots 24.0, bad in Plots 25.1
plot(p1, p2, p3)
```
![zcolor](https://user-images.githubusercontent.com/16589944/60652571-c6b38b00-9e48-11e9-885d-a891b79b4195.png)
