### PR TITLE
RFC: Print vectors passed to label as vectors in GR

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -874,7 +874,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     # has to be done now due to a potential adjustment to the plotarea given an outer legend.
     legendn = 0
     legendw = 0
-    legendi = 0
     if sp[:legend] != :none
         GR.savestate()
         GR.selntran(0)
@@ -889,12 +888,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         for series in series_list(sp)
             should_add_to_legend(series) || continue
             legendn += 1
-            if typeof(series[:label]) <: Array
-                legendi += 1
-                lab = series[:label][legendi]
-            else
-                lab = series[:label]
-            end
+            lab = series[:label]
             tbx, tby = gr_inqtext(0, 0, string(lab))
             legendw = max(legendw, tbx[3] - tbx[1])
         end
@@ -1485,7 +1479,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         GR.setscale(0)
         gr_set_font(legendfont(sp))
         w = legendw
-        i = legendi
         n = legendn
         if w > 0
             dy = _gr_point_mult[1] * sp[:legendfontsize] * 1.75
@@ -1538,12 +1531,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     gr_draw_markers(series, xpos - .035, ypos, clims, 6)
                 end
 
-                if typeof(series[:label]) <: Array
-                    i += 1
-                    lab = series[:label][i]
-                else
-                    lab = series[:label]
-                end
+                lab = series[:label]
                 GR.settextalign(GR.TEXT_HALIGN_LEFT, GR.TEXT_VALIGN_HALF)
                 gr_set_textcolor(sp[:legendfontcolor])
                 gr_text(xpos, ypos, string(lab))


### PR DESCRIPTION
Fixes #2179 and partially (for GR) #2182 
```julia
using Plots
plot(rand(10,5),label=[1,2,3,4,5])
```
![label_gr](https://user-images.githubusercontent.com/16589944/64682034-0a49f700-d481-11e9-9867-fa67b346dd42.png)

```julia
plot([1,2],[1.5,2.5], labels = [:o])
scatter!([1,2],[1,2], labels = [:s])
```
used to fail with gr and now gives
![label_gr2](https://user-images.githubusercontent.com/16589944/64682150-454c2a80-d481-11e9-8b06-d48e54248d9c.png)

I'm actually not really sure what the use cases for passing vectors as labels could be. The legends in the plots above don't look that nice. But I think we should strive consistency among different backends and stick to http://docs.juliaplots.org/latest/input_data/#columns-are-series.

Any opinions?

Related issues:
#901
#996
#1367
#1550
#2179
#2182 