### PR TITLE
Update adapted_grid recipes

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,7 @@ end
     for plt in plots
         display(plt)
     end
+    @test_nowarn plot(x->x^2,0,2)
 end
 
 @testset "EmptyAnim" begin


### PR DESCRIPTION
Take new return types of `adated_grid` into account. This will change in https://github.com/JuliaPlots/PlotUtils.jl/pull/68.
This should cutdown the number of function evaluations.