### PR TITLE
PlotlyJS backend rewrite (fix #1721 #1756 #1934 #2003)

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -804,9 +804,12 @@ plotly_series_json(plt::Plot) = JSON.json(plotly_series(plt), 4)
 
 # ----------------------------------------------------------------
 
+html_head(plt::Plot{PlotlyBackend}) = plotly_html_head(plt)
+html_body(plt::Plot{PlotlyBackend}) = plotly_html_body(plt)
+
 const ijulia_initialized = Ref(false)
 
-function html_head(plt::Plot{PlotlyBackend})
+function plotly_html_head(plt::Plot)
     local_file = ("file://" * plotly_local_file_path)
     plotly = use_local_dependencies[] ? local_file : plotly_remote_file_path
     if isijulia() && !ijulia_initialized[]
@@ -825,7 +828,7 @@ function html_head(plt::Plot{PlotlyBackend})
     return "<script src=$(repr(plotly))></script>"
 end
 
-function html_body(plt::Plot{PlotlyBackend}, style = nothing)
+function plotly_html_body(plt, style = nothing)
     if style == nothing
         w, h = plt[:size]
         style = "width:$(w)px;height:$(h)px;"
@@ -841,23 +844,26 @@ function html_body(plt::Plot{PlotlyBackend}, style = nothing)
     html
 end
 
-function js_body(plt::Plot{PlotlyBackend}, uuid)
+function js_body(plt::Plot, uuid)
     js = """
         PLOT = document.getElementById('$(uuid)');
         Plotly.plot(PLOT, $(plotly_series_json(plt)), $(plotly_layout_json(plt)));
     """
 end
 
-
-# ----------------------------------------------------------------
-
-function _show(io::IO, ::MIME"application/vnd.plotly.v1+json", plot::Plot{PlotlyBackend})
+function plotly_show_js(io::IO, plot::Plot)
     data = []
     for series in plot.series_list
         append!(data, plotly_series(plot, series))
     end
     layout = plotly_layout(plot)
     JSON.print(io, Dict(:data => data, :layout => layout))
+end
+
+# ----------------------------------------------------------------
+
+function _show(io::IO, ::MIME"application/vnd.plotly.v1+json", plot::Plot{PlotlyBackend})
+    plotly_show_js(io, plot)
 end
 
 

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -17,51 +17,6 @@ function plotlyjs_syncplot(plt::Plot{PlotlyJSBackend})
     return plt.o
 end
 
-
-# function _create_backend_figure(plt::Plot{PlotlyJSBackend})
-#     if !isplotnull() && plt[:overwrite_figure] && isa(current().o, PlotlyJS.SyncPlot)
-#         PlotlyJS.SyncPlot(PlotlyJS.Plot(), options = current().o.options)
-#     else
-#         PlotlyJS.plot()
-#     end
-# end
-#
-#
-# function _series_added(plt::Plot{PlotlyJSBackend}, series::Series)
-#     syncplot = plt.o
-#     pdicts = plotly_series(plt, series)
-#     for pdict in pdicts
-#         typ = pop!(pdict, :type)
-#         gt = PlotlyJS.GenericTrace(typ; pdict...)
-#         PlotlyJS.addtraces!(syncplot, gt)
-#     end
-# end
-#
-# function _series_updated(plt::Plot{PlotlyJSBackend}, series::Series)
-#     xsym, ysym = (ispolar(series) ? (:t,:r) : (:x,:y))
-#     kw = KW(xsym => (series.plotattributes[:x],), ysym => (series.plotattributes[:y],))
-#     z = series[:z]
-#     if z != nothing
-#         kw[:z] = (isa(z,Surface) ? transpose_z(series, series[:z].surf, false) : z,)
-#     end
-#     PlotlyJS.restyle!(
-#         plt.o,
-#         findfirst(isequal(series), plt.series_list),
-#         kw
-#     )
-# end
-#
-#
-# # ----------------------------------------------------------------
-#
-# function _update_plot_object(plt::Plot{PlotlyJSBackend})
-#     pdict = plotly_layout(plt)
-#     syncplot = plt.o
-#     w,h = plt[:size]
-#     PlotlyJS.relayout!(syncplot, pdict, width = w, height = h)
-# end
-
-
 # ----------------------------------------------------------------
 
 const _plotlyjs_mimeformats = Dict(
@@ -75,46 +30,15 @@ for (mime, fmt) in _plotlyjs_mimeformats
     @eval _show(io::IO, ::MIME{Symbol($mime)}, plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plotlyjs_syncplot(plt), format = $fmt)
 end
 
-const _plotlyjs_showformats = ["text/html", "application/vnd.plotly.v1+json"]
-
-# for mime in ["text/html", "application/vnd.plotly.v1+json"]
-#     @eval _show(io::IO, mime::MIME{Symbol($mime)}, plt::Plot{PlotlyJSBackend}) = show(io, mime, plotlyjs_syncplot(plt))
-# end
-
 # Use the Plotly implementation for json and html:
-_show(io::IO, mime::MIME"application/vnd.plotly.v1+json", plt::Plot{PlotlyJSBackend}) = plotly_show_js(io, plot)
+_show(io::IO, mime::MIME"application/vnd.plotly.v1+json", plt::Plot{PlotlyJSBackend}) = plotly_show_js(io, plt)
 
 html_head(plt::Plot{PlotlyJSBackend}) = plotly_html_head(plt)
 html_body(plt::Plot{PlotlyJSBackend}) = plotly_html_body(plt)
 
 _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend}) = write(io, standalone_html(plt))
 
-# _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend}) = show(io, ::MIME"text/html", plt.o)
-# _show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="svg")
-# _show(io::IO, ::MIME"image/png", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="png")
-# _show(io::IO, ::MIME"application/pdf", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="pdf")
-# _show(io::IO, ::MIME"image/eps", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="eps")
-
-# function _show(io::IO, m::MIME"application/vnd.plotly.v1+json", plt::Plot{PlotlyJSBackend})
-#     show(io, m, plt.o)
-# end
-
-
-# function write_temp_html(plt::Plot{PlotlyJSBackend})
-#     filename = string(tempname(), ".html")
-#     savefig(plt, filename)
-#     filename
-# end
-
 _display(plt::Plot{PlotlyJSBackend}) = display(plotlyjs_syncplot(plt))
-
-# function _display(plt::Plot{PlotlyJSBackend})
-#     if get(ENV, "PLOTS_USE_ATOM_PLOTPANE", true) in (true, 1, "1", "true", "yes")
-#         display(plt.o)
-#     else
-#         standalone_html_window(plt)
-#     end
-# end
 
 @require WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29" begin
     function WebIO.render(plt::Plot{PlotlyJSBackend})

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -1,6 +1,6 @@
 # https://github.com/sglyon/PlotlyJS.jl
 
-# --------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 function plotlyjs_syncplot(plt::Plot{PlotlyJSBackend})
     plt[:overwrite_figure] && closeall()
@@ -17,7 +17,7 @@ function plotlyjs_syncplot(plt::Plot{PlotlyJSBackend})
     return plt.o
 end
 
-# ----------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 const _plotlyjs_mimeformats = Dict(
     "application/pdf" => "pdf",

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -2,77 +2,111 @@
 
 # --------------------------------------------------------------------------------------
 
-
-function _create_backend_figure(plt::Plot{PlotlyJSBackend})
-    if !isplotnull() && plt[:overwrite_figure] && isa(current().o, PlotlyJS.SyncPlot)
-        PlotlyJS.SyncPlot(PlotlyJS.Plot(), options = current().o.options)
-    else
-        PlotlyJS.plot()
+function plotlyjs_syncplot(plt::Plot{PlotlyJSBackend})
+    plt[:overwrite_figure] && closeall()
+    plt.o = PlotlyJS.plot()
+    traces = PlotlyJS.GenericTrace[]
+    for series_dict in plotly_series(plt)
+        plotly_type = pop!(series_dict, :type)
+        push!(traces, PlotlyJS.GenericTrace(plotly_type; series_dict...))
     end
+    PlotlyJS.addtraces!(plt.o, traces...)
+    layout = plotly_layout(plt)
+    w, h = plt[:size]
+    PlotlyJS.relayout!(plt.o, layout, width = w, height = h)
+    return plt.o
 end
 
 
-function _series_added(plt::Plot{PlotlyJSBackend}, series::Series)
-    syncplot = plt.o
-    pdicts = plotly_series(plt, series)
-    for pdict in pdicts
-        typ = pop!(pdict, :type)
-        gt = PlotlyJS.GenericTrace(typ; pdict...)
-        PlotlyJS.addtraces!(syncplot, gt)
-    end
-end
-
-function _series_updated(plt::Plot{PlotlyJSBackend}, series::Series)
-    xsym, ysym = (ispolar(series) ? (:t,:r) : (:x,:y))
-    kw = KW(xsym => (series.plotattributes[:x],), ysym => (series.plotattributes[:y],))
-    z = series[:z]
-    if z != nothing
-        kw[:z] = (isa(z,Surface) ? transpose_z(series, series[:z].surf, false) : z,)
-    end
-    PlotlyJS.restyle!(
-        plt.o,
-        findfirst(isequal(series), plt.series_list),
-        kw
-    )
-end
+# function _create_backend_figure(plt::Plot{PlotlyJSBackend})
+#     if !isplotnull() && plt[:overwrite_figure] && isa(current().o, PlotlyJS.SyncPlot)
+#         PlotlyJS.SyncPlot(PlotlyJS.Plot(), options = current().o.options)
+#     else
+#         PlotlyJS.plot()
+#     end
+# end
+#
+#
+# function _series_added(plt::Plot{PlotlyJSBackend}, series::Series)
+#     syncplot = plt.o
+#     pdicts = plotly_series(plt, series)
+#     for pdict in pdicts
+#         typ = pop!(pdict, :type)
+#         gt = PlotlyJS.GenericTrace(typ; pdict...)
+#         PlotlyJS.addtraces!(syncplot, gt)
+#     end
+# end
+#
+# function _series_updated(plt::Plot{PlotlyJSBackend}, series::Series)
+#     xsym, ysym = (ispolar(series) ? (:t,:r) : (:x,:y))
+#     kw = KW(xsym => (series.plotattributes[:x],), ysym => (series.plotattributes[:y],))
+#     z = series[:z]
+#     if z != nothing
+#         kw[:z] = (isa(z,Surface) ? transpose_z(series, series[:z].surf, false) : z,)
+#     end
+#     PlotlyJS.restyle!(
+#         plt.o,
+#         findfirst(isequal(series), plt.series_list),
+#         kw
+#     )
+# end
+#
+#
+# # ----------------------------------------------------------------
+#
+# function _update_plot_object(plt::Plot{PlotlyJSBackend})
+#     pdict = plotly_layout(plt)
+#     syncplot = plt.o
+#     w,h = plt[:size]
+#     PlotlyJS.relayout!(syncplot, pdict, width = w, height = h)
+# end
 
 
 # ----------------------------------------------------------------
 
-function _update_plot_object(plt::Plot{PlotlyJSBackend})
-    pdict = plotly_layout(plt)
-    syncplot = plt.o
-    w,h = plt[:size]
-    PlotlyJS.relayout!(syncplot, pdict, width = w, height = h)
+const _plotlyjs_mimeformats = Dict(
+    "application/pdf" => "pdf",
+    "image/png"       => "png",
+    "image/svg+xml"   => "svg",
+    "image/eps"       => "eps",
+)
+
+for (mime, fmt) in _plotlyjs_mimeformats
+    @eval _show(io::IO, ::MIME{Symbol($mime)}, plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plotlyjs_syncplot(plt), format = $fmt)
 end
 
+const _plotlyjs_showformats = ["text/html", "application/vnd.plotly.v1+json"]
 
-# ----------------------------------------------------------------
-
-_show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend}) = show(io, MIME("text/html"), plt.o)
-_show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="svg")
-_show(io::IO, ::MIME"image/png", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="png")
-_show(io::IO, ::MIME"application/pdf", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="pdf")
-_show(io::IO, ::MIME"image/eps", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="eps")
-
-function _show(io::IO, m::MIME"application/vnd.plotly.v1+json", plt::Plot{PlotlyJSBackend})
-    show(io, m, plt.o)
+for mime in ["text/html", "application/vnd.plotly.v1+json"]
+    @eval _show(io::IO, mime::MIME{Symbol($mime)}, plt::Plot{PlotlyJSBackend}) = show(io, mime, plotlyjs_syncplot(plt))
 end
 
+# _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend}) = show(io, ::MIME"text/html", plt.o)
+# _show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="svg")
+# _show(io::IO, ::MIME"image/png", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="png")
+# _show(io::IO, ::MIME"application/pdf", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="pdf")
+# _show(io::IO, ::MIME"image/eps", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="eps")
 
-function write_temp_html(plt::Plot{PlotlyJSBackend})
-    filename = string(tempname(), ".html")
-    savefig(plt, filename)
-    filename
-end
+# function _show(io::IO, m::MIME"application/vnd.plotly.v1+json", plt::Plot{PlotlyJSBackend})
+#     show(io, m, plt.o)
+# end
 
-function _display(plt::Plot{PlotlyJSBackend})
-    if get(ENV, "PLOTS_USE_ATOM_PLOTPANE", true) in (true, 1, "1", "true", "yes")
-        display(plt.o)
-    else
-        standalone_html_window(plt)
-    end
-end
+
+# function write_temp_html(plt::Plot{PlotlyJSBackend})
+#     filename = string(tempname(), ".html")
+#     savefig(plt, filename)
+#     filename
+# end
+
+_display(plt::Plot{PlotlyJSBackend}) = display(plotlyjs_syncplot(plt))
+
+# function _display(plt::Plot{PlotlyJSBackend})
+#     if get(ENV, "PLOTS_USE_ATOM_PLOTPANE", true) in (true, 1, "1", "true", "yes")
+#         display(plt.o)
+#     else
+#         standalone_html_window(plt)
+#     end
+# end
 
 @require WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29" begin
     function WebIO.render(plt::Plot{PlotlyJSBackend})

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -77,9 +77,17 @@ end
 
 const _plotlyjs_showformats = ["text/html", "application/vnd.plotly.v1+json"]
 
-for mime in ["text/html", "application/vnd.plotly.v1+json"]
-    @eval _show(io::IO, mime::MIME{Symbol($mime)}, plt::Plot{PlotlyJSBackend}) = show(io, mime, plotlyjs_syncplot(plt))
-end
+# for mime in ["text/html", "application/vnd.plotly.v1+json"]
+#     @eval _show(io::IO, mime::MIME{Symbol($mime)}, plt::Plot{PlotlyJSBackend}) = show(io, mime, plotlyjs_syncplot(plt))
+# end
+
+# Use the Plotly implementation for json and html:
+_show(io::IO, mime::MIME"application/vnd.plotly.v1+json", plt::Plot{PlotlyJSBackend}) = plotly_show_js(io, plot)
+
+html_head(plt::Plot{PlotlyJSBackend}) = plotly_html_head(plt)
+html_body(plt::Plot{PlotlyJSBackend}) = plotly_html_body(plt)
+
+_show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend}) = write(io, standalone_html(plt))
 
 # _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend}) = show(io, ::MIME"text/html", plt.o)
 # _show(io::IO, ::MIME"image/svg+xml", plt::Plot{PlotlyJSBackend}) = PlotlyJS.savefig(io, plt.o, format="svg")

--- a/src/ijulia.jl
+++ b/src/ijulia.jl
@@ -20,7 +20,10 @@ frontends like jupyterlab and nteract.
 _ijulia__extra_mime_info!(plt::Plot, out::Dict) = out
 
 function _ijulia__extra_mime_info!(plt::Plot{PlotlyJSBackend}, out::Dict)
-    out["application/vnd.plotly.v1+json"] = JSON.lower(plt.o)
+    out["application/vnd.plotly.v1+json"] = Dict(
+        :data => plotly_series(plt),
+        :layout => plotly_layout(plt)
+    )
     out
 end
 


### PR DESCRIPTION
This is a new implementation to improve the PlotlyJS backend.
- It is now possible to plot to multiple windows (#1721)
- It is possible to plot in IJulia and save to html (#1934 #2003). For html we us the methods implemented for Plotly now as a workaround, so we do not actually access PlotlyJS in IJulia unless we save as svg/pdf/png.
- performance for plots with multiple segments is improved.