### PR TITLE
A real "first time to plot" analysis

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -220,6 +220,7 @@ end
 
 # ---------------------------------------------------------
 
-const CURRENT_BACKEND = CurrentBackend(:none)
+const CURRENT_BACKEND = Plots.CurrentBackend(:gr)
+gr()
 
 end # module

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -1,5 +1,5 @@
 
-const _arg_desc = KW(
+const _arg_desc = Dict{Symbol,String}(
 
 # series args
 :label 			=> "String type. The label for a series, which appears in a legend.  If empty, no legend entry is added.",
@@ -50,7 +50,7 @@ const _arg_desc = KW(
 :primary                => "Bool.  Does this count as a 'real series'?  For example, you could have a path (primary), and a scatter (secondary) as 2 separate series, maybe with different data (see sticks recipe for an example).  The secondary series will get the same color, etc as the primary.",
 :hover 	        	=> "nothing or vector of strings. Text to display when hovering over each data point.",
 :colorbar_entry   => "Bool.  Include this series in the color bar?  Set to `false` to exclude.",
-  
+
 # plot args
 :plot_title               => "String. Title for the whole plot (not the subplots) (Note: Not currently implemented)",
 :background_color         => "Color Type.  Base color for all backgrounds.",

--- a/src/args.jl
+++ b/src/args.jl
@@ -879,9 +879,9 @@ function processFontArg!(plotattributes::KW, fontname::Symbol, arg)
     end
 end
 
-_replace_markershape(shape::Symbol) = get(_markerAliases, shape, shape)
-_replace_markershape(shapes::AVec) = map(_replace_markershape, shapes)
-_replace_markershape(shape) = shape
+@noinline _replace_markershape(shape::Symbol) = get(_markerAliases, shape, shape)
+@noinline _replace_markershape(shapes::AVec) = map(_replace_markershape, shapes)
+@noinline _replace_markershape(shape) = shape
 
 function _add_markershape(plotattributes::KW)
     # add the markershape if it needs to be added... hack to allow "m=10" to add a shape,

--- a/src/args.jl
+++ b/src/args.jl
@@ -2,7 +2,7 @@
 
 const _keyAliases = Dict{Symbol,Symbol}()
 
-function add_aliases(sym::Symbol, aliases::Symbol...)
+@noinline function add_aliases(sym::Symbol, aliases::Symbol...)
     for alias in aliases
         if haskey(_keyAliases, alias)
             error("Already an alias $alias => $(_keyAliases[alias])... can't also alias $sym")
@@ -11,7 +11,7 @@ function add_aliases(sym::Symbol, aliases::Symbol...)
     end
 end
 
-function add_non_underscore_aliases!(aliases::Dict{Symbol,Symbol})
+@noinline function add_non_underscore_aliases!(aliases::Dict{Symbol,Symbol})
     for (k,v) in aliases
         s = string(k)
         if '_' in s
@@ -84,17 +84,17 @@ const _histogram_like = [:histogram, :barhist, :barbins]
 const _line_like = [:line, :path, :steppre, :steppost]
 const _surface_like = [:contour, :contourf, :contour3d, :heatmap, :surface, :wireframe, :image]
 
-like_histogram(seriestype::Symbol) = seriestype in _histogram_like
-like_line(seriestype::Symbol)      = seriestype in _line_like
-like_surface(seriestype::Symbol)   = seriestype in _surface_like
+@noinline like_histogram(seriestype::Symbol) = seriestype in _histogram_like
+@noinline like_line(seriestype::Symbol)      = seriestype in _line_like
+@noinline like_surface(seriestype::Symbol)   = seriestype in _surface_like
 
-is3d(seriestype::Symbol) = seriestype in _3dTypes
-is3d(series::Series) = is3d(series.plotattributes)
-is3d(plotattributes::KW) = trueOrAllTrue(is3d, Symbol(plotattributes[:seriestype]))
+@noinline is3d(seriestype::Symbol) = seriestype in _3dTypes
+@noinline is3d(series::Series) = is3d(series.plotattributes)
+@noinline is3d(plotattributes::KW) = trueOrAllTrue(is3d, Symbol(plotattributes[:seriestype]))
 
-is3d(sp::Subplot) = string(sp.attr[:projection]) == "3d"
-ispolar(sp::Subplot) = string(sp.attr[:projection]) == "polar"
-ispolar(series::Series) = ispolar(series.plotattributes[:subplot])
+@noinline is3d(sp::Subplot) = string(sp.attr[:projection]) == "3d"
+@noinline ispolar(sp::Subplot) = string(sp.attr[:projection]) == "polar"
+@noinline ispolar(series::Series) = ispolar(series.plotattributes[:subplot])
 
 # ------------------------------------------------------------
 
@@ -188,9 +188,9 @@ const _allGridSyms = [:x, :y, :z,
                     :all, :both, :on, :yes, :show,
                     :none, :off, :no, :hide]
 const _allGridArgs = [_allGridSyms; string.(_allGridSyms); nothing]
-hasgrid(arg::Nothing, letter) = false
-hasgrid(arg::Bool, letter) = arg
-function hasgrid(arg::Symbol, letter)
+@noinline hasgrid(arg::Nothing, letter) = false
+@noinline hasgrid(arg::Bool, letter) = arg
+@noinline function hasgrid(arg::Symbol, letter)
     if arg in _allGridSyms
         arg in (:all, :both, :on) || occursin(string(letter), string(arg))
     else
@@ -198,7 +198,7 @@ function hasgrid(arg::Symbol, letter)
         true
     end
 end
-hasgrid(arg::AbstractString, letter) = hasgrid(Symbol(arg), letter)
+@noinline hasgrid(arg::AbstractString, letter) = hasgrid(Symbol(arg), letter)
 
 const _allShowaxisSyms = [:x, :y, :z,
                     :xy, :xz, :yx, :yz, :zx, :zy,
@@ -206,9 +206,9 @@ const _allShowaxisSyms = [:x, :y, :z,
                     :all, :both, :on, :yes, :show,
                     :off, :no, :hide]
 const _allShowaxisArgs = [_allGridSyms; string.(_allGridSyms)]
-showaxis(arg::Nothing, letter) = false
-showaxis(arg::Bool, letter) = arg
-function showaxis(arg::Symbol, letter)
+@noinline showaxis(arg::Nothing, letter) = false
+@noinline showaxis(arg::Bool, letter) = arg
+@noinline function showaxis(arg::Symbol, letter)
     if arg in _allGridSyms
         arg in (:all, :both, :on, :yes) || occursin(string(letter), string(arg))
     else
@@ -216,7 +216,7 @@ function showaxis(arg::Symbol, letter)
         true
     end
 end
-showaxis(arg::AbstractString, letter) = hasgrid(Symbol(arg), letter)
+@noinline showaxis(arg::AbstractString, letter) = hasgrid(Symbol(arg), letter)
 
 const _allFramestyles = [:box, :semi, :axes, :origin, :zerolines, :grid, :none]
 const _framestyleAliases = Dict{Symbol, Symbol}(
@@ -448,7 +448,7 @@ const _initial_defaults = deepcopy(_all_defaults)
 const _initial_axis_defaults = deepcopy(_axis_defaults)
 
 # to be able to reset font sizes to initial values
-const _initial_fontsizes = Dict(:titlefontsize  => _subplot_defaults[:titlefontsize],
+const _initial_fontsizes = Dict{Any,Any}(:titlefontsize  => _subplot_defaults[:titlefontsize],
                                 :legendfontsize => _subplot_defaults[:legendfontsize],
                                 :tickfontsize   => _axis_defaults[:tickfontsize],
                                 :guidefontsize  => _axis_defaults[:guidefontsize])
@@ -459,15 +459,15 @@ RecipesBase.is_key_supported(k::Symbol) = is_attr_supported(k)
 
 # -----------------------------------------------------------------------------
 
-makeplural(s::Symbol) = Symbol(string(s,"s"))
+@noinline makeplural(s::Symbol) = Symbol(string(s,"s"))
 
-autopick(arr::AVec, idx::Integer) = arr[mod1(idx,length(arr))]
-autopick(notarr, idx::Integer) = notarr
+@noinline autopick(arr::AVec, idx::Integer) = arr[mod1(idx,length(arr))]
+@noinline autopick(notarr, idx::Integer) = notarr
 
-autopick_ignore_none_auto(arr::AVec, idx::Integer) = autopick(setdiff(arr, [:none, :auto]), idx)
-autopick_ignore_none_auto(notarr, idx::Integer) = notarr
+@noinline autopick_ignore_none_auto(arr::AVec, idx::Integer) = autopick(setdiff(arr, [:none, :auto]), idx)
+@noinline autopick_ignore_none_auto(notarr, idx::Integer) = notarr
 
-function aliasesAndAutopick(plotattributes::KW, sym::Symbol, aliases::Dict{Symbol,Symbol}, options::AVec, plotIndex::Int)
+@noinline function aliasesAndAutopick(plotattributes::KW, sym::Symbol, aliases::Dict{Symbol,Symbol}, options::AVec, plotIndex::Int)
     if plotattributes[sym] == :auto
         plotattributes[sym] = autopick_ignore_none_auto(options, plotIndex)
     elseif haskey(aliases, plotattributes[sym])
@@ -475,7 +475,7 @@ function aliasesAndAutopick(plotattributes::KW, sym::Symbol, aliases::Dict{Symbo
     end
 end
 
-function aliases(aliasMap::Dict{Symbol,Symbol}, val)
+@noinline function aliases(aliasMap::Dict{Symbol,Symbol}, val)
     sortedkeys(filter((k,v)-> v==val, aliasMap))
 end
 
@@ -1074,7 +1074,7 @@ end
 
 
 # this is when given a vector-type of values to group by
-function extractGroupArgs(v::AVec, args...; legendEntry = string)
+@noinline function extractGroupArgs(v::AVec, args...; legendEntry = string)
     groupLabels = sort(collect(unique(v)))
     n = length(groupLabels)
     if n > 100
@@ -1084,17 +1084,17 @@ function extractGroupArgs(v::AVec, args...; legendEntry = string)
     GroupBy(map(legendEntry, groupLabels), groupIds)
 end
 
-legendEntryFromTuple(ns::Tuple) = join(ns, ' ')
+@noinline legendEntryFromTuple(ns::Tuple) = join(ns, ' ')
 
 # this is when given a tuple of vectors of values to group by
-function extractGroupArgs(vs::Tuple, args...)
+@noinline function extractGroupArgs(vs::Tuple, args...)
     isempty(vs) && return GroupBy([""], [1:size(args[1],1)])
     v = map(tuple, vs...)
     extractGroupArgs(v, args...; legendEntry = legendEntryFromTuple)
 end
 
 # allow passing NamedTuples for a named legend entry
-legendEntryFromTuple(ns::NamedTuple) =
+@noinline legendEntryFromTuple(ns::NamedTuple) =
     join(["$k = $v" for (k, v) in pairs(ns)], ", ")
 
 function extractGroupArgs(vs::NamedTuple, args...)
@@ -1104,22 +1104,22 @@ function extractGroupArgs(vs::NamedTuple, args...)
 end
 
 # expecting a mapping of "group label" to "group indices"
-function extractGroupArgs(idxmap::Dict{T,V}, args...) where {T, V<:AVec{Int}}
+@noinline function extractGroupArgs(idxmap::Dict{T,V}, args...) where {T, V<:AVec{Int}}
     groupLabels = sortedkeys(idxmap)
     groupIds = Vector{Int}[collect(idxmap[k]) for k in groupLabels]
     GroupBy(groupLabels, groupIds)
 end
 
-filter_data(v::AVec, idxfilter::AVec{Int}) = v[idxfilter]
-filter_data(v, idxfilter) = v
+@noinline filter_data(v::AVec, idxfilter::AVec{Int}) = v[idxfilter]
+@noinline filter_data(v, idxfilter) = v
 
-function filter_data!(plotattributes::KW, idxfilter)
+@noinline function filter_data!(plotattributes::KW, idxfilter)
     for s in (:x, :y, :z)
         plotattributes[s] = filter_data(get(plotattributes, s, nothing), idxfilter)
     end
 end
 
-function _filter_input_data!(plotattributes::KW)
+@noinline function _filter_input_data!(plotattributes::KW)
     idxfilter = pop!(plotattributes, :idxfilter, nothing)
     if idxfilter !== nothing
         filter_data!(plotattributes, idxfilter)
@@ -1182,7 +1182,7 @@ end
 
 # -----------------------------------------------------------------------------
 
-function convertLegendValue(val::Symbol)
+@noinline function convertLegendValue(val::Symbol)
     if val in (:both, :all, :yes)
         :best
     elseif val in (:no, :none)
@@ -1193,10 +1193,10 @@ function convertLegendValue(val::Symbol)
         error("Invalid symbol for legend: $val")
     end
 end
-convertLegendValue(val::Bool) = val ? :best : :none
-convertLegendValue(val::Nothing) = :none
-convertLegendValue(v::Tuple{S,T}) where {S<:Real, T<:Real} = v
-convertLegendValue(v::AbstractArray) = map(convertLegendValue, v)
+@noinline convertLegendValue(val::Bool) = val ? :best : :none
+@noinline convertLegendValue(val::Nothing) = :none
+@noinline convertLegendValue(v::Tuple{S,T}) where {S<:Real, T<:Real} = v
+@noinline convertLegendValue(v::AbstractArray) = map(convertLegendValue, v)
 
 # -----------------------------------------------------------------------------
 
@@ -1205,12 +1205,12 @@ convertLegendValue(v::AbstractArray) = map(convertLegendValue, v)
 # multi-row matrices will give a column
 # InputWrapper just gives the contents
 # anything else is returned as-is
-function slice_arg(v::AMat, idx::Int)
+@noinline function slice_arg(v::AMat, idx::Int)
     c = mod1(idx, size(v,2))
     size(v,1) == 1 ? v[1,c] : v[:,c]
 end
-slice_arg(wrapper::InputWrapper, idx) = wrapper.obj
-slice_arg(v, idx) = v
+@noinline slice_arg(wrapper::InputWrapper, idx) = wrapper.obj
+@noinline slice_arg(v, idx) = v
 
 
 # given an argument key (k), we want to extract the argument value for this index.
@@ -1509,9 +1509,9 @@ end
 
 # -----------------------------------------------------------------------------
 
-has_black_border_for_default(st) = error("The seriestype attribute only accepts Symbols, you passed the $(typeof(st)) $st.")
-has_black_border_for_default(st::Function) = error("The seriestype attribute only accepts Symbols, you passed the function $st.")
-function has_black_border_for_default(st::Symbol)
+@noinline has_black_border_for_default(st) = error("The seriestype attribute only accepts Symbols, you passed the $(typeof(st)) $st.")
+@noinline has_black_border_for_default(st::Function) = error("The seriestype attribute only accepts Symbols, you passed the function $st.")
+@noinline function has_black_border_for_default(st::Symbol)
     like_histogram(st) || st in (:hexbin, :bar, :shape)
 end
 

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -754,5 +754,5 @@ function axis_drawing_info(sp::Subplot)
         end
     end
 
-    xticks, yticks, xaxis_segs, yaxis_segs, xtick_segs, ytick_segs, xgrid_segs, ygrid_segs, xminorgrid_segs, yminorgrid_segs, xborder_segs, yborder_segs
+    Any[xticks, yticks, xaxis_segs, yaxis_segs, xtick_segs, ytick_segs, xgrid_segs, ygrid_segs, xminorgrid_segs, yminorgrid_segs, xborder_segs, yborder_segs]
 end

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -47,17 +47,17 @@ end
 # ---------------------------------------------------------
 
 # don't do anything as a default
-_create_backend_figure(plt::Plot) = nothing
-_prepare_plot_object(plt::Plot) = nothing
-_initialize_subplot(plt::Plot, sp::Subplot) = nothing
+@noinline _create_backend_figure(plt::Plot) = nothing
+@noinline _prepare_plot_object(plt::Plot) = nothing
+@noinline _initialize_subplot(plt::Plot, sp::Subplot) = nothing
 
-_series_added(plt::Plot, series::Series) = nothing
-_series_updated(plt::Plot, series::Series) = nothing
+@noinline _series_added(plt::Plot, series::Series) = nothing
+@noinline _series_updated(plt::Plot, series::Series) = nothing
 
-_before_layout_calcs(plt::Plot) = nothing
+@noinline _before_layout_calcs(plt::Plot) = nothing
 
-title_padding(sp::Subplot) = sp[:title] == "" ? 0mm : sp[:titlefontsize] * pt
-guide_padding(axis::Axis) = axis[:guide] == "" ? 0mm : axis[:guidefontsize] * pt
+@noinline title_padding(sp::Subplot) = sp[:title] == "" ? 0mm : sp[:titlefontsize] * pt
+@noinline guide_padding(axis::Axis) = axis[:guide] == "" ? 0mm : axis[:guidefontsize] * pt
 
 "Returns the (width,height) of a text label."
 function text_size(lablen::Int, sz::Number, rot::Number = 0)
@@ -123,7 +123,7 @@ function _update_min_padding!(sp::Subplot)
     sp.minpad = (leftpad, toppad, rightpad, bottompad)
 end
 
-_update_plot_object(plt::Plot) = nothing
+@noinline _update_plot_object(plt::Plot) = nothing
 
 # ---------------------------------------------------------
 
@@ -148,7 +148,7 @@ end
 
 # ---------------------------------------------------------
 
-_fallback_default_backend() = backend(GRBackend())
+@noinline _fallback_default_backend() = backend(GRBackend())
 
 function _pick_default_backend()
     env_default = get(ENV, "PLOTS_DEFAULT_BACKEND", "")
@@ -305,9 +305,8 @@ function _initialize_backend(pkg::AbstractBackend)
     end
 end
 
-_initialize_backend(pkg::GRBackend) = nothing
-
-_initialize_backend(pkg::PlotlyBackend) = nothing
+@noinline _initialize_backend(pkg::GRBackend) = nothing
+@noinline _initialize_backend(pkg::PlotlyBackend) = nothing
 
 
 # ------------------------------------------------------------------------------

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -9,7 +9,7 @@ export GR
 
 # --------------------------------------------------------------------------------------
 
-const gr_linetype = KW(
+const gr_linetype = Dict{Symbol,Int}(
     :auto => 1,
     :solid => 1,
     :dash => 2,
@@ -18,7 +18,7 @@ const gr_linetype = KW(
     :dashdotdot => -1
 )
 
-const gr_markertype = KW(
+const gr_markertype = Dict{Symbol,Int}(
     :auto => 1,
     :none => -1,
     :circle => -1,
@@ -45,19 +45,19 @@ const gr_markertype = KW(
     :hline => -31
 )
 
-const gr_halign = KW(
+const gr_halign = Dict{Symbol,Int}(
     :left => 1,
     :hcenter => 2,
     :right => 3
 )
 
-const gr_valign = KW(
+const gr_valign = Dict{Symbol,Int}(
     :top => 1,
     :vcenter => 3,
     :bottom => 5
 )
 
-const gr_font_family = Dict(
+const gr_font_family = Dict{String,Int}(
     "times" => 1,
     "helvetica" => 5,
     "courier" => 9,
@@ -84,7 +84,7 @@ gr_set_transparency(c, α) = gr_set_transparency(α)
 gr_set_transparency(c::Colorant, ::Nothing) = gr_set_transparency(c)
 gr_set_transparency(c::Colorant) = GR.settransparency(alpha(c))
 
-const _gr_arrow_map = Dict(
+const _gr_arrow_map = Dict{Symbol,Int}(
     :simple => 1,
     :hollow => 3,
     :filled => 4,
@@ -1580,7 +1580,7 @@ end
 
 # ----------------------------------------------------------------
 
-const _gr_mimeformats = Dict(
+const _gr_mimeformats = Dict{String,String}(
     "application/pdf"         => "pdf",
     "image/png"               => "png",
     "application/postscript"  => "ps",

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -74,15 +74,15 @@ const gr_font_family = Dict{String,Int}(
     convert(Int, GR.inqcolorfromrgb(red(c), green(c), blue(c)))
 end
 
-gr_set_linecolor(c)   = GR.setlinecolorind(gr_getcolorind(_cycle(c,1)))
-gr_set_fillcolor(c)   = GR.setfillcolorind(gr_getcolorind(_cycle(c,1)))
-gr_set_markercolor(c) = GR.setmarkercolorind(gr_getcolorind(_cycle(c,1)))
-gr_set_textcolor(c)   = GR.settextcolorind(gr_getcolorind(_cycle(c,1)))
-gr_set_transparency(α::Real) = GR.settransparency(clamp(α, 0, 1))
-gr_set_transparency(::Nothing) = GR.settransparency(1)
-gr_set_transparency(c, α) = gr_set_transparency(α)
-gr_set_transparency(c::Colorant, ::Nothing) = gr_set_transparency(c)
-gr_set_transparency(c::Colorant) = GR.settransparency(alpha(c))
+@noinline gr_set_linecolor(c)   = GR.setlinecolorind(gr_getcolorind(_cycle(c,1)))
+@noinline gr_set_fillcolor(c)   = GR.setfillcolorind(gr_getcolorind(_cycle(c,1)))
+@noinline gr_set_markercolor(c) = GR.setmarkercolorind(gr_getcolorind(_cycle(c,1)))
+@noinline gr_set_textcolor(c)   = GR.settextcolorind(gr_getcolorind(_cycle(c,1)))
+@noinline gr_set_transparency(α::Real) = GR.settransparency(clamp(α, 0, 1))
+@noinline gr_set_transparency(::Nothing) = GR.settransparency(1)
+@noinline gr_set_transparency(c, α) = gr_set_transparency(α)
+@noinline gr_set_transparency(c::Colorant, ::Nothing) = gr_set_transparency(c)
+@noinline gr_set_transparency(c::Colorant) = GR.settransparency(alpha(c))
 
 const _gr_arrow_map = Dict{Symbol,Int}(
     :simple => 1,
@@ -93,7 +93,7 @@ const _gr_arrow_map = Dict{Symbol,Int}(
     :closed => 6,
     :open => 5,
 )
-gr_set_arrowstyle(s::Symbol) = GR.setarrowstyle(get(_gr_arrow_map, s, 1))
+@noinline gr_set_arrowstyle(s::Symbol) = GR.setarrowstyle(get(_gr_arrow_map, s, 1))
 
 # --------------------------------------------------------------------------------------
 
@@ -142,7 +142,7 @@ function gr_polyline(x, y, func = GR.polyline; arrowside = :none, arrowstyle = :
     end
 end
 
-gr_inqtext(x, y, s::Symbol) = gr_inqtext(x, y, string(s))
+@noinline gr_inqtext(x, y, s::Symbol) = gr_inqtext(x, y, string(s))
 
 @noinline function gr_inqtext(x, y, s)
     if length(s) >= 2 && s[1] == '$' && s[end] == '$'
@@ -154,7 +154,7 @@ gr_inqtext(x, y, s::Symbol) = gr_inqtext(x, y, string(s))
     end
 end
 
-gr_text(x, y, s::Symbol) = gr_text(x, y, string(s))
+@noinline gr_text(x, y, s::Symbol) = gr_text(x, y, string(s))
 
 @noinline function gr_text(x, y, s)
     if length(s) >= 2 && s[1] == '$' && s[end] == '$'
@@ -382,7 +382,7 @@ const gr_plot_size = [600.0, 400.0]
 
 const gr_colorbar_ratio = 0.1
 
-function gr_viewport_from_bbox(sp::Subplot{GRBackend}, bb::BoundingBox, w, h, viewport_canvas)
+@noinline function gr_viewport_from_bbox(sp::Subplot{GRBackend}, bb::BoundingBox, w, h, viewport_canvas)
     viewport = zeros(4)
     viewport[1] = viewport_canvas[2] * (left(bb) / w)
     viewport[2] = viewport_canvas[2] * (right(bb) / w)
@@ -423,7 +423,7 @@ end
 end
 
 @noinline function gr_set_viewport_polar()
-    xmin, xmax, ymin, ymax = viewport_plotarea
+    xmin::Float64, xmax::Float64, ymin::Float64, ymax::Float64 = viewport_plotarea
     ymax -= 0.05 * (xmax - xmin)
     xcenter = 0.5 * (xmin + xmax)
     ycenter = 0.5 * (ymin + ymax)
@@ -459,7 +459,7 @@ end
     levels
 end
 
-function gr_colorbar_colors(series::Series, clims)::Vector{Int}
+@noinline function gr_colorbar_colors(series::Series, clims)::Vector{Int}
     if iscontour(series)
         levels = gr_contour_levels(series, clims)
         if isfilledcontour(series)
@@ -556,6 +556,8 @@ function gr_legend_pos(sp::Subplot, w, h)
     s = sp[:legend]
     typeof(s) <: Symbol || return gr_legend_pos(s, w, h)
     str = string(s)
+    xpos::Float64 = 0.0
+    ypos::Float64 = 0.0
     if str == "best"
         str = "topright"
     end
@@ -599,8 +601,8 @@ function gr_legend_pos(sp::Subplot, w, h)
 end
 
 @noinline function gr_legend_pos(v::Tuple{S,T},w,h) where {S<:Real, T<:Real}
-    xpos = v[1] * (viewport_plotarea[2] - viewport_plotarea[1]) + viewport_plotarea[1]
-    ypos = v[2] * (viewport_plotarea[4] - viewport_plotarea[3]) + viewport_plotarea[3]
+    xpos::Float64 = v[1] * (viewport_plotarea[2] - viewport_plotarea[1]) + viewport_plotarea[1]
+    ypos::Float64 = v[2] * (viewport_plotarea[4] - viewport_plotarea[3]) + viewport_plotarea[3]
     (xpos,ypos)
 end
 
@@ -623,7 +625,7 @@ end
     color !== nothing && gr_set_gradient(color)
 end
 
-function gr_get_color(series::Series)
+@noinline function gr_get_color(series::Series)
     st = series[:seriestype]
     if st in (:surface, :heatmap) || isfilledcontour(series)
         series[:fillcolor]
@@ -689,7 +691,7 @@ function gr_display(plt::Plot, fmt="")
 end
 
 
-function gr_set_xticks_font(sp)
+@noinline function gr_set_xticks_font(sp)
     flip = sp[:yaxis][:flip]
     mirror = sp[:xaxis][:mirror]
     gr_set_font(tickfont(sp[:xaxis]),
@@ -700,7 +702,7 @@ function gr_set_xticks_font(sp)
 end
 
 
-function gr_set_yticks_font(sp)
+@noinline function gr_set_yticks_font(sp)
     flip = sp[:xaxis][:flip]
     mirror = sp[:yaxis][:mirror]
     gr_set_font(tickfont(sp[:yaxis]),
@@ -710,7 +712,7 @@ function gr_set_yticks_font(sp)
     return flip, mirror
 end
 
-function gr_text_size(str)
+@noinline function gr_text_size(str)
     GR.savestate()
     GR.selntran(0)
     xs, ys = gr_inqtext(0, 0, string(str))
@@ -722,7 +724,7 @@ function gr_text_size(str)
     return w, h
 end
 
-function gr_text_size(str, rot)
+@noinline function gr_text_size(str, rot)
     GR.savestate()
     GR.selntran(0)
     xs, ys = gr_inqtext(0, 0, string(str))
@@ -737,7 +739,7 @@ end
 @noinline text_box_width(w, h, rot) = abs(cosd(rot)) * w + abs(cosd(rot + 90)) * h
 @noinline text_box_height(w, h, rot) = abs(sind(rot)) * w + abs(sind(rot + 90)) * h
 
-function gr_get_ticks_size(ticks, rot)
+@noinline function gr_get_ticks_size(ticks, rot)
     w, h = 0.0, 0.0
     for (cv, dv) in zip(ticks...)
         wi, hi = gr_text_size(dv, rot)
@@ -747,7 +749,7 @@ function gr_get_ticks_size(ticks, rot)
     return w, h
 end
 
-function gr_xaxis_height(sp)
+@noinline function gr_xaxis_height(sp)
     xaxis = sp[:xaxis]
     xticks, yticks = axis_drawing_info(sp)[1:2]
     gr_set_font(tickfont(xaxis))
@@ -759,7 +761,7 @@ function gr_xaxis_height(sp)
     return h
 end
 
-function gr_yaxis_width(sp)
+@noinline function gr_yaxis_width(sp)
     yaxis = sp[:yaxis]
     xticks, yticks = axis_drawing_info(sp)[1:2]
     gr_set_font(tickfont(yaxis))
@@ -779,10 +781,10 @@ function _update_min_padding!(sp::Subplot{GRBackend})
         end
     end
     # Add margin given by the user
-    leftpad   = 2mm  + sp[:left_margin]
-    toppad    = 2mm  + sp[:top_margin]
-    rightpad  = 2mm  + sp[:right_margin]
-    bottompad = 2mm  + sp[:bottom_margin]
+    leftpad::AbsoluteLength   = 2mm  + sp[:left_margin]
+    toppad::AbsoluteLength    = 2mm  + sp[:top_margin]
+    rightpad::AbsoluteLength  = 2mm  + sp[:right_margin]
+    bottompad::AbsoluteLength = 2mm  + sp[:bottom_margin]
     # Add margin for title
     if sp[:title] != ""
         gr_set_font(titlefont(sp))
@@ -853,6 +855,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     ratio = sp[:aspect_ratio]
 
     if ratio != :none
+        (function ()
         if ratio == :equal
             ratio = 1
         end
@@ -869,14 +872,16 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             viewport_plotarea[3] = viewport_center - 0.5 * viewport_size
             viewport_plotarea[4] = viewport_center + 0.5 * viewport_size
         end
+        end)()
     end
 
     # calculate legend size
     # has to be done now due to a potential adjustment to the plotarea given an outer legend.
-    legendn = 0
-    legendw = 0
-    legendi = 0
+    legendn::Int = 0
+    legendw::Float64 = 0.0
+    legendi::Int = 0
     if sp[:legend] != :none
+        (function ()
         GR.savestate()
         GR.selntran(0)
         GR.setscale(0)
@@ -902,6 +907,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         GR.setscale(1)
         GR.selntran(1)
         GR.restorestate()
+        end)()
     end
 
     dy = _gr_point_mult[1] * sp[:legendfontsize] * 1.75
@@ -964,10 +970,11 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     zaxis = sp[:zaxis]
 
     # set the scale flags and window
-    xmin, xmax, ymin, ymax = data_lims
+    xmin::Float64, xmax::Float64, ymin::Float64, ymax::Float64 = data_lims
     scaleop = 0
     xtick, ytick = 1, 1
     if xmax > xmin && ymax > ymin
+        (function ()
         # NOTE: for log axes, the major_x and major_y - if non-zero (omit labels) - control the minor grid lines (1 = draw 9 minor grid lines, 2 = no minor grid lines)
         # NOTE: for log axes, the x_tick and y_tick - if non-zero (omit axes) - only affect the output appearance (1 = nomal, 2 = scientiic notation)
         xaxis[:scale] == :log10 && (scaleop |= GR.OPTION_X_LOG)
@@ -994,6 +1001,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         # NOTE: setwindow sets the "data coordinate" limits of the current "viewport"
         GR.setwindow(xmin, xmax, ymin, ymax)
         GR.setscale(scaleop)
+        end)()
     end
 
     # draw the axes
@@ -1263,6 +1271,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         end
 
         if st in (:path, :scatter, :straightline)
+            (@noinline function ()
             if x !== nothing && length(x) > 1
                 lz = series[:line_z]
                 segments = iter_segments(series)
@@ -1297,9 +1306,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             if series[:markershape] != :none
                 gr_draw_markers(series, x, y, clims)
             end
-
+            end)()
         elseif st == :contour
-            (function ()
+            (@noinline function ()
             GR.setspace(clims[1], clims[2], 0, 90)
             GR.setlinetype(gr_linetype[get_linestyle(series)])
             GR.setlinewidth(max(0, get_linewidth(series) / (sum(gr_plot_size) * 0.001)))
@@ -1318,7 +1327,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             end
             end)()
         elseif st in [:surface, :wireframe]
-            (function ()
+            (@noinline function ()
             if st == :surface
                 if length(x) == length(y) == length(z)
                     GR.trisurface(x, y, z)
@@ -1335,13 +1344,13 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             end
             end)()
         elseif st == :volume
-            (function ()
+            (@noinline function ()
             sp[:legend] = :none
             GR.gr3.clear()
             dmin, dmax = GR.gr3.volume(y.v, 0)
             end)()
         elseif st == :heatmap
-            (function ()
+            (@noinline function ()
             zmin, zmax = clims
             if !ispolar(sp)
                 xmin, xmax, ymin, ymax = xy_lims
@@ -1364,7 +1373,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             end
             end)()
         elseif st in (:path3d, :scatter3d)
-            (function ()
+            (@noinline function ()
             # draw path
             if st == :path3d
                 if length(x) > 1
@@ -1387,7 +1396,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             end)()
         # TODO: replace with pie recipe
         elseif st == :pie
-            (function ()
+            (@noinline function ()
             GR.selntran(0)
             GR.setfillintstyle(GR.INTSTYLE_SOLID)
             xmin, xmax, ymin, ymax = viewport_plotarea
@@ -1435,7 +1444,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             GR.selntran(1)
             end)()
         elseif st == :shape
-            (function ()
+            (@noinline function ()
             x, y = shape_data(series)
             for (i,rng) in enumerate(iter_segments(x, y))
                 if length(rng) > 1
@@ -1460,7 +1469,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             end
             end)()
         elseif st == :image
-            (function ()
+            (@noinline function ()
             z = transpose_z(series, series[:z].surf, true)'
             w, h = size(z)
             xmin, xmax = ignorenan_extrema(series[:x]); ymin, ymax = ignorenan_extrema(series[:y])
@@ -1492,7 +1501,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
     # add the legend
     if sp[:legend] != :none
-        (function ()
+        (@noinline function ()
         GR.savestate()
         GR.selntran(0)
         GR.setscale(0)

--- a/src/components.jl
+++ b/src/components.jl
@@ -137,7 +137,7 @@ const _shape_keys = Symbol[
   :x,
 ]
 
-const _shapes = KW(
+const _shapes = Dict{Symbol,Shape}(
     :circle    => makeshape(20),
     :rect       => makeshape(4, offset=-0.25),
     :diamond    => makeshape(4),

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -188,29 +188,29 @@ parent_bbox(layout::AbstractLayout) = bbox(parent(layout))
 # padding_h(layout::AbstractLayout) = bottom_padding(layout) + top_padding(layout)
 # padding(layout::AbstractLayout) = (padding_w(layout), padding_h(layout))
 
-update_position!(layout::AbstractLayout) = nothing
-update_child_bboxes!(layout::AbstractLayout, minimum_perimeter = [0mm,0mm,0mm,0mm]) = nothing
+@noinline update_position!(layout::AbstractLayout) = nothing
+@noinline update_child_bboxes!(layout::AbstractLayout, minimum_perimeter = [0mm,0mm,0mm,0mm]) = nothing
 
-left(layout::AbstractLayout) = left(bbox(layout))
-top(layout::AbstractLayout) = top(bbox(layout))
-right(layout::AbstractLayout) = right(bbox(layout))
-bottom(layout::AbstractLayout) = bottom(bbox(layout))
-width(layout::AbstractLayout) = width(bbox(layout))
-height(layout::AbstractLayout) = height(bbox(layout))
+@noinline left(layout::AbstractLayout) = left(bbox(layout))
+@noinline top(layout::AbstractLayout) = top(bbox(layout))
+@noinline right(layout::AbstractLayout) = right(bbox(layout))
+@noinline bottom(layout::AbstractLayout) = bottom(bbox(layout))
+@noinline width(layout::AbstractLayout) = width(bbox(layout))
+@noinline height(layout::AbstractLayout) = height(bbox(layout))
 
 # pass these through to the bbox methods if there's no plotarea
-plotarea(layout::AbstractLayout) = bbox(layout)
-plotarea!(layout::AbstractLayout, bb::BoundingBox) = bbox!(layout, bb)
+@noinline plotarea(layout::AbstractLayout) = bbox(layout)
+@noinline plotarea!(layout::AbstractLayout, bb::BoundingBox) = bbox!(layout, bb)
 
-attr(layout::AbstractLayout, k::Symbol) = layout.attr[k]
-attr(layout::AbstractLayout, k::Symbol, v) = get(layout.attr, k, v)
-attr!(layout::AbstractLayout, v, k::Symbol) = (layout.attr[k] = v)
-hasattr(layout::AbstractLayout, k::Symbol) = haskey(layout.attr, k)
+@noinline attr(layout::AbstractLayout, k::Symbol) = layout.attr[k]
+@noinline attr(layout::AbstractLayout, k::Symbol, v) = get(layout.attr, k, v)
+@noinline attr!(layout::AbstractLayout, v, k::Symbol) = (layout.attr[k] = v)
+@noinline hasattr(layout::AbstractLayout, k::Symbol) = haskey(layout.attr, k)
 
-leftpad(layout::AbstractLayout)   = 0mm
-toppad(layout::AbstractLayout)    = 0mm
-rightpad(layout::AbstractLayout)  = 0mm
-bottompad(layout::AbstractLayout) = 0mm
+@noinline leftpad(layout::AbstractLayout)   = 0mm
+@noinline toppad(layout::AbstractLayout)    = 0mm
+@noinline rightpad(layout::AbstractLayout)  = 0mm
+@noinline bottompad(layout::AbstractLayout) = 0mm
 
 # -----------------------------------------------------------
 # RootLayout
@@ -349,18 +349,18 @@ function update_child_bboxes!(layout::GridLayout, minimum_perimeter = [0mm,0mm,0
     # # create a matrix for each minimum padding direction
     # _update_min_padding!(layout)
 
-    minpad_left   = map(leftpad,   layout.grid)
-    minpad_top    = map(toppad,    layout.grid)
-    minpad_right  = map(rightpad,  layout.grid)
-    minpad_bottom = map(bottompad, layout.grid)
+    minpad_left::Matrix{AbsoluteLength}   = map(leftpad,   layout.grid)
+    minpad_top::Matrix{AbsoluteLength}    = map(toppad,    layout.grid)
+    minpad_right::Matrix{AbsoluteLength}  = map(rightpad,  layout.grid)
+    minpad_bottom::Matrix{AbsoluteLength} = map(bottompad, layout.grid)
 
     # get the max horizontal (left and right) padding over columns,
     # and max vertical (bottom and top) padding over rows
     # TODO: add extra padding here
-    pad_left   = maximum(minpad_left,   dims = 1)
-    pad_top    = maximum(minpad_top,    dims = 2)
-    pad_right  = maximum(minpad_right,  dims = 1)
-    pad_bottom = maximum(minpad_bottom, dims = 2)
+    pad_left::Matrix{AbsoluteLength}   = maximum(minpad_left,   dims = 1)
+    pad_top::Matrix{AbsoluteLength}    = maximum(minpad_top,    dims = 2)
+    pad_right::Matrix{AbsoluteLength}  = maximum(minpad_right,  dims = 1)
+    pad_bottom::Matrix{AbsoluteLength} = maximum(minpad_bottom, dims = 2)
 
     # make sure the perimeter match the parent
     pad_left[1]     = max(pad_left[1], minimum_perimeter[1])
@@ -389,14 +389,14 @@ function update_child_bboxes!(layout::GridLayout, minimum_perimeter = [0mm,0mm,0
         child = layout[r,c]
 
         # get the top-left corner of this child... the first one is top-left of the parent (i.e. layout)
-        child_left = (c == 1 ? left(layout.bbox) : right(layout[r, c-1].bbox))
-        child_top  = (r == 1 ? top(layout.bbox) : bottom(layout[r-1, c].bbox))
+        child_left::AbsoluteLength  = (c == 1 ? left(layout.bbox) : right(layout[r, c-1].bbox))
+        child_top::AbsoluteLength   = (r == 1 ? top(layout.bbox) : bottom(layout[r-1, c].bbox))
 
         # compute plot area
-        plotarea_left   = child_left + pad_left[c]
-        plotarea_top    = child_top + pad_top[r]
-        plotarea_width  = total_plotarea_horizontal * layout.widths[c]
-        plotarea_height = total_plotarea_vertical * layout.heights[r]
+        plotarea_left::AbsoluteLength    = child_left + pad_left[c]
+        plotarea_top::AbsoluteLength     = child_top + pad_top[r]
+        plotarea_width::AbsoluteLength   = total_plotarea_horizontal * layout.widths[c]
+        plotarea_height::AbsoluteLength  = total_plotarea_vertical * layout.heights[r]
         plotarea!(child, BoundingBox(plotarea_left, plotarea_top, plotarea_width, plotarea_height))
 
         # compute child bbox

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -227,8 +227,8 @@ bbox(::RootLayout) = defaultbox
 
 # contains blank space
 mutable struct EmptyLayout <: AbstractLayout
-    parent::AbstractLayout
-    bbox::BoundingBox
+    parent
+    bbox#::BoundingBox
     attr::KW  # store label, width, and height for initialization
     # label  # this is the label that the subplot will take (since we create a layout before initialization)
 end
@@ -245,12 +245,12 @@ _update_min_padding!(layout::EmptyLayout) = nothing
 
 # nested, gridded layout with optional size percentages
 mutable struct GridLayout <: AbstractLayout
-    parent::AbstractLayout
-    minpad::Tuple # leftpad, toppad, rightpad, bottompad
-    bbox::BoundingBox
-    grid::Matrix{AbstractLayout} # Nested layouts. Each position is a AbstractLayout, which allows for arbitrary recursion
-    widths::Vector{Measure}
-    heights::Vector{Measure}
+    parent
+    minpad::Tuple{AbsoluteLength,AbsoluteLength,AbsoluteLength,AbsoluteLength} # leftpad, toppad, rightpad, bottompad
+    bbox#::BoundingBox
+    grid::Matrix{Any} # Nested layouts. Each position is a AbstractLayout, which allows for arbitrary recursion
+    widths::Vector{Any}
+    heights::Vector{Any}
     attr::KW
 end
 
@@ -268,14 +268,14 @@ function GridLayout(dims...;
                     widths = zeros(dims[2]),
                     heights = zeros(dims[1]),
                     kw...)
-    grid = Matrix{AbstractLayout}(undef, dims...)
+    grid = Matrix{Any}(undef, dims...)
     layout = GridLayout(
         parent,
         (20mm, 5mm, 2mm, 10mm),
         defaultbox,
         grid,
-        Measure[w*pct for w in widths],
-        Measure[h*pct for h in heights],
+        Any[w*pct for w in widths],
+        Any[h*pct for h in heights],
         # convert(Vector{Float64}, widths),
         # convert(Vector{Float64}, heights),
         KW(kw))
@@ -512,14 +512,14 @@ end
 
 # # just a single subplot
 # function build_layout(sp::Subplot, n::Integer)
-#     sp, Subplot[sp], SubplotMap(gensym() => sp)
+#     sp, Subplot[sp], KW(gensym() => sp)
 # end
 
 # n is the number of subplots... build a grid and initialize the inner subplots recursively
 function build_layout(layout::GridLayout, n::Integer)
     nr, nc = size(layout)
-    subplots = Subplot[]
-    spmap = SubplotMap()
+    subplots = Any[]
+    spmap = KW()
     i = 0
     for r=1:nr, c=1:nc
         l = layout[r,c]
@@ -560,8 +560,8 @@ end
 # TODO... much of the logic overlaps with the method above... can we merge?
 function build_layout(layout::GridLayout, numsp::Integer, plts::AVec{Plot})
     nr, nc = size(layout)
-    subplots = Subplot[]
-    spmap = SubplotMap()
+    subplots = Any[]
+    spmap = KW()
     i = 0
     for r=1:nr, c=1:nc
         l = layout[r,c]

--- a/src/output.jl
+++ b/src/output.jl
@@ -228,7 +228,7 @@ closeall() = closeall(backend())
 # ---------------------------------------------------------
 # Atom PlotPane
 # ---------------------------------------------------------
-function showjuno(io::IO, m, plt)
+@noinline function showjuno(io::IO, m, plt)
     sz = plt[:size]
     dpi = plt[:dpi]
     thickness_scaling = plt[:thickness_scaling]
@@ -250,7 +250,7 @@ function showjuno(io::IO, m, plt)
     end
 end
 
-function _showjuno(io::IO, m::MIME"image/svg+xml", plt)
+@noinline function _showjuno(io::IO, m::MIME"image/svg+xml", plt)
   if Symbol(plt.attr[:html_output_format]) ≠ :svg
     throw(MethodError(show, (typeof(m), typeof(plt))))
   else
@@ -258,4 +258,4 @@ function _showjuno(io::IO, m::MIME"image/svg+xml", plt)
   end
 end
 
-_showjuno(io::IO, m, plt) = _show(io, m, plt)
+@noinline _showjuno(io::IO, m, plt) = _show(io, m, plt)

--- a/src/output.jl
+++ b/src/output.jl
@@ -129,29 +129,29 @@ savefig(fn::AbstractString) = savefig(current(), fn)
 
 Display a plot using the backends' gui window
 """
-gui(plt::Plot = current()) = display(PlotsDisplay(), plt)
+@noinline gui(plt::Plot = current()) = display(PlotsDisplay(), plt)
 
 # IJulia only... inline display
-function inline(plt::Plot = current())
+@noinline function inline(plt::Plot = current())
     isijulia() || error("inline() is IJulia-only")
     Main.IJulia.clear_output(true)
     display(Main.IJulia.InlineDisplay(), plt)
 end
 
-function Base.display(::PlotsDisplay, plt::Plot)
+@noinline function Base.display(::PlotsDisplay, plt::Plot)
     prepare_output(plt)
-    #_display(plt)
+    _display(plt)
 end
 
-_do_plot_show(plt, showval::Bool) = showval && gui(plt)
-function _do_plot_show(plt, showval::Symbol)
+@noinline _do_plot_show(plt, showval::Bool) = showval && gui(plt)
+@noinline function _do_plot_show(plt, showval::Symbol)
     showval == :gui && gui(plt)
     showval in (:inline,:ijulia) && inline(plt)
 end
 
 # ---------------------------------------------------------
 
-const _best_html_output_type = KW(
+const _best_html_output_type = Dict{Symbol,Symbol}(
     :pyplot => :png,
     :unicodeplots => :txt,
     :plotlyjs => :html,
@@ -159,7 +159,7 @@ const _best_html_output_type = KW(
 )
 
 # a backup for html... passes to svg or png depending on the html_output_format arg
-function _show(io::IO, ::MIME"text/html", plt::Plot)
+@noinline function _show(io::IO, ::MIME"text/html", plt::Plot)
     output_type = Symbol(plt.attr[:html_output_format])
     if output_type == :auto
         output_type = get(_best_html_output_type, backend_name(plt.backend), :svg)
@@ -178,11 +178,11 @@ function _show(io::IO, ::MIME"text/html", plt::Plot)
 end
 
 # delegate showable to _show instead
-function Base.showable(m::M, plt::P) where {M<:MIME, P<:Plot}
+@noinline function Base.showable(m::M, plt::P) where {M<:MIME, P<:Plot}
     return hasmethod(_show, Tuple{IO, M, P})
 end
 
-function _display(plt::Plot)
+@noinline function _display(plt::Plot)
     @warn("_display is not defined for this backend.")
 end
 
@@ -202,7 +202,7 @@ for mime in ("text/plain", "text/html", "image/png", "image/eps", "image/svg+xml
 end
 
 # default text/plain for all backends
-_show(io::IO, ::MIME{Symbol("text/plain")}, plt::Plot) = show(io, plt)
+@noinline _show(io::IO, ::MIME{Symbol("text/plain")}, plt::Plot) = show(io, plt)
 
 "Close all open gui windows of the current backend"
 closeall() = closeall(backend())

--- a/src/output.jl
+++ b/src/output.jl
@@ -140,7 +140,7 @@ end
 
 function Base.display(::PlotsDisplay, plt::Plot)
     prepare_output(plt)
-    _display(plt)
+    #_display(plt)
 end
 
 _do_plot_show(plt, showval::Bool) = showval && gui(plt)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -203,7 +203,7 @@ end
 # ------------------------------------------------------------------
 # setup plot and subplot
 
-function _plot_setup(plt::Plot, plotattributes::KW, kw_list::Vector{KW})
+function _plot_setup(plt::Plot{T}, plotattributes::KW, kw_list::Vector{KW}) where {T}
     # merge in anything meant for the Plot
     for kw in kw_list, (k,v) in kw
         haskey(_plot_defaults, k) && (plotattributes[k] = pop!(kw, k))
@@ -252,18 +252,17 @@ function _plot_setup(plt::Plot, plotattributes::KW, kw_list::Vector{KW})
     plt[:inset_subplots] = nothing
 end
 
-function _subplot_setup(plt::Plot, plotattributes::KW, kw_list::Vector{KW})
+function _subplot_setup(plt::Plot{T}, plotattributes::KW, kw_list::Vector{KW}) where T
     # we'll keep a map of subplot to an attribute override dict.
     # Subplot/Axis attributes set by a user/series recipe apply only to the
     # Subplot object which they belong to.
     # TODO: allow matrices to still apply to all subplots
-    sp_attrs = Dict{Subplot,Any}()
+    sp_attrs = Dict{Subplot{T},Any}()
     for kw in kw_list
         # get the Subplot object to which the series belongs.
         sps = get(kw, :subplot, :auto)
-        sp = get_subplot(plt, _cycle(sps == :auto ? plt.subplots : plt.subplots[sps], command_idx(kw_list,kw)))
+        sp::Subplot{T} = get_subplot(plt, _cycle(sps == :auto ? plt.subplots : plt.subplots[sps], command_idx(kw_list,kw)))
         kw[:subplot] = sp
-
         # extract subplot/axis attributes from kw and add to sp_attr
         attr = KW()
         for (k,v) in collect(kw)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -23,7 +23,7 @@ end
     end
 end
 
-function _preprocess_args(plotattributes::KW, args, still_to_process::Vector{RecipeData})
+@noinline function _preprocess_args(plotattributes::KW, args, still_to_process::Vector{RecipeData})
     # the grouping mechanism is a recipe on a GroupBy object
     # we simply add the GroupBy object to the front of the args list to allow
     # the recipe to be applied
@@ -57,7 +57,7 @@ end
 # user recipes
 
 
-function _process_userrecipes(plt::Plot, plotattributes::KW, args)
+@noinline function _process_userrecipes(plt::Plot, plotattributes::KW, args)
     still_to_process = RecipeData[]
     args = _preprocess_args(plotattributes, args, still_to_process)
 
@@ -90,7 +90,7 @@ function _process_userrecipes(plt::Plot, plotattributes::KW, args)
     kw_list
 end
 
-function _process_userrecipe(plt::Plot, kw_list::Vector{KW}, recipedata::RecipeData)
+@noinline function _process_userrecipe(plt::Plot, kw_list::Vector{KW}, recipedata::RecipeData)
     # when the arg tuple is empty, that means there's nothing left to recursively
     # process... finish up and add to the kw_list
     kw = recipedata.plotattributes
@@ -108,7 +108,7 @@ function _process_userrecipe(plt::Plot, kw_list::Vector{KW}, recipedata::RecipeD
     return
 end
 
-function _preprocess_userrecipe(kw::KW)
+@noinline function _preprocess_userrecipe(kw::KW)
     _add_markershape(kw)
 
     # if there was a grouping, filter the data here
@@ -302,7 +302,7 @@ end
 
 # getting ready to add the series... last update to subplot from anything
 # that might have been added during series recipes
-function _prepare_subplot(plt::Plot{T}, plotattributes::KW) where T
+@noinline function _prepare_subplot(plt::Plot{T}, plotattributes::KW) where T
     st::Symbol = plotattributes[:seriestype]
     sp::Subplot{T} = plotattributes[:subplot]
     sp_idx = get_subplot_index(plt, sp)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -3,11 +3,11 @@
 # ------------------------------------------------------------------
 # preprocessing
 
-function command_idx(kw_list::AVec{KW}, kw::KW)
+@noinline function command_idx(kw_list::AVec{KW}, kw::KW)
     Int(kw[:series_plotindex]) - Int(kw_list[1][:series_plotindex]) + 1
 end
 
-function _expand_seriestype_array(plotattributes::KW, args)
+@noinline function _expand_seriestype_array(plotattributes::KW, args)
     sts = get(plotattributes, :seriestype, :path)
     if typeof(sts) <: AbstractArray
         delete!(plotattributes, :seriestype)
@@ -132,7 +132,7 @@ function _preprocess_userrecipe(kw::KW)
     return
 end
 
-function _add_errorbar_kw(kw_list::Vector{KW}, kw::KW)
+@noinline function _add_errorbar_kw(kw_list::Vector{KW}, kw::KW)
     # handle error bars by creating new recipedata data... these will have
     # the same recipedata index as the recipedata they are copied from
     for esym in (:xerror, :yerror)
@@ -147,7 +147,7 @@ function _add_errorbar_kw(kw_list::Vector{KW}, kw::KW)
     end
 end
 
-function _add_smooth_kw(kw_list::Vector{KW}, kw::KW)
+@noinline function _add_smooth_kw(kw_list::Vector{KW}, kw::KW)
     # handle smoothing by adding a new series
     if get(kw, :smooth, false)
         x, y = kw[:x], kw[:y]
@@ -257,11 +257,11 @@ function _subplot_setup(plt::Plot{T}, plotattributes::KW, kw_list::Vector{KW}) w
     # Subplot/Axis attributes set by a user/series recipe apply only to the
     # Subplot object which they belong to.
     # TODO: allow matrices to still apply to all subplots
-    sp_attrs = Dict{Subplot{T},Any}()
+    sp_attrs = Dict{Any,Any}()
     for kw in kw_list
         # get the Subplot object to which the series belongs.
         sps = get(kw, :subplot, :auto)
-        sp::Subplot{T} = get_subplot(plt, _cycle(sps == :auto ? plt.subplots : plt.subplots[sps], command_idx(kw_list,kw)))
+        sp = get_subplot(plt, _cycle(sps == :auto ? plt.subplots : plt.subplots[sps], command_idx(kw_list,kw)))
         kw[:subplot] = sp
         # extract subplot/axis attributes from kw and add to sp_attr
         attr = KW()
@@ -326,7 +326,7 @@ end
 # ------------------------------------------------------------------
 # series types
 
-function _override_seriestype_check(plotattributes::KW, st::Symbol)
+@noinline function _override_seriestype_check(plotattributes::KW, st::Symbol)
     # do we want to override the series type?
     if !is3d(st) && !(st in (:contour,:contour3d))
         z = plotattributes[:z]
@@ -338,7 +338,7 @@ function _override_seriestype_check(plotattributes::KW, st::Symbol)
     st
 end
 
-function _prepare_annotations(sp::Subplot, plotattributes::KW)
+@noinline function _prepare_annotations(sp::Subplot, plotattributes::KW)
     # strip out series annotations (those which are based on series x/y coords)
     # and add them to the subplot attr
     sp_anns = annotations(sp[:annotations])
@@ -371,7 +371,7 @@ function _expand_subplot_extrema(sp::Subplot, plotattributes::KW, st::Symbol)
     end
 end
 
-function _add_the_series(plt, sp, plotattributes)
+@noinline function _add_the_series(plt, sp, plotattributes)
     warnOnUnsupported_args(plt.backend, plotattributes)
     warnOnUnsupported(plt.backend, plotattributes)
     series = Series(plotattributes)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -16,7 +16,7 @@ Returns the Plot object for the current plot
     end
     CURRENT_PLOT.nullableplot
 end
-current(plot::AbstractPlot) = (CURRENT_PLOT.nullableplot = plot)
+@noinline current(plot::AbstractPlot) = (CURRENT_PLOT.nullableplot = plot)
 
 # ---------------------------------------------------------
 
@@ -175,6 +175,7 @@ function _plot!(plt::Plot{T}, plotattributes::KW, args::Vector{Any}) where {T}
     # "USER RECIPES"
     # --------------------------------
 
+    # 1 second
     kw_list = _process_userrecipes(plt, plotattributes, args)
 
     # @info(1)
@@ -189,6 +190,7 @@ function _plot!(plt::Plot{T}, plotattributes::KW, args::Vector{Any}) where {T}
     # the plot layout is created, which allows for setting layouts and other plot-wide attributes.
     # we get inputs which have been fully processed by "user recipes" and "type recipes",
     # so we can expect standard vectors, surfaces, etc.  No defaults have been set yet.
+
     still_to_process = kw_list
     kw_list = KW[]
     while !isempty(still_to_process)
@@ -203,11 +205,12 @@ function _plot!(plt::Plot{T}, plotattributes::KW, args::Vector{Any}) where {T}
     # Plot/Subplot/Layout setup
     # --------------------------------
 
+    # 2.5 seconds
     _plot_setup(plt, plotattributes, kw_list)
 
     # 6 seconds
     _subplot_setup(plt, plotattributes, kw_list)
-    #=
+
     # !!! note: At this point, kw_list is fully decomposed into individual series... one KW per series.          !!!
     # !!!       The next step is to recursively apply series recipes until the backend supports that series type !!!
 
@@ -238,6 +241,7 @@ function _plot!(plt::Plot{T}, plotattributes::KW, args::Vector{Any}) where {T}
     end
     # --------------------------------
 
+    # 7 seconds
     current(plt)
 
     # do we want to force display?
@@ -246,13 +250,13 @@ function _plot!(plt::Plot{T}, plotattributes::KW, args::Vector{Any}) where {T}
     # end
     _do_plot_show(plt, plt[:show])
     plt
-    =#
 end
 
 
 # we're getting ready to display/output.  prep for layout calcs, then update
 # the plot object after
-function prepare_output(plt::Plot)
+@noinline function prepare_output(plt::Plot)
+
     _before_layout_calcs(plt)
 
     w, h = plt.attr[:size]
@@ -273,9 +277,10 @@ function prepare_output(plt::Plot)
 
     # the backend callback, to reposition subplots, etc
     _update_plot_object(plt)
+
 end
 
-function backend_object(plt::Plot)
+@noinline function backend_object(plt::Plot)
     prepare_output(plt)
     plt.o
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -50,7 +50,6 @@ function plot(args...; kw...)
     # this creates a new plot with args/kw and sets it to be the current plot
     plotattributes = KW(kw)
     preprocessArgs!(plotattributes)
-
     # create an empty Plot then process
     plt = Plot()
     # plt.user_attr = plotattributes
@@ -163,7 +162,7 @@ end
 # this is the core plotting function.  recursively apply recipes to build
 # a list of series KW dicts.
 # note: at entry, we only have those preprocessed args which were passed in... no default values yet
-function _plot!(plt::Plot, plotattributes::KW, args::Tuple)
+function _plot!(plt::Plot{T}, plotattributes::KW, args::Tuple) where {T}
     plotattributes[:plot_object] = plt
 
     if !isempty(args) && !isdefined(Main, :StatsPlots) &&
@@ -202,7 +201,10 @@ function _plot!(plt::Plot, plotattributes::KW, args::Tuple)
     # --------------------------------
     # Plot/Subplot/Layout setup
     # --------------------------------
+
     _plot_setup(plt, plotattributes, kw_list)
+
+    # 6 seconds
     _subplot_setup(plt, plotattributes, kw_list)
 
     # !!! note: At this point, kw_list is fully decomposed into individual series... one KW per series.          !!!
@@ -216,7 +218,7 @@ function _plot!(plt::Plot, plotattributes::KW, args::Tuple)
     # map(DD, kw_list)
 
     for kw in kw_list
-        sp::Subplot = kw[:subplot]
+        sp::Subplot{T} = kw[:subplot]
         # idx = get_subplot_index(plt, sp)
 
         # # we update subplot args in case something like the color palatte is part of the recipe
@@ -233,7 +235,6 @@ function _plot!(plt::Plot, plotattributes::KW, args::Tuple)
         # be able to support step, bar, and histogram plots (and any recipes that use those components).
         _process_seriesrecipe(plt, kw)
     end
-
     # --------------------------------
 
     current(plt)
@@ -243,7 +244,6 @@ function _plot!(plt::Plot, plotattributes::KW, args::Tuple)
     #     gui(plt)
     # end
     _do_plot_show(plt, plt[:show])
-
     plt
 end
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -4,13 +4,13 @@ mutable struct CurrentPlot
 end
 const CURRENT_PLOT = CurrentPlot(nothing)
 
-isplotnull() = CURRENT_PLOT.nullableplot === nothing
+@noinline isplotnull() = CURRENT_PLOT.nullableplot === nothing
 
 """
     current()
 Returns the Plot object for the current plot
 """
-function current()
+@noinline function current()
     if isplotnull()
         error("No current plot/subplot")
     end
@@ -25,9 +25,9 @@ Base.string(plt::Plot) = "Plot{$(plt.backend) n=$(plt.n)}"
 Base.print(io::IO, plt::Plot) = print(io, string(plt))
 Base.show(io::IO, plt::Plot) = print(io, string(plt))
 
-getplot(plt::Plot) = plt
-getattr(plt::Plot, idx::Int = 1) = plt.attr
-convertSeriesIndex(plt::Plot, n::Int) = n
+@noinline getplot(plt::Plot) = plt
+@noinline getattr(plt::Plot, idx::Int = 1) = plt.attr
+@noinline convertSeriesIndex(plt::Plot, n::Int) = n
 
 # ---------------------------------------------------------
 
@@ -207,7 +207,7 @@ function _plot!(plt::Plot{T}, plotattributes::KW, args::Vector{Any}) where {T}
 
     # 6 seconds
     _subplot_setup(plt, plotattributes, kw_list)
-
+    #=
     # !!! note: At this point, kw_list is fully decomposed into individual series... one KW per series.          !!!
     # !!!       The next step is to recursively apply series recipes until the backend supports that series type !!!
 
@@ -246,6 +246,7 @@ function _plot!(plt::Plot{T}, plotattributes::KW, args::Vector{Any}) where {T}
     # end
     _do_plot_show(plt, plt[:show])
     plt
+    =#
 end
 
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -53,7 +53,7 @@ function plot(args...; kw...)
     # create an empty Plot then process
     plt = Plot()
     # plt.user_attr = plotattributes
-    _plot!(plt, plotattributes, args)
+    _plot!(plt, plotattributes, Any[args...])
 end
 
 # build a new plot from existing plots
@@ -154,7 +154,7 @@ function plot!(plt::Plot, args...; kw...)
     plotattributes = KW(kw)
     preprocessArgs!(plotattributes)
     # merge!(plt.user_attr, plotattributes)
-    _plot!(plt, plotattributes, args)
+    _plot!(plt, plotattributes, Any[args...])
 end
 
 # -------------------------------------------------------------------------------
@@ -162,8 +162,9 @@ end
 # this is the core plotting function.  recursively apply recipes to build
 # a list of series KW dicts.
 # note: at entry, we only have those preprocessed args which were passed in... no default values yet
-function _plot!(plt::Plot{T}, plotattributes::KW, args::Tuple) where {T}
+function _plot!(plt::Plot{T}, plotattributes::KW, args::Vector{Any}) where {T}
     plotattributes[:plot_object] = plt
+
 
     if !isempty(args) && !isdefined(Main, :StatsPlots) &&
             first(split(string(typeof(args[1])), ".")) == "DataFrames"

--- a/src/series.jl
+++ b/src/series.jl
@@ -143,7 +143,7 @@ struct SliceIt end
             rib = ribbons[mod1(i,mr)]
             di[:ribbon] = isa(rib, Function) ? map(rib, di[:x]) : rib
 
-            push!(series_list, RecipeData(di, ()))
+            push!(series_list, RecipeData(di, Any[]))
         end
     end
     nothing  # don't add a series for the main block

--- a/src/types.jl
+++ b/src/types.jl
@@ -30,10 +30,11 @@ attr!(series::Series, v, k::Symbol) = (series.plotattributes[k] = v)
 # -----------------------------------------------------------
 
 # a single subplot
+const StandardPad = Measures.Length{:mm,Float64}
 mutable struct Subplot{T<:AbstractBackend} <: AbstractLayout
     parent::AbstractLayout
     series_list::Vector{Series}  # arguments for each series
-    minpad::Tuple # leftpad, toppad, rightpad, bottompad
+    minpad::Tuple{StandardPad,StandardPad,StandardPad,StandardPad} # leftpad, toppad, rightpad, bottompad
     bbox::BoundingBox  # the canvas area which is available to this subplot
     plotarea::BoundingBox  # the part where the data goes
     attr::KW  # args specific to this subplot

--- a/src/types.jl
+++ b/src/types.jl
@@ -30,13 +30,12 @@ attr!(series::Series, v, k::Symbol) = (series.plotattributes[k] = v)
 # -----------------------------------------------------------
 
 # a single subplot
-const StandardPad = Measures.Length{:mm,Float64}
 mutable struct Subplot{T<:AbstractBackend} <: AbstractLayout
-    parent::AbstractLayout
+    parent
     series_list::Vector{Series}  # arguments for each series
-    minpad::Tuple{StandardPad,StandardPad,StandardPad,StandardPad} # leftpad, toppad, rightpad, bottompad
-    bbox::BoundingBox  # the canvas area which is available to this subplot
-    plotarea::BoundingBox  # the part where the data goes
+    minpad::Tuple{AbsoluteLength,AbsoluteLength,AbsoluteLength,AbsoluteLength} # leftpad, toppad, rightpad, bottompad
+    bbox#::BoundingBox  # the canvas area which is available to this subplot
+    plotarea#::BoundingBox  # the part where the data goes
     attr::KW  # args specific to this subplot
     o  # can store backend-specific data... like a pyplot ax
     plt  # the enclosing Plot object (can't give it a type because of no forward declarations)
@@ -60,10 +59,6 @@ Extrema() = Extrema(Inf, -Inf)
 
 # -----------------------------------------------------------
 
-const SubplotMap = Dict{Any, Subplot}
-
-# -----------------------------------------------------------
-
 
 mutable struct Plot{T<:AbstractBackend} <: AbstractPlot{T}
     backend::T                   # the backend type
@@ -73,15 +68,15 @@ mutable struct Plot{T<:AbstractBackend} <: AbstractPlot{T}
     series_list::Vector{Series}  # arguments for each series
     o                            # the backend's plot object
     subplots::Vector{Subplot{T}}
-    spmap::SubplotMap            # provide any label as a map to a subplot
-    layout::AbstractLayout
+    spmap::KW            # provide any label as a map to a subplot
+    layout
     inset_subplots::Vector{Subplot{T}}  # list of inset subplots
     init::Bool
 end
 
 function Plot(_backend = CURRENT_BACKEND)
     Plot(_backend.pkg, 0, KW(), KW(), Series[], nothing,
-         Subplot{typeof(_backend.pkg)}[], SubplotMap(), EmptyLayout(),
+         Subplot{typeof(_backend.pkg)}[], KW(), EmptyLayout(),
          Subplot{typeof(_backend.pkg)}[], false)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -71,17 +71,17 @@ mutable struct Plot{T<:AbstractBackend} <: AbstractPlot{T}
     user_attr::KW                # raw arg inputs (after aliases).  these are used as the input dict in `_plot!`
     series_list::Vector{Series}  # arguments for each series
     o                            # the backend's plot object
-    subplots::Vector{Subplot}
+    subplots::Vector{Subplot{T}}
     spmap::SubplotMap            # provide any label as a map to a subplot
     layout::AbstractLayout
-    inset_subplots::Vector{Subplot}  # list of inset subplots
+    inset_subplots::Vector{Subplot{T}}  # list of inset subplots
     init::Bool
 end
 
-function Plot()
-    Plot(backend(), 0, KW(), KW(), Series[], nothing,
-         Subplot[], SubplotMap(), EmptyLayout(),
-         Subplot[], false)
+function Plot(_backend = CURRENT_BACKEND)
+    Plot(_backend.pkg, 0, KW(), KW(), Series[], nothing,
+         Subplot{typeof(_backend.pkg)}[], SubplotMap(), EmptyLayout(),
+         Subplot{typeof(_backend.pkg)}[], false)
 end
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
After seeing a bunch of nonsense like [this thread](https://discourse.julialang.org/t/roadmap-for-a-faster-time-to-first-plot/22956/142), I decided it was a good idea to document why "first time to plot" is a thing. tl;dr, it's because the original author was not careful with types, nothing more nothing less. 

(I have to do this on my desktop to not segfault, but @vtjnash saw it. Will post the profile when I am back from travelling.)

First of all, there is no code loading going on in like a year. GR is baked into the system since that PR was done, so let's stop assuming that code loading nonsense is still the issue since we ruled that out a long time ago... and it doesn't even exist anymore. Get it out of your head. Now let's continue with a clear mind.

If you look at the profile using `ProfileView.view(C=true)`, we can distinguish between Julia type inference time and LLVM compile time. That gigantic bump is Julia type inference time, while the sliver between the bumps is LLVM time. Conclusion: it's our fault in type inference and there's no one else to blame. This is actually quite peculiar since most of the time you see LLVM taking a lot of the time, but that's not the case specifically for Plots.jl.

And the reason is because Plots.jl's choices with types are a mess. To start, almost everything is stored in a `KW = Dict{Symbol.Any}`. All of the args are handled in this structure, but this item does not show up in the Julia sysimage, so all operations with it require being compiled. Changing this to `KW = Dict{Any,Any}` is actually a little helpful (Requires the similar first time to plot RecipesBase branch). Basically, we want type inference to give up quickly and just go to `Any`. However, this library throws `KW` into small structs, and then has some abstract types over fields. To make it give up, we can just kick to `Any` again. Etc. 

Usually that can be helpful, but here we kick to Any too much and then we start getting type inference nightmares. We know from around the ecosystem that function-barriers cause a lot of compile time increases:

https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/841
https://github.com/JuliaDiffEq/StochasticDiffEq.jl/pull/207

and this is precisely where we start running into a wall. With every function call, we hit a barrier and so this overhead cost of knowing that it's a dynamic dispatch function barrier will be hit (to be honest, I'm not sure why this extra cost exists, @vtjnash?). But similarly, putting everything into one super long function will cause superlinear compile time growth, so we need to split functions.

So as a proof of concept for this idea, I split out the series types and legends handling branches in the `gr.jl` file. If you comment those portions out you see a massive compile time decrease. If you split them out to functions, you don't get that same decrease because you're now hitting the secondary inference compile time issue.

So given how these two play against each other, the only real way to solve this is to make Plots not drop so many types. That a giant feat because everything is stored in bad dictionaries, so someone would have to

1) Set the argument types underlying the attributes.
2) Converting to a standard form the moment the arguments are seen like that.
3) Pushing this type information down.

Currently this is very difficult, the biggest offender being Measures.jl. Measures just has so much type information on every value, like Units, that it's very difficult to keep the types aligned with them. It's just way too much type information, so it should just be made a struct with a value and symbol, using the symbol to branch behavior, instead of holding each new value with a possibly new type. 

When you dig into the pipeline, you see that 7 seconds of compilation is on the type handling of the plot.jl `_plot!` function, and then 13 is in the gr_display function (at least with GR). Essentially all of that time could be cut if the types were more inferred, given that the entire issue is that inference is just going insane. Oh, and this splitting shows why it's so hard to fix this issue: 7 seconds comes from mostly 3 function calls, while the other 13 comes from a few different branches, but that's still quite a few hotspots to hit, so just trying to "be type inference" and declare types would still be a long process (and you still lose inference every time you dig into one of these types without information...)

In conclusion, don't use Measures.jl and a bunch of non-inferred partially abstractly typed dictionaries and then wonder why it takes forever to compile. I can tell you why: type inference gone amok. The profiles show it, and it's hard to get around since the original tools like function barriers end up contributing to the problem. This PR shows that you can get very minor gains by avoiding that issue, but you actually need to address it if you want to go anywhere. It really has nothing to do with "tradeoffs" or whatever nonsense, it's just about writing code that's easy on inference. We could fix this in Plots, Makie, GR, etc., does matter which. This makes it clear it's not the method but it's the implementation.