### PR TITLE
Allow BinaryProvider installation of `ffmpeg`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ examples/meetup/.ipynb_checkpoints/*
 deps/plotly-latest.min.js
 deps/build.log
 deps/deps.jl
+deps/binary_provider_deps.jl
+deps/usr
+deps/build_*.jl
 Manifest.toml

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ---
 ## (current master)
+- Optionally use BinaryProvider for `ffmpeg`
 
 ## 0.25.1
 - fix gr_display

--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+BinaryProvider = "≥ 0.3.0"
 FixedPointNumbers = "≥ 0.3.0"
 GR = "≥ 0.31.0"
 PlotThemes = "≥ 0.1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,6 @@ StatsBase = "≥ 0.14.0"
 julia = "≥ 1.0.0"
 
 [extras]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
@@ -55,4 +54,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 
 [targets]
-test = ["BinaryProvider", "Pkg", "Test", "Random", "StatsPlots", "VisualRegressionTests", "LaTeXStrings", "Images", "ImageMagick", "RDatasets", "FileIO", "UnicodePlots"]
+test = ["Pkg", "Test", "Random", "StatsPlots", "VisualRegressionTests", "LaTeXStrings", "Images", "ImageMagick", "RDatasets", "FileIO", "UnicodePlots"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.25.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 GeometryTypes = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Measures = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
@@ -39,6 +41,7 @@ StatsBase = "≥ 0.14.0"
 julia = "≥ 1.0.0"
 
 [extras]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
@@ -50,7 +53,6 @@ StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 
 [targets]
 test = ["BinaryProvider", "Pkg", "Test", "Random", "StatsPlots", "VisualRegressionTests", "LaTeXStrings", "Images", "ImageMagick", "RDatasets", "FileIO", "UnicodePlots"]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -65,7 +65,11 @@ if use_bp
 else
     @info("Using system `ffmpeg`. If you run into `ffmpeg`-related trouble, trying running `ENV[\"PLOTS_INSTALL_FFMPEG\"]=\"true\"; using Pkg; Pkg.build(\"Plots\")` to use `BinaryProvider`-provided `ffmpeg` instead.")
 
-    
+    # if we're using the system `ffmpeg`, remove `binary_provider_deps.jl`,
+    # so the existence of that file is equivalent to using BinaryProvider. 
+    # This lets us check if the file exists to know whether or not to 
+    # call `check_deps` in `__init__()`, and to set the system fallback
+    # `const ffmpeg = "ffmpeg"` in Plots.jl.
     if isfile("binary_provider_deps.jl")
         rm("binary_provider_deps.jl")
     end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,76 @@
 
+using BinaryProvider # requires BinaryProvider 0.3.0 or later
+
+# If the environmental variable is set, obey that.
+# Otherwise, use BinaryProvider `ffmpeg` if we cannot find
+# a system version.
+if get(ENV, "PLOTS_INSTALL_FFMPEG", "auto") == "true"
+    use_bp = true
+elseif get(ENV, "PLOTS_INSTALL_FFMPEG", "auto") == "false"
+    use_bp = false
+elseif get(ENV, "PLOTS_INSTALL_FFMPEG", "auto") == "auto"
+    if Sys.which("ffmpeg") === nothing
+        use_bp = true
+    else
+        use_bp = false
+    end
+end
+
+
+if use_bp
+    @info("Using BinaryProvider `ffmpeg`")
+
+    # Parse some basic command-line arguments
+    const verbose = "--verbose" in ARGS
+    const prefix = Prefix(get([a for a in ARGS if a != "--verbose"], 1, joinpath(@__DIR__, "usr")))
+
+    products = Product[
+        ExecutableProduct(prefix, "ffmpeg", :ffmpeg),
+    ]
+
+    dependencies = [
+        "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Bzip2-v1.0.6-2/build_Bzip2.v1.0.6.jl",
+
+        "https://github.com/ianshmean/ZlibBuilder/releases/download/v1.2.11/build_Zlib.v1.2.11.jl",
+        "https://github.com/SimonDanisch/FDKBuilder/releases/download/0.1.6/build_libfdk.v0.1.6.jl",
+        "https://github.com/SimonDanisch/FribidiBuilder/releases/download/0.14.0/build_fribidi.v0.14.0.jl",
+        "https://github.com/JuliaGraphics/FreeTypeBuilder/releases/download/v2.9.1-4/build_FreeType2.v2.10.0.jl",
+        "https://github.com/JuliaIO/LibassBuilder/releases/download/v0.14.0-2/build_libass.v0.14.0.jl",
+        
+        "https://github.com/JuliaIO/LAMEBuilder/releases/download/v3.100.0-2/build_liblame.v3.100.0.jl",
+        
+        "https://github.com/JuliaIO/OggBuilder/releases/download/v1.3.3-7/build_Ogg.v1.3.3.jl",
+        "https://github.com/JuliaIO/LibVorbisBuilder/releases/download/v1.3.6-2/build_libvorbis.v1.3.6.jl",
+                            
+        "https://github.com/JuliaIO/LibVPXBuilder/releases/download/v1.8.0/build_LibVPX.v1.8.0.jl",
+        "https://github.com/JuliaIO/x264Builder/releases/download/v2019.5.25-static/build_x264Builder.v2019.5.25.jl",
+        "https://github.com/JuliaIO/x265Builder/releases/download/v3.0.0-static/build_x265Builder.v3.0.0.jl",
+        
+        "https://github.com/JuliaIO/FFMPEGBuilder/releases/download/v4.1.0/build_FFMPEG.v4.1.0.jl"
+    ]
+
+    for dependency in dependencies
+        file = joinpath(@__DIR__, basename(dependency))
+        isfile(file) || download(dependency, file)
+        # it's a bit faster to run the build in an anonymous module instead of
+        # starting a new julia process
+
+        # Build the dependencies
+        Mod = @eval module Anon end
+        Mod.include(file)
+    end
+
+    write_deps_file(joinpath(@__DIR__, "binary_provider_deps.jl"), products)
+
+else
+    @info("Using system `ffmpeg`. If you run into `ffmpeg`-related trouble, trying running `ENV[\"PLOTS_INSTALL_FFMPEG\"]=\"true\"; using Pkg; Pkg.build(\"Plots\")` to use `BinaryProvider`-provided `ffmpeg` instead.")
+
+    
+    if isfile("binary_provider_deps.jl")
+        rm("binary_provider_deps.jl")
+    end
+end
+
 #TODO: download https://cdn.plot.ly/plotly-latest.min.js to deps/ if it doesn't exist
 file_path = ""
 if get(ENV, "PLOTS_HOST_DEPENDENCY_LOCAL", "false") == "true"

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -30,6 +30,12 @@ else
     const plotly_local_file_path = ""
 end
 
+if isfile(joinpath(@__DIR__, "..", "deps", "binary_provider_deps.jl"))
+    include(joinpath(@__DIR__, "..", "deps", "binary_provider_deps.jl"))
+else
+    const ffmpeg = "ffmpeg"
+end
+
 export
     grid,
     bbox,

--- a/src/animation.jl
+++ b/src/animation.jl
@@ -76,15 +76,15 @@ function buildanimation(animdir::AbstractString, fn::AbstractString,
         if variable_palette
             # generate a colorpalette for each frame for highest quality, but larger filesize
             palette="palettegen=stats_mode=single[pal],[0:v][pal]paletteuse=new=1"
-            run(`ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -lavfi "$palette" -y $fn`)
+            run(`$ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -lavfi "$palette" -y $fn`)
         else
             # generate a colorpalette first so ffmpeg does not have to guess it
-            run(`ffmpeg -v 0 -i $(animdir)/%06d.png -vf "palettegen=stats_mode=diff" -y "$(animdir)/palette.bmp"`)
+            run(`$ffmpeg -v 0 -i $(animdir)/%06d.png -vf "palettegen=stats_mode=diff" -y "$(animdir)/palette.bmp"`)
             # then apply the palette to get better results
-            run(`ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -i "$(animdir)/palette.bmp" -lavfi "paletteuse=dither=sierra2_4a" -y $fn`)
+            run(`$ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -i "$(animdir)/palette.bmp" -lavfi "paletteuse=dither=sierra2_4a" -y $fn`)
         end
     else
-        run(`ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -pix_fmt yuv420p -y $fn`)
+        run(`$ffmpeg -v 0 -framerate $fps -loop $loop -i $(animdir)/%06d.png -pix_fmt yuv420p -y $fn`)
     end
 
     show_msg && @info("Saved animation to ", fn)

--- a/src/init.jl
+++ b/src/init.jl
@@ -11,6 +11,12 @@ end
 
 
 function __init__()
+
+    # for BinaryProvider
+    if isfile(joinpath(@__DIR__, "..", "deps", "binary_provider_deps.jl"))
+        check_deps() 
+    end
+
     user_defaults = _plots_defaults()
     if haskey(user_defaults, :theme)
         theme(user_defaults[:theme])


### PR DESCRIPTION
[VideoIO](https://github.com/JuliaIO/VideoIO.jl) recently switched to building `ffmpeg` and all its dependencies via BinaryProvider, and I thought it would be helpful for Plots' users to have a BinaryProvider option as well (since lacking `ffmpeg` can be frustrating for those wanting to make an animation or gif).

I based the changes to `build.jl` off of [VideoIO.jl/deps/build.jl](https://github.com/JuliaIO/VideoIO.jl/blob/master/deps/build.jl).

I think one concern here will be keeping the links (e.g. "https://github.com/JuliaIO/FFMPEGBuilder/releases/download/v4.1.0/build_FFMPEG.v4.1.0.jl") up to date.

The other concern I thought might arise would be those who already have `ffmpeg` might not want to download all the binaries for `ffmpeg` and its dependencies. I tried to work around that by first making an environmental variable "PLOTS_INSTALL_FFMPEG" which can be set to "true" or "false" to control whether or not Plots installs its own ffmpeg via BinaryProvider. If the variable is not set, the default behavior is to then install ffmpeg if and only if it cannot find a system version (using `Sys.which`, as recommended [on Discourse](https://discourse.julialang.org/t/how-to-check-if-a-program-exists-in-a-system-using-julia/19604/12)).