### PR TITLE
[WIP] Generic support for permuting axes (generalizes `orientation=:horizontal`)

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -72,6 +72,11 @@ export
     xgrid!,
     ygrid!,
 
+    permuteaxes!,
+    swapxy!,
+    swapxz!,
+    swapyz!,
+
     xlims,
     ylims,
     zlims,
@@ -211,10 +216,15 @@ let PlotOrSubplot = Union{Plot, Subplot}
     global ygrid!(plt::PlotOrSubplot, args...; kw...)                  = plot!(plt; ygrid = args, kw...)
     global annotate!(plt::PlotOrSubplot, anns...; kw...)                         = plot!(plt; annotation = anns, kw...)
     global annotate!(plt::PlotOrSubplot, anns::AVec{T}; kw...) where {T<:Tuple}         = plot!(plt; annotation = anns, kw...)
-    global xflip!(plt::PlotOrSubplot, flip::Bool = true; kw...)                  = plot!(plt; xflip = flip, kw...)
-    global yflip!(plt::PlotOrSubplot, flip::Bool = true; kw...)                  = plot!(plt; yflip = flip, kw...)
-    global xaxis!(plt::PlotOrSubplot, args...; kw...)                            = plot!(plt; xaxis = args, kw...)
-    global yaxis!(plt::PlotOrSubplot, args...; kw...)                            = plot!(plt; yaxis = args, kw...)
+    global xflip!(plt::PlotOrSubplot, flip::Bool = true; kw...)        = plot!(plt; xflip = flip, kw...)
+    global yflip!(plt::PlotOrSubplot, flip::Bool = true; kw...)        = plot!(plt; yflip = flip, kw...)
+    global xaxis!(plt::PlotOrSubplot, args...; kw...)                  = plot!(plt; xaxis = args, kw...)
+    global yaxis!(plt::PlotOrSubplot, args...; kw...)                  = plot!(plt; yaxis = args, kw...)
+    global permuteaxes!(plt::PlotOrSubplot, perm...)    = _permuteaxes!(plt, _axis_permutation(perm))
+    global permuteaxes!(plt::PlotOrSubplot)             = _permuteaxes!(plt, [2,1,3])
+    global swapxy!(plt::PlotOrSubplot) = permuteaxes!(plt,2,1,3)
+    global swapxz!(plt::PlotOrSubplot) = permuteaxes!(plt,3,2,1)
+    global swapyz!(plt::PlotOrSubplot) = permuteaxes!(plt,1,3,2)
 end
 
 

--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -453,3 +453,34 @@ xaxis!(args...; kw...)                                    = plot!(; xaxis = args
 yaxis!(args...; kw...)                                    = plot!(; yaxis = args, kw...)
 xgrid!(args...; kw...)                                    = plot!(; xgrid = args, kw...)
 ygrid!(args...; kw...)                                    = plot!(; ygrid = args, kw...)
+
+
+"""
+    permuteaxes!([plt], axes...)
+
+Permute the axes of an existing plot.
+Axes may be specified by letter (`:x`, `:y`, `:z`) or number (1,2,3).
+`plt` defaults to the current plot. `axes` default to `(2,1,3)`.
+
+# Examples
+## Permuting axes by letters
+```julia-repl
+julia> x = range(0, 5π; length=100)
+julia> plot(x, cos.(x), sin.(2x))
+julia> permuteaxes!(:z,:x,:y)
+```
+## Bar plot with horizontal bars
+```julia-repl
+julia> bar(rand(4))
+julia> permuteaxes!()
+```
+See also: [`swapxy!`](@ref), [`swapxz!`](@ref), [`swapyz!`](@ref)
+"""
+permuteaxes!(axes...) = permuteaxes!(current(), axes...)
+
+"Swap the x and y axes of the current plot"
+swapxy!() = swapxy!(current())
+"Swap the x and z axes of the current plot"
+swapxz!() = swapxz!(current())
+"Swap the y and z axes of the current plot"
+swapyz!() = swapyz!(current())


### PR DESCRIPTION
I was trying to add support for `orientation=:horizontal` to the `dendrogram` recipe from `StatsPlots`, and some code in `axes.jl` that also reads the `orientation` attribute was getting in the way. Trying to see how other recipes implement this keyword, I discovered most of them are currently broken (see #1412, #1907, and maybe also #1410).

So instead, I decided to implement a more general solution to changing plot orientation that doesn't need re-implementing for each recipe/plot type. This PR adds functions `permuteaxes!, swapxy!, swapxz!, swapyz!` that can be called on existing plots to swap the axes around. 
So now a horizontal dendrogram can be plotted like this, without any support from the `dendrogram` recipe itself:
```
using Plots, StatsPlots, Clustering, LinearAlgebra
X = rand(10,10)
D = [norm(x.-y) for x in eachcol(X), y in eachcol(X)]
hc = hclust(D)
plt = plot(hc)
swapxy!()
plot!(xflip=true, ymirror=true)
```
![tmp](https://user-images.githubusercontent.com/4170948/62726011-ee38dd00-ba1e-11e9-9e6f-76a805a39e87.png)

I'm not sure if we also want a keyword interface, and what should be done with the current `orientation` keyword. Maybe something like:
```
histogram(foo, axis_permutation=[:y,:x])
```
but then what to make of
```
histogram(foo, axis_permutation=[:y,:x], xticks=[-5,0,5])
```
should the permutation be applied before or after the ticks?

- [x] Permute axes of existing plot
- [ ] Keyword argument support similar to or extending current `orientation`?
- [ ] Clean up `orientation` cruft
- [ ] Docs
