### PR TITLE
Saving to png with Plotly

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -296,9 +296,6 @@ end
 
 _initialize_backend(pkg::GRBackend) = nothing
 
-_initialize_backend(pkg::PlotlyBackend) = nothing
-
-
 # ------------------------------------------------------------------------------
 # gr
 
@@ -356,6 +353,16 @@ is_marker_supported(::GRBackend, shape::Shape) = true
 
 # ------------------------------------------------------------------------------
 # plotly
+
+function _initialize_backend(pkg::PlotlyBackend)
+    try
+        @eval Main begin
+            import ORCA
+        end
+    catch
+        @info "For saving to png with the Plotly backend ORCA has to be installed."
+    end
+end
 
 const _plotly_attr = merge_with_base_supported([
     :annotations,
@@ -708,7 +715,7 @@ const _pgfplotsx_attr = merge_with_base_supported([
 const _pgfplotsx_seriestype =
         [:path,  :scatter, :straightline,
         :path3d, :scatter3d, :surface, :wireframe,
-        :heatmap, :contour, :contour3d, 
+        :heatmap, :contour, :contour3d,
         :shape,
         :steppre, :stepmid, :steppost,  :ysticks, :xsticks]
 const _pgfplotsx_style = [:auto, :solid, :dash, :dot, :dashdot, :dashdotdot]

--- a/src/backends/orca.jl
+++ b/src/backends/orca.jl
@@ -1,0 +1,15 @@
+function plotlybase_syncplot(plt::Plot)
+    plt.o = ORCA.PlotlyBase.Plot()
+    traces = ORCA.PlotlyBase.GenericTrace[]
+    for series_dict in plotly_series(plt)
+        plotly_type = pop!(series_dict, :type)
+        push!(traces, ORCA.PlotlyBase.GenericTrace(plotly_type; series_dict...))
+    end
+    ORCA.PlotlyBase.addtraces!(plt.o, traces...)
+    layout = plotly_layout(plt)
+    w, h = plt[:size]
+    ORCA.PlotlyBase.relayout!(plt.o, layout, width = w, height = h)
+    return plt.o
+end
+
+_show(io::IO, ::MIME{Symbol("image/png")}, plt::Plot{PlotlyBackend}) = ORCA.PlotlyBase.savefig(io, plotlybase_syncplot(plt), format = "png")

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -26,7 +26,6 @@ const plotly_remote_file_path = "https://cdn.plot.ly/plotly-latest.min.js"
 # end
 using UUIDs
 
-push!(_initialized_backends, :plotly)
 # ----------------------------------------------------------------
 
 const _plotly_legend_pos = KW(

--- a/src/init.jl
+++ b/src/init.jl
@@ -46,6 +46,12 @@ function __init__()
         @require Revise = "295af30f-e4ad-537b-8983-00126c2a3abe" Revise.track(Plots, fn)
     end
 
+    @require ORCA = "47be7bcc-f1a6-5447-8b36-7eeeff7534fd" begin
+        fn = joinpath(@__DIR__, "backends", "orca.jl")
+        include(fn)
+        @require Revise = "295af30f-e4ad-537b-8983-00126c2a3abe" Revise.track(Plots, fn)
+    end
+
     @require PGFPlotsX = "8314cec4-20b6-5062-9cdb-752b83310925" begin
         fn = joinpath(@__DIR__, "backends", "pgfplotsx.jl")
         include(fn)


### PR DESCRIPTION
This allows saving plots to png with the plotly backend when ORCA is installed