### PR TITLE
make Juno plots devicePixelRatio aware

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -234,10 +234,11 @@ function showjuno(io::IO, m, plt)
     thickness_scaling = plt[:thickness_scaling]
 
     jsize = get(io, :juno_plotsize, [400, 500])
+    jdpi = get(io, :juno_dpi_ratio, 1)*Plots.DPI
 
     scale = minimum(jsize[i] / sz[i] for i in 1:2)
     plt[:size] = (s * scale for s in sz)
-    plt[:dpi] = Plots.DPI
+    plt[:dpi] = jdpi
     plt[:thickness_scaling] *= scale
 
     prepare_output(plt)


### PR DESCRIPTION
Together with https://github.com/JunoLab/Atom.jl/pull/179 and https://github.com/JunoLab/atom-julia-client/pull/609 this should make sure plots in Juno are DPI-aware.

I didn't actually test this yet, but it should work :P