### PR TITLE
Remove line through marker in pgfplots legend.

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -128,16 +128,18 @@ function pgf_marker(plotattributes, i = 1)
     shape = _cycle(plotattributes[:markershape], i)
     cstr, a = pgf_color(plot_color(get_markercolor(plotattributes, i), get_markeralpha(plotattributes, i)))
     cstr_stroke, a_stroke = pgf_color(plot_color(get_markerstrokecolor(plotattributes, i), get_markerstrokealpha(plotattributes, i)))
-    """
-    mark = $(get(_pgfplots_markers, shape, "*")),
-    mark size = $(pgf_thickness_scaling(plotattributes) * 0.5 * _cycle(plotattributes[:markersize], i)),
-    mark options = {
-        color = $cstr_stroke, draw opacity = $a_stroke,
-        fill = $cstr, fill opacity = $a,
-        line width = $(pgf_thickness_scaling(plotattributes) * _cycle(plotattributes[:markerstrokewidth], i)),
-        rotate = $(shape == :dtriangle ? 180 : 0),
-        $(get(_pgfplots_linestyles, _cycle(plotattributes[:markerstrokestyle], i), "solid"))
-    }"""
+    return string(
+        "mark = $(get(_pgfplots_markers, shape, "*")),\n",
+        "mark size = $(pgf_thickness_scaling(plotattributes) * 0.5 * _cycle(plotattributes[:markersize], i)),\n",
+        plotattributes[:seriestype] == :scatter ? "only marks,\n" : "",
+        "mark options = {
+            color = $cstr_stroke, draw opacity = $a_stroke,
+            fill = $cstr, fill opacity = $a,
+            line width = $(pgf_thickness_scaling(plotattributes) * _cycle(plotattributes[:markerstrokewidth], i)),
+            rotate = $(shape == :dtriangle ? 180 : 0),
+            $(get(_pgfplots_linestyles, _cycle(plotattributes[:markerstrokestyle], i), "solid"))
+        }"
+        )
 end
 
 function pgf_add_annotation!(o, x, y, val, thickness_scaling = 1)


### PR DESCRIPTION
Fixes #1618

After PR:
```julia
using Plots
pgfplots()
scatter(rand(5,2), size=(200,200))
```
![scatter_demo](https://user-images.githubusercontent.com/16306680/69265397-1b219200-0bc1-11ea-8a8a-fec3f754ba35.png)


normal `plot`s are untouched:
```julia
plot(rand(5,2), size=(200,200), mark=:circle)
```
![plot_demo](https://user-images.githubusercontent.com/16306680/69265404-1d83ec00-0bc1-11ea-8013-ce55d67e6350.png)


The notable addition to the code is the line
```julia
        plotattributes[:seriestype] == :scatter ? "only marks,\n" : "",
```
The other changes are just to avoid an error from this conditional producing an empty line in the previous way that the string was constructed.