### PR TITLE
swap x/y formatters for vline

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -937,6 +937,15 @@ function preprocessArgs!(plotattributes::KW)
         end
     end
 
+    # vline accesses the y argument but actually maps it to the x axis.
+    # Hence, we have to swap formatters
+    if get(plotattributes, :seriestype, :path) == :vline
+        xformatter = get(plotattributes, :xformatter, :auto)
+        yformatter = get(plotattributes, :yformatter, :auto)
+        plotattributes[:xformatter] = yformatter
+        plotattributes[:yformatter] = xformatter
+    end
+
     # handle grid args common to all axes
     args = pop!(plotattributes, :grid, ())
     for arg in wraptuple(args)


### PR DESCRIPTION
`vline` uses y input and applies it to the x axis. This messes up the axis formatter for type recipes (cf #1762). This is a somewhat hacky workaround, but I think a special case for vline can be justified.
```julia
using Plots, Dates
plot(DateTime(2018):Day(1):DateTime(2019), cumsum(randn(366)))
vline!([DateTime(2018, 6)])
```
![vline1](https://user-images.githubusercontent.com/16589944/64082854-211c7b00-cd16-11e9-82b0-35884359ad7f.png)

User-defined formatters still match the correct axis:
```julia
plot(rand(10))
vline!([4], yformatter = :scientific)
```
![vline2](https://user-images.githubusercontent.com/16589944/64082913-df400480-cd16-11e9-9e64-2b26558630df.png)

Closes #1762 and closes #1914.
