### PR TITLE
Add histogram2d with log10 bins - advice/help welcome

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -777,6 +777,24 @@ end
 @deps histogram2d bins2d
 
 
+@recipe function f(::Type{Val{:histogram2d_log10}}, x, y, z)
+    h = _make_hist((x, y), plotattributes[:bins], normed = plotattributes[:normalize], weights = plotattributes[:weights])
+    x := h.edges[1]
+    y := h.edges[2]
+
+    transform(x) = x == 0 ? NaN : log10(x)
+
+    z := Surface(transform.(h.weights))
+
+    # TODO: doc
+    legend := false
+    seriestype := :bins2d
+    ()
+end
+@shorthands histogram2d_log10
+@deps histogram2d_log bins2d
+
+
 @recipe function f(h::StatsBase.Histogram{T, 2, E}) where {T, E}
     seriestype --> :bins2d
     (h.edges[1], h.edges[2], Surface(h.weights))


### PR DESCRIPTION
This PR adds a `histogram2d` whose bins are not drawn in linear but in `log10` scale. It is still a draft since the additional code is probably not added at the right place. I need help from someone with a deeper understanding of Plots.jl in order to get this right, so I opened up this draft pull request. Any advice or hints are welcome 😄 

My main desire is to make these 2d histograms work with the `GR` backend. As of now, the color bar is still drawn in linear scale, which is quite confusing. I've done some digging in the code, and it appears to me that I'd need to change the `GR` backend's code at some places (e.g. [here](https://github.com/JuliaPlots/Plots.jl/blob/07ffa8c117345aa2e2e09138d6c6580a718799fd/src/backends/gr.jl#L955), or [here](https://github.com/JuliaPlots/Plots.jl/blob/07ffa8c117345aa2e2e09138d6c6580a718799fd/src/backends/gr.jl#L490-L502), ...) to get the color bar work with the `log10` scale. But I don't know how to do that yet and need some advice from an expert.

To summarize, these are the points that I'd like to get right:

1. The legend, especially the color bar should also be drawn in log10 scale.
1. It would probably be much nicer to activate the log10 output by adding a keyword argument like `scale = :log10` to the `histogram2d` shorthand rather than being forced to call my `histogram2d_log10` shorthand. However, I'm not sure if `scale` would be the right keyword argument.
1. It would be nice if the logarithmic 2d histogram worked for other backends than `GR` as well...

Could anyone with more experience with Plots.jl development give me some advice there?