### PR TITLE
don't split color_palette into groups (fix #2104)

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -550,7 +550,7 @@ end
 # end
 
 splittable_kw(key, val, lengthGroup) = false
-splittable_kw(key, val::AbstractArray, lengthGroup) = (key != :group) && size(val,1) == lengthGroup
+splittable_kw(key, val::AbstractArray, lengthGroup) = !(key in (:group, :color_palette)) && size(val,1) == lengthGroup
 splittable_kw(key, val::Tuple, lengthGroup) = all(splittable_kw.(key, val, lengthGroup))
 splittable_kw(key, val::SeriesAnnotations, lengthGroup) = splittable_kw(key, val.strs, lengthGroup)
 


### PR DESCRIPTION
When the provided `group`-Vector had the same length as the user-provided `color_palette`, it was split by the grouping recipe leading to unexpected results as described in #2104.
This PR provides the fix by not splitting any color_palettes for grouping and changes
```julia
using Plots
default(markersize = 10, legend = false)

my_palette = plot_color.([:red, :green, :blue])
scatter(1:3, group = 1:3, palette = my_palette)
```
from
![palette_old](https://user-images.githubusercontent.com/16589944/62371914-588ce180-b536-11e9-99a4-d28b970168fd.png)
to
![palette_new](https://user-images.githubusercontent.com/16589944/62371929-604c8600-b536-11e9-9df4-948b6c23a810.png)
 