### PR TITLE
Specify legend title font in GR and PyPlot

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -50,7 +50,7 @@ const _arg_desc = KW(
 :primary                => "Bool.  Does this count as a 'real series'?  For example, you could have a path (primary), and a scatter (secondary) as 2 separate series, maybe with different data (see sticks recipe for an example).  The secondary series will get the same color, etc as the primary.",
 :hover 	        	=> "nothing or vector of strings. Text to display when hovering over each data point.",
 :colorbar_entry   => "Bool.  Include this series in the color bar?  Set to `false` to exclude.",
-  
+
 # plot args
 :plot_title               => "String. Title for the whole plot (not the subplots) (Note: Not currently implemented)",
 :background_color         => "Color Type.  Base color for all backgrounds.",
@@ -95,9 +95,16 @@ const _arg_desc = KW(
 :legendfontvalign         => "Symbol. Font vertical alignment of legend entries: :vcenter, :top, :bottom or :center",
 :legendfontrotation       => "Real. Font rotation of legend entries",
 :legendfontcolor          => "Color Type. Font color of legend entries",
+:legendtitlefontfamily    => "String or Symbol. Font family of the legend title.",
+:legendtitlefontsize           => "Integer. Font pointsize the legend title.",
+:legendtitlefonthalign         => "Symbol. Font horizontal alignment of the legend title: :hcenter, :left, :right or :center",
+:legendtitlefontvalign         => "Symbol. Font vertical alignment of the legend title: :vcenter, :top, :bottom or :center",
+:legendtitlefontrotation       => "Real. Font rotation of the legend title",
+:legendtitlefontcolor          => "Color Type. Font color of the legend title",
 :colorbar                 => "Bool (show the colorbar?) or Symbol (colorbar position).  Symbol values: `:none`, `:best`, `:right`, `:left`, `:top`, `:bottom`, `:legend` (matches legend value) (note: only some may be supported in each backend)",
 :clims 					  => "`:auto` or NTuple{2,Number}.  Fixes the limits of the colorbar.",
 :legendfont               => "Font. Font of legend items.",
+:legendtitlefont          => "Font. Font of the legend title.",
 :annotations              => "(x,y,text) tuple(s).  Can be a single tuple or a list of them.  Text can be String or PlotText (created with `text(args...)`)  Add one-off text annotations at the x,y coordinates.",
 :projection               => "Symbol or String.  '3d' or 'polar'",
 :aspect_ratio             => "Symbol (:equal) or Number. Plot area is resized so that 1 y-unit is the same size as `aspect_ratio` x-units.",

--- a/src/args.jl
+++ b/src/args.jl
@@ -336,6 +336,12 @@ const _subplot_defaults = KW(
     :legendfontvalign         => :vcenter,
     :legendfontrotation       => 0.0,
     :legendfontcolor          => :match,
+    :legendtitlefontfamily    => :match,
+    :legendtitlefontsize      => 11,
+    :legendtitlefonthalign    => :hcenter,
+    :legendtitlefontvalign    => :vcenter,
+    :legendtitlefontrotation  => 0.0,
+    :legendtitlefontcolor     => :match,
     :annotations              => [],                # annotation tuples... list of (x,y,annotation)
     :projection               => :none,             # can also be :polar or :3d
     :aspect_ratio             => :none,             # choose from :none or :equal
@@ -450,6 +456,7 @@ const _initial_axis_defaults = deepcopy(_axis_defaults)
 # to be able to reset font sizes to initial values
 const _initial_fontsizes = Dict(:titlefontsize  => _subplot_defaults[:titlefontsize],
                                 :legendfontsize => _subplot_defaults[:legendfontsize],
+                                :legendtitlefontsize => _subplot_defaults[:legendtitlefontsize],
                                 :tickfontsize   => _axis_defaults[:tickfontsize],
                                 :guidefontsize  => _axis_defaults[:guidefontsize])
 
@@ -961,7 +968,7 @@ function preprocessArgs!(plotattributes::KW)
         end
     end
     # fonts
-    for fontname in (:titlefont, :legendfont)
+    for fontname in (:titlefont, :legendfont, :legendtitlefont)
         args = pop!(plotattributes, fontname, ())
         for arg in wraptuple(args)
             processFontArg!(plotattributes, fontname, arg)
@@ -1271,8 +1278,10 @@ const _match_map = KW(
     :bottom_margin => :margin,
     :titlefontfamily          => :fontfamily_subplot,
     :legendfontfamily         => :fontfamily_subplot,
+    :legendtitlefontfamily    => :fontfamily_subplot,
     :titlefontcolor           => :foreground_color_subplot,
     :legendfontcolor          => :foreground_color_subplot,
+    :legendtitlefontcolor     => :foreground_color_subplot,
     :tickfontcolor            => :foreground_color_text,
     :guidefontcolor           => :foreground_color_guide,
 )

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -879,12 +879,13 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         GR.savestate()
         GR.selntran(0)
         GR.setscale(0)
-        gr_set_font(legendfont(sp))
         if sp[:legendtitle] !== nothing
+            gr_set_font(legendtitlefont(sp))
             tbx, tby = gr_inqtext(0, 0, string(sp[:legendtitle]))
             legendw = tbx[3] - tbx[1]
             legendn += 1
         end
+        gr_set_font(legendfont(sp))
         for series in series_list(sp)
             should_add_to_legend(series) || continue
             legendn += 1
@@ -1498,10 +1499,10 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
             i = 0
             if sp[:legendtitle] !== nothing
                 GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_HALF)
-                gr_set_textcolor(sp[:legendfontcolor])
-                gr_set_transparency(sp[:legendfontcolor])
+                gr_set_font(legendtitlefont(sp))
                 gr_text(xpos - 0.03 + 0.5*w, ypos, string(sp[:legendtitle]))
                 ypos -= dy
+                gr_set_font(legendfont(sp))
             end
             for series in series_list(sp)
                 should_add_to_legend(series) || continue

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1335,10 +1335,13 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
             frame = leg."get_frame"()
             frame."set_linewidth"(py_thickness_scale(plt, 1))
             leg."set_zorder"(1000)
-            sp[:legendtitle] !== nothing && leg."set_title"(sp[:legendtitle])
+            if sp[:legendtitle] !== nothing
+                leg."set_title"(sp[:legendtitle])
+                PyPlot.plt."setp"(leg."get_title"(), color = py_color(sp[:legendtitlefontcolor]), family = sp[:legendtitlefontfamily], fontsize = py_thickness_scale(plt, sp[:legendtitlefontsize]))
+            end
 
             for txt in leg."get_texts"()
-                PyPlot.plt."setp"(txt, color = py_color(sp[:legendfontcolor]), family = sp[:legendfontfamily])
+                PyPlot.plt."setp"(txt, color = py_color(sp[:legendfontcolor]), family = sp[:legendfontfamily], fontsize = py_thickness_scale(plt, sp[:legendfontsize]))
             end
         end
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1060,6 +1060,15 @@ legendfont(sp::Subplot) = font(
     sp[:legendfontcolor],
 )
 
+legendtitlefont(sp::Subplot) = font(
+    sp[:legendtitlefontfamily],
+    sp[:legendtitlefontsize],
+    sp[:legendtitlefontvalign],
+    sp[:legendtitlefonthalign],
+    sp[:legendtitlefontrotation],
+    sp[:legendtitlefontcolor],
+)
+
 tickfont(ax::Axis) = font(
     ax[:tickfontfamily],
     ax[:tickfontsize],


### PR DESCRIPTION
Introduces the new attributes
- `legendtitlefontfamily`
- `legendtitlefontsize`
- `legendtitlefontcolor`
- `legendtitlefonthalign`
- `legendtitlefontvalign`
- `legendtitlefontrotation` and
- `legendtitlefont`
and closes #2151. 

GR:
```julia
plot(rand(10, 4), legendtitle = "Hello", legendtitlefontcolor = :red)
```
![legendtitlefontgr](https://user-images.githubusercontent.com/16589944/63689569-9a920600-c80a-11e9-9f3b-a7e04c7afdf8.png)

PyPlot:
```julia
plot(rand(10, 4), legendtitle = "Hello", legendtitlefont = (14, :green, "serif"))
```
![legendtitlefontpyplot](https://user-images.githubusercontent.com/16589944/63689606-b39ab700-c80a-11e9-844a-f5e6ff37017e.png)
