### PR TITLE
Neglect clims of series with colorbar_entry=false

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -980,6 +980,14 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     GR.setlinewidth(sp.plt[:thickness_scaling])
 
     if is3d(sp)
+        # TODO do we really need a different clims computation here from the one
+        #      computed above using get_clims(sp)?
+        zmin, zmax = gr_lims(sp, zaxis, true)
+        clims3d = sp[:clims]
+        if is_2tuple(clims3d)
+            isfinite(clims3d[1]) && (zmin = clims3d[1])
+            isfinite(clims3d[2]) && (zmax = clims3d[2])
+        end
         GR.setspace(zmin, zmax, round.(Int, sp[:camera])...)
         xtick = GR.tick(xmin, xmax) / 2
         ytick = GR.tick(ymin, ymax) / 2

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -260,19 +260,6 @@ function gr_fill_viewport(vp::AVec{Float64}, c)
     GR.restorestate()
 end
 
-
-normalize_zvals(args...) = nothing
-function normalize_zvals(zv::AVec, clims::NTuple{2, <:Real})
-    vmin, vmax = ignorenan_extrema(zv)
-    isfinite(clims[1]) && (vmin = clims[1])
-    isfinite(clims[2]) && (vmax = clims[2])
-    if vmin == vmax
-        zeros(length(zv))
-    else
-        clamp.((zv .- vmin) ./ (vmax .- vmin), 0, 1)
-    end
-end
-
 # ---------------------------------------------------------
 
 # draw ONE Shape
@@ -920,8 +907,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     # reduced from before... set some flags based on the series in this subplot
     # TODO: can these be generic flags?
     outside_ticks = false
-    # calculate the colorbar limits once for a subplot
-    clims = get_clims(sp)
     cbar = GRColorbar()
 
     draw_axes = sp[:framestyle] != :none
@@ -995,14 +980,6 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     GR.setlinewidth(sp.plt[:thickness_scaling])
 
     if is3d(sp)
-        # TODO do we really need a different clims computation here from the one
-        #      computed above using get_clims(sp)?
-        zmin, zmax = gr_lims(sp, zaxis, true)
-        clims3d = sp[:clims]
-        if is_2tuple(clims3d)
-            isfinite(clims3d[1]) && (zmin = clims3d[1])
-            isfinite(clims3d[2]) && (zmax = clims3d[2])
-        end
         GR.setspace(zmin, zmax, round.(Int, sp[:camera])...)
         xtick = GR.tick(xmin, xmax) / 2
         ytick = GR.tick(ymin, ymax) / 2
@@ -1233,6 +1210,8 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
         x, y, z = series[:x], series[:y], series[:z]
         frng = series[:fillrange]
+
+        clims = get_clims(sp, series)
 
         # add custom frame shapes to markershape?
         series_annotations_shapes!(series)
@@ -1470,7 +1449,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     end
 
     # draw the colorbar
-    hascolorbar(sp) && gr_draw_colorbar(cbar, sp, clims)
+    hascolorbar(sp) && gr_draw_colorbar(cbar, sp, get_clims(sp))
 
     # add the legend
     if sp[:legend] != :none
@@ -1498,6 +1477,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 gr_set_font(legendfont(sp))
             end
             for series in series_list(sp)
+                clims = get_clims(sp, series)
                 should_add_to_legend(series) || continue
                 st = series[:seriestype]
                 lc = get_linecolor(series, clims)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -454,7 +454,7 @@ function plotly_series(plt::Plot, series::Series)
     st = series[:seriestype]
 
     sp = series[:subplot]
-    clims = get_clims(sp)
+    clims = get_clims(sp, series)
 
     if st == :shape
         return plotly_series_shapes(plt, series, clims)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -399,7 +399,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
 
     # handle zcolor and get c/cmap
     needs_colorbar = hascolorbar(sp)
-    vmin, vmax = clims = get_clims(sp)
+    vmin, vmax = clims = get_clims(sp, series)
 
     # Dict to store extra kwargs
     if st == :wireframe
@@ -1290,13 +1290,13 @@ py_legend_bbox(pos) = pos
 
 function py_add_legend(plt::Plot, sp::Subplot, ax)
     leg = sp[:legend]
-    clims = get_clims(sp)
     if leg != :none
         # gotta do this to ensure both axes are included
         labels = []
         handles = []
         for series in series_list(sp)
             if should_add_to_legend(series)
+                clims = get_clims(sp, series)
                 # add a line/marker and a label
                 push!(handles, if series[:seriestype] == :shape || series[:fillrange] !== nothing
                     pypatches."Patch"(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -525,11 +525,13 @@ function get_clims(sp::Subplot)
     zmin, zmax = Inf, -Inf
     z_colored_series = (:contour, :contour3d, :heatmap, :histogram2d, :surface)
     for series in series_list(sp)
-        for vals in (series[:seriestype] in z_colored_series ? series[:z] : nothing, series[:line_z], series[:marker_z], series[:fill_z])
-            if (typeof(vals) <: AbstractSurface) && (eltype(vals.surf) <: Union{Missing, Real})
-                zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals.surf)...)
-            elseif (vals !== nothing) && (eltype(vals) <: Union{Missing, Real})
-                zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals)...)
+        if series[:colorbar_entry]
+            for vals in (series[:seriestype] in z_colored_series ? series[:z] : nothing, series[:line_z], series[:marker_z], series[:fill_z])
+                if (typeof(vals) <: AbstractSurface) && (eltype(vals.surf) <: Union{Missing, Real})
+                    zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals.surf)...)
+                elseif (vals !== nothing) && (eltype(vals) <: Union{Missing, Real})
+                    zmin, zmax = _update_clims(zmin, zmax, ignorenan_extrema(vals)...)
+                end
             end
         end
     end


### PR DESCRIPTION
This addresses #2229 and another example @mkborregaard brought up on slack. We still have `clims` as a subplot attribute and multiple series sharing the same clims. However, with this we can exclude certain series from the `clims` calculation by setting `colorbar_entry = false`.

In the following there are two code examples with old and new behaviour for GR and PyPlot.

```julia
xs = ys = -3:0.01:3

heatmap(xs, ys, (x,y) -> sign(x^2 - y^2 - 1))
contour!(xs, ys, (x,y) -> x^2 - y^2 - 1, levels = [0], colorbar_entry = false, lw = 3, color = :black)
```
GR old:
![gr_contour_old](https://user-images.githubusercontent.com/16589944/67706795-b2783880-f9b9-11e9-8d29-eed5c15d71e0.png)

GR new:
![gr_contour_new](https://user-images.githubusercontent.com/16589944/67706540-439adf80-f9b9-11e9-90f9-5fcbc5dde3a0.png)

PyPlot old:
![pyplot_contour_old](https://user-images.githubusercontent.com/16589944/67706812-b86e1980-f9b9-11e9-96a3-9fa7b2f34cf6.png)

PyPlot new:
![pyplot_contour_new](https://user-images.githubusercontent.com/16589944/67706600-5a413680-f9b9-11e9-851b-792429b0efc0.png)


```julia
mat1 = rand([0.0, 1.0], 7, 7)
mat2 = 20 * rand(7, 7)
mat2[:, 1:3] .= NaN

heatmap(mat1, c = :greys, colorbar_entry = false)
heatmap!(mat2)
```
GR old:
![gr_heatmap_old](https://user-images.githubusercontent.com/16589944/67706751-9d030e80-f9b9-11e9-9b36-16dd0dda40c2.png)

GR new:
![gr_heatmap_new](https://user-images.githubusercontent.com/16589944/67706639-6af1ac80-f9b9-11e9-92ee-e6263fa18507.png)

PyPlot old:
![pyplot_heatmap_old](https://user-images.githubusercontent.com/16589944/67706772-ab512a80-f9b9-11e9-8128-b24fbd006e3e.png)

PyPlot new:
![pyplot_heatmap_new](https://user-images.githubusercontent.com/16589944/67706692-82c93080-f9b9-11e9-8c7a-75e44058ea4d.png)
