### PR TITLE
Fix pgfplots legend fg/bg transparency.

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -476,16 +476,10 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
         if haskey(_pgfplots_legend_pos, legpos)
             kw[:legendPos] = _pgfplots_legend_pos[legpos]
         end
-        cstr, a = pgf_color(plot_color(sp[:background_color_legend]))
-        a == 0 && (cstr = "none") 
+        cstr, bg_alpha = pgf_color(plot_color(sp[:background_color_legend]))
+        fg_alpha = alpha(plot_color(sp[:foreground_color_legend]))
 
-        if hasfield(typeof(sp[:foreground_color_legend]), :alpha) && sp[:foreground_color_legend].alpha == 0
-            legend_linestyle = "draw = none"
-        else
-            legend_linestyle = pgf_linestyle(pgf_thickness_scaling(sp), sp[:foreground_color_legend], 1.0, "solid", )
-        end
-
-        push!(style, string("legend style = {", legend_linestyle, ",", "fill = $cstr,", "font = ", pgf_font(sp[:legendfontsize], pgf_thickness_scaling(sp)), "}"))
+        push!(style, string("legend style = {", pgf_linestyle(pgf_thickness_scaling(sp), sp[:foreground_color_legend], fg_alpha, "solid", ), ",", "fill = $cstr,", "fill opacity = $bg_alpha,", "text opacity = 1,", "font = ", pgf_font(sp[:legendfontsize], pgf_thickness_scaling(sp)), "}"))
 
         if any(s[:seriestype] == :contour for s in series_list(sp))
             kw[:view] = "{0}{90}"

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -479,7 +479,15 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
         cstr, bg_alpha = pgf_color(plot_color(sp[:background_color_legend]))
         fg_alpha = alpha(plot_color(sp[:foreground_color_legend]))
 
-        push!(style, string("legend style = {", pgf_linestyle(pgf_thickness_scaling(sp), sp[:foreground_color_legend], fg_alpha, "solid", ), ",", "fill = $cstr,", "fill opacity = $bg_alpha,", "text opacity = 1,", "font = ", pgf_font(sp[:legendfontsize], pgf_thickness_scaling(sp)), "}"))
+        push!(style, string(
+            "legend style = {", 
+                pgf_linestyle(pgf_thickness_scaling(sp), sp[:foreground_color_legend], fg_alpha, "solid", ), ",", 
+                "fill = $cstr,", 
+                "fill opacity = $bg_alpha,", 
+                "text opacity = $(alpha(plot_color(sp[:legendfontcolor]))),", 
+                "font = ", pgf_font(sp[:legendfontsize], pgf_thickness_scaling(sp)), 
+            "}",
+        ))
 
         if any(s[:seriestype] == :contour for s in series_list(sp))
             kw[:view] = "{0}{90}"

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -477,7 +477,15 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
             kw[:legendPos] = _pgfplots_legend_pos[legpos]
         end
         cstr, a = pgf_color(plot_color(sp[:background_color_legend]))
-        push!(style, string("legend style = {", pgf_linestyle(pgf_thickness_scaling(sp), sp[:foreground_color_legend], 1.0, "solid"), ",", "fill = $cstr,", "font = ", pgf_font(sp[:legendfontsize], pgf_thickness_scaling(sp)), "}"))
+        a == 0 && (cstr = "none") 
+
+        if hasfield(typeof(sp[:foreground_color_legend]), :alpha) && sp[:foreground_color_legend].alpha == 0
+            legend_linestyle = "draw = none"
+        else
+            legend_linestyle = pgf_linestyle(pgf_thickness_scaling(sp), sp[:foreground_color_legend], 1.0, "solid", )
+        end
+
+        push!(style, string("legend style = {", legend_linestyle, ",", "fill = $cstr,", "font = ", pgf_font(sp[:legendfontsize], pgf_thickness_scaling(sp)), "}"))
 
         if any(s[:seriestype] == :contour for s in series_list(sp))
             kw[:view] = "{0}{90}"


### PR DESCRIPTION
Fix `fg_legend=:transparent` and `bg_legend=:transparent` for the PGFPlots backend.

```julia
using Plots
pgfplots()
plot(x->x, fg_legend=:transparent, bg_legend=:transparent)
```
Before PR:
![before](https://user-images.githubusercontent.com/16306680/69170334-d24ed800-0af1-11ea-99f1-b2091113ee2f.png)

After PR:
![after](https://user-images.githubusercontent.com/16306680/69170015-49d03780-0af1-11ea-96f1-1583fba7fc81.png)

