### PR TITLE
Expand paths beginning with ~ on unix systems.

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -70,7 +70,7 @@ function buildanimation(animdir::AbstractString, fn::AbstractString,
                         fps::Integer = 20, loop::Integer = 0,
                         variable_palette::Bool=false,
                         show_msg::Bool=true)
-    fn = abspath(fn)
+    fn = abspath(expanduser(fn))
 
     if is_animated_gif
         if variable_palette

--- a/src/output.jl
+++ b/src/output.jl
@@ -103,7 +103,7 @@ type is inferred from the file extension. All backends support png and pdf
 file types, some also support svg, ps, eps, html and tex.
 """
 function savefig(plt::Plot, fn::AbstractString)
-
+  fn = abspath(expanduser(fn))
   # get the extension
   local ext
   try


### PR DESCRIPTION
Fixes #2121 

While doing this work, I noticed that none of the saving and animation stuff seems to be covered by unit tests. Is that on purpose? Are there nice ways to unit test animation and saving functionalities?

Sorry for the beginner questions.

Also, credit goes to @asinghvi17 for coming up with this idea.

**EDIT**
I forgot to mention that I looked up the equivalent for windows. From this SO post

https://superuser.com/questions/332871/what-is-the-equivalent-of-linuxs-tilde-in-windows

it seems that windows users are just as good to do things manually.