### PR TITLE
Convert infinite values to NaN

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -480,6 +480,23 @@ PlotExample("Histogram2D (complex values)",
     end)]
 ),
 
+PlotExample("Unconnected lines using NaN values",
+"""
+Non-finite values, including `NaN`, are not plotted.
+Instead, lines are separated into segments at these values.
+""",
+    [:(begin
+        x,y = [1,2,2,1,1], [1,2,1,2,1]
+        plot(
+              plot([rand(5); NaN; rand(5); NaN; rand(5)]),
+              plot([1,Inf,2,3], marker=true),
+              plot([x; NaN; x.+2], [y; NaN; y.+1], arrow=2),
+              plot([1, 2+3im, Inf, 4im, 3, -Inf*im, 0, 3+3im], marker=true),
+              legend=false
+        )
+    end)]
+),
+
 ]
 
 # Some constants for PlotDocs and PlotReferenceImages

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -480,16 +480,16 @@ PlotExample("Histogram2D (complex values)",
     end)]
 ),
 
-PlotExample("Unconnected lines using NaN values",
+PlotExample("Unconnected lines using `missing` or `NaN`",
 """
-Non-finite values, including `NaN`, are not plotted.
+Missing values and non-finite values, including `NaN`, are not plotted.
 Instead, lines are separated into segments at these values.
 """,
     [:(begin
         x,y = [1,2,2,1,1], [1,2,1,2,1]
         plot(
               plot([rand(5); NaN; rand(5); NaN; rand(5)]),
-              plot([1,Inf,2,3], marker=true),
+              plot([1,missing,2,3], marker=true),
               plot([x; NaN; x.+2], [y; NaN; y.+1], arrow=2),
               plot([1, 2+3im, Inf, 4im, 3, -Inf*im, 0, 3+3im], marker=true),
               legend=false

--- a/src/series.jl
+++ b/src/series.jl
@@ -14,7 +14,10 @@ const SeriesData = Union{AVec{<:DataPoint}, Function, Surface, Volume}
 
 prepareSeriesData(x) = error("Cannot convert $(typeof(x)) to series data for plotting")
 prepareSeriesData(::Nothing) = nothing
-prepareSeriesData(s::SeriesData) = handlemissings(s)
+prepareSeriesData(s::SeriesData) = handleinfinites(handlemissings(s))
+
+handleinfinites(s) = s
+handleinfinites(s::AbstractArray{<:MaybeNumber}) = [isinf(x) ? NaN : x for x in s]
 
 handlemissings(v) = v
 handlemissings(v::AbstractArray{<:MaybeNumber}) = replace(v, missing => NaN)

--- a/src/series.jl
+++ b/src/series.jl
@@ -22,8 +22,6 @@ prepareSeriesData(s::Surface{<:AMat{<:MaybeNumber}}) = Surface(prepareSeriesData
 prepareSeriesData(s::Surface) = s  # non-numeric Surface, such as an image
 prepareSeriesData(v::Volume) = Volume(prepareSeriesData(v.v), v.x_extents, v.y_extents, v.z_extents)
 
-prepareSeriesArray(a::AbstractArray{<:MaybeNumber}) = [ismissing(x) || isinf(x) ? NaN : x for x in a]
-
 # default: assume x represents a single series
 convertToAnyVector(x, plotattributes) = Any[prepareSeriesData(x)]
 


### PR DESCRIPTION
Ref #1261. The discussion there includes some other ideas for how to plot infinite values, so maybe should be left open.
An example which plots incorrectly on GR before this change:
```
plot([1,Inf,2,3])
```
Corresponding reference image: JuliaPlots/PlotReferenceImages.jl#49