### PR TITLE
Fix GR axis flip for heatmap and image plots

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1337,9 +1337,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             if !ispolar(sp)
                 xmin, xmax, ymin, ymax = xy_lims
                 m, n = length(x), length(y)
-                xinds = sort(1:m, rev = xaxis[:flip])
-                yinds = sort(1:n, rev = yaxis[:flip])
-                z = reshape(reshape(z, m, n)[xinds, yinds], m*n)
                 GR.setspace(zmin, zmax, 0, 90)
                 grad = isa(series[:fillcolor], ColorGradient) ? series[:fillcolor] : cgrad()
                 colors = [plot_color(grad[clamp((zi-zmin) / (zmax-zmin), 0, 1)], series[:fillalpha]) for zi=z]
@@ -1454,9 +1451,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         elseif st == :image
             z = transpose_z(series, series[:z].surf, true)'
             w, h = size(z)
-            xinds = sort(1:w, rev = xaxis[:flip])
-            yinds = sort(1:h, rev = yaxis[:flip])
-            z = z[xinds, yinds]
             xmin, xmax = ignorenan_extrema(series[:x]); ymin, ymax = ignorenan_extrema(series[:y])
             if eltype(z) <: Colors.AbstractGray
                 grey = round.(UInt8, clamp.(float(z) * 255, 0, 255))


### PR DESCRIPTION
Fixes #2126 by undoing #1570. I suppose GR fixed handling of the flip flags in `GR.drawimage` since then...