### PR TITLE
add tikz ending

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -72,6 +72,7 @@ const _savemap = Dict(
     "eps" => eps,
     "tex" => tex,
     "html" => html,
+    "tikz" => tex,
   )
 
 function getExtension(fn::AbstractString)


### PR DESCRIPTION
Enables saving the tex-output with ".tikz"-ending.

Fixes https://github.com/JuliaPlots/Plots.jl/issues/1335.