### PR TITLE
Add handling for empty animation build error (fix #2138)

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -60,17 +60,22 @@ end
 
 file_extension(fn) = Base.Filesystem.splitext(fn)[2][2:end]
 
-gif(anim::Animation, fn = giffn(); kw...) = buildanimation(anim.dir, fn; kw...)
-mov(anim::Animation, fn = movfn(); kw...) = buildanimation(anim.dir, fn, false; kw...)
-mp4(anim::Animation, fn = mp4fn(); kw...) = buildanimation(anim.dir, fn, false; kw...)
+gif(anim::Animation, fn = giffn(); kw...) = buildanimation(anim, fn; kw...)
+mov(anim::Animation, fn = movfn(); kw...) = buildanimation(anim, fn, false; kw...)
+mp4(anim::Animation, fn = mp4fn(); kw...) = buildanimation(anim, fn, false; kw...)
 
 
-function buildanimation(animdir::AbstractString, fn::AbstractString,
+function buildanimation(anim::Animation, fn::AbstractString,
                         is_animated_gif::Bool=true;
                         fps::Integer = 20, loop::Integer = 0,
                         variable_palette::Bool=false,
                         show_msg::Bool=true)
+    if length(anim.frames) == 0
+        throw(ArgumentError("Cannot build empty animations"))
+    end
+
     fn = abspath(expanduser(fn))
+    animdir = anim.dir
 
     if is_animated_gif
         if variable_palette

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,13 @@ end
     end
 end
 
+@testset "EmptyAnim" begin
+    anim = @animate for i in []
+    end
+
+    @test_throws ArgumentError gif(anim)
+end
+
 @testset "Segments" begin
     function segments(args...)
         segs = UnitRange{Int}[]


### PR DESCRIPTION
#2138 
Throws an error message when a build call (such as `gif`) is made on an `Animation` instance that has no frames.