### PR TITLE
allow minorgrid = true for only two tick values

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -297,7 +297,7 @@ function get_minor_ticks(sp, axis, ticks)
     #Add one phantom tick either side of the ticks to ensure minor ticks extend to the axis limits
     if length(ticks) > 2
         ratio = (ticks[3] - ticks[2])/(ticks[2] - ticks[1])
-    elseif axis[:scale] == :none
+    elseif axis[:scale] in (:none, :identity)
         ratio = 1
     else
         return nothing


### PR DESCRIPTION
```julia
plot(["A", "B"], 1:2, minorgrid = true)
```
used to fail with:
```julia
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: MethodError: no method matching iterate(::Nothing)
Closest candidates are:
  iterate(::Core.SimpleVector) at essentials.jl:604
  iterate(::Core.SimpleVector, ::Any) at essentials.jl:604
  iterate(::ExponentialBackOff) at error.jl:214
  ...
Stacktrace:
 [1] axis_drawing_info(::Plots.Subplot{Plots.GRBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\axes.jl:683
 [2] _update_min_padding!(::Plots.Subplot{Plots.GRBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\backends\gr.jl:781
 [3] iterate at .\generator.jl:47 [inlined]
 [4] _collect(::Array{AbstractLayout,2}, ::Base.Generator{Array{AbstractLayout,2},typeof(Plots._update_min_padding!)}, ::Base.EltypeUnknown, ::Base.HasShape{2}) at .\array.jl:619
 [5] collect_similar at .\array.jl:548 [inlined]
 [6] map at .\abstractarray.jl:2073 [inlined]
 [7] _update_min_padding!(::Plots.GridLayout) at C:\Users\Daniel\.julia\dev\Plots\src\layouts.jl:310
 [8] prepare_output(::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\plot.jl:261
 [9] showjuno(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("text/html")}, ::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:247
 [10] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("application/prs.juno.plotpane+html")}, ::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\dev\Plots\src\output.jl:205
 [11] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::String, ::Plots.Plot{Plots.GRBackend}) at .\multimedia.jl:109
 [12] displayinplotpane(::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\packages\Atom\ambhH\src\display\showdisplay.jl:51
 [13] display(::Atom.JunoDisplay, ::Plots.Plot{Plots.GRBackend}) at C:\Users\Daniel\.julia\packages\Atom\ambhH\src\display\showdisplay.jl:112
 [14] display(::Any) at .\multimedia.jl:323
 [15] #invokelatest#1 at .\essentials.jl:790 [inlined]
 [16] invokelatest at .\essentials.jl:789 [inlined]
 [17] print_response(::IO, ::Any, ::Bool, ::Bool, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.2\REPL\src\REPL.jl:156
 [18] print_response(::REPL.AbstractREPL, ::Any, ::Bool, ::Bool) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.2\REPL\src\REPL.jl:141
 [19] (::getfield(REPL, Symbol("#do_respond#38")){Bool,getfield(Atom, Symbol("##176#177")),REPL.LineEditREPL,REPL.LineEdit.Prompt})(::Any, ::Any, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.2\REPL\src\REPL.jl:718
 [20] #invokelatest#1 at .\essentials.jl:790 [inlined]
 [21] invokelatest at .\essentials.jl:789 [inlined]
 [22] run_interface(::REPL.Terminals.TextTerminal, ::REPL.LineEdit.ModalInterface, ::REPL.LineEdit.MIState) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.2\REPL\src\LineEdit.jl:2306
 [23] run_frontend(::REPL.LineEditREPL, ::REPL.REPLBackendRef) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.2\REPL\src\REPL.jl:1038
 [24] run_repl(::REPL.AbstractREPL, ::Any) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.2\REPL\src\REPL.jl:201
 [25] (::getfield(Base, Symbol("##737#739")){Bool,Bool,Bool,Bool})(::Module) at .\client.jl:390
 [26] #invokelatest#1 at .\essentials.jl:790 [inlined]
 [27] invokelatest at .\essentials.jl:789 [inlined]
 [28] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at .\client.jl:374
 [29] exec_options(::Base.JLOptions) at .\client.jl:312
 [30] _start() at .\client.jl:464
```

With this change we get:
![minorgrid_new](https://user-images.githubusercontent.com/16589944/67951835-8e506d80-fbec-11e9-9e62-d29dc3e931f5.png)
