### PR TITLE
allow to broadcast over linestyle attribute only

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -653,7 +653,7 @@ function has_attribute_segments(series::Series)
     end
     series[:seriestype] == :shape && return false
     # ... else we check relevant attributes if they have multiple inputs
-    return any((typeof(series[attr]) <: AbstractVector && length(series[attr]) > 1) for attr in [:seriescolor, :seriesalpha, :linecolor, :linealpha, :linewidth, :fillcolor, :fillalpha, :markercolor, :markeralpha, :markerstrokecolor, :markerstrokealpha]) || any(typeof(series[attr]) <: AbstractArray for attr in (:line_z, :fill_z, :marker_z))
+    return any((typeof(series[attr]) <: AbstractVector && length(series[attr]) > 1) for attr in [:seriescolor, :seriesalpha, :linecolor, :linealpha, :linewidth, :linestyle, :fillcolor, :fillalpha, :markercolor, :markeralpha, :markerstrokecolor, :markerstrokealpha]) || any(typeof(series[attr]) <: AbstractArray for attr in (:line_z, :fill_z, :marker_z))
 end
 
 # ---------------------------------------------------------------


### PR DESCRIPTION
See https://github.com/JuliaPlots/Plots.jl/pull/1467#issuecomment-529790294 and https://discourse.julialang.org/t/plots-jl-attributes-can-be-broadcasted-changing-linestyle-for-example/19559

```julia
using Plots
plot(rand(9), linestyle = repeat([:solid, :dot], inner = 4))
```
![linestyle](https://user-images.githubusercontent.com/16589944/64593233-04cfac80-d3ae-11e9-98cf-0ff3aa9efc66.png)
