### PR TITLE
Generalized array fixes

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1098,7 +1098,7 @@ function extractGroupArgs(v::AVec, args...; legendEntry = string)
     if n > 100
         @warn("You created n=$n groups... Is that intended?")
     end
-    groupIds = Vector{Int}[filter(i -> v[i] == glab, 1:length(v)) for glab in groupLabels]
+    groupIds = Vector{Int}[filter(i -> v[i] == glab, eachindex(v)) for glab in groupLabels]
     GroupBy(map(legendEntry, groupLabels), groupIds)
 end
 
@@ -1106,7 +1106,7 @@ legendEntryFromTuple(ns::Tuple) = join(ns, ' ')
 
 # this is when given a tuple of vectors of values to group by
 function extractGroupArgs(vs::Tuple, args...)
-    isempty(vs) && return GroupBy([""], [1:size(args[1],1)])
+    isempty(vs) && return GroupBy([""], [axes(args[1],1)])
     v = map(tuple, vs...)
     extractGroupArgs(v, args...; legendEntry = legendEntryFromTuple)
 end
@@ -1116,7 +1116,7 @@ legendEntryFromTuple(ns::NamedTuple) =
     join(["$k = $v" for (k, v) in pairs(ns)], ", ")
 
 function extractGroupArgs(vs::NamedTuple, args...)
-    isempty(vs) && return GroupBy([""], [1:size(args[1],1)])
+    isempty(vs) && return GroupBy([""], [axes(args[1],1)])
     v = map(NamedTuple{keys(vs)}∘tuple, values(vs)...)
     extractGroupArgs(v, args...; legendEntry = legendEntryFromTuple)
 end
@@ -1225,7 +1225,8 @@ convertLegendValue(v::AbstractArray) = map(convertLegendValue, v)
 # anything else is returned as-is
 function slice_arg(v::AMat, idx::Int)
     c = mod1(idx, size(v,2))
-    size(v,1) == 1 ? v[1,c] : v[:,c]
+    m,n = axes(v)
+    size(v,1) == 1 ? v[first(m),n[c]] : v[:,n[c]]
 end
 slice_arg(wrapper::InputWrapper, idx) = wrapper.obj
 slice_arg(v, idx) = v

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -577,10 +577,10 @@ end
 
 # add the discrete value for each item.  return the continuous values and the indices
 function discrete_value!(axis::Axis, v::AVec)
-    n = length(v)
-    cvec = zeros(n)
-    discrete_indices = zeros(Int, n)
-    for i=1:n
+    n = eachindex(v)
+    cvec = zeros(axes(v))
+    discrete_indices = similar(Array{Int}, axes(v))
+    for i in n
         cvec[i], discrete_indices[i] = discrete_value!(axis, v[i])
     end
     cvec, discrete_indices
@@ -588,10 +588,10 @@ end
 
 # add the discrete value for each item.  return the continuous values and the indices
 function discrete_value!(axis::Axis, v::AMat)
-    n,m = size(v)
-    cmat = zeros(n,m)
-    discrete_indices = zeros(Int, n, m)
-    for i=1:n, j=1:m
+    n,m = axes(v)
+    cmat = zeros(axes(v))
+    discrete_indices = similar(Array{Int}, axes(v))
+    for i in n, j in m
         cmat[i,j], discrete_indices[i,j] = discrete_value!(axis, v[i,j])
     end
     cmat, discrete_indices

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -197,7 +197,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     if xaxis[:grid]
         gr_set_line(xaxis[:gridlinewidth], xaxis[:gridstyle], xaxis[:foreground_color_grid])
         gr_set_transparency(xaxis[:foreground_color_grid], xaxis[:gridalpha])
-        for i in 1:length(α)
+        for i in eachindex(α)
             GR.polyline([sinf[i], 0], [cosf[i], 0])
         end
     end
@@ -206,7 +206,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     if yaxis[:grid]
         gr_set_line(yaxis[:gridlinewidth], yaxis[:gridstyle], yaxis[:foreground_color_grid])
         gr_set_transparency(yaxis[:foreground_color_grid], yaxis[:gridalpha])
-        for i in 1:length(rtick_values)
+        for i in eachindex(rtick_values)
             r = (rtick_values[i] - rmin) / (rmax - rmin)
             if r <= 1.0 && r >= 0.0
                 GR.drawarc(-r, r, -r, r, 0, 359)
@@ -223,7 +223,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
     #draw angular ticks
     if xaxis[:showaxis]
         GR.drawarc(-1, 1, -1, 1, 0, 359)
-        for i in 1:length(α)
+        for i in eachindex(α)
             x, y = GR.wctondc(1.1 * sinf[i], 1.1 * cosf[i])
             GR.textext(x, y, string((360-α[i])%360, "^o"))
         end
@@ -231,7 +231,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
 
     #draw radial ticks
     if yaxis[:showaxis]
-        for i in 1:length(rtick_values)
+        for i in eachindex(rtick_values)
             r = (rtick_values[i] - rmin) / (rmax - rmin)
             if r <= 1.0 && r >= 0.0
                 x, y = GR.wctondc(0.05, r)
@@ -305,7 +305,7 @@ function gr_draw_markers(series::Series, x, y, clims, msize = series[:markersize
 
     shapes = series[:markershape]
     if shapes != :none
-        for i=1:length(x)
+        for i=eachindex(x)
             msi = _cycle(msize, i)
             shape = _cycle(shapes, i)
             cfunc = isa(shape, Shape) ? gr_set_fillcolor : gr_set_markercolor

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -180,11 +180,11 @@ function pgf_series(sp::Subplot, series::Series)
     end
 
     # PGFPlots can't handle non-Vector?
-    args = map(a -> if typeof(a) <: AbstractVector && typeof(a) != Vector
-            collect(a)
-        else
-            a
-        end, args)
+    # args = map(a -> if typeof(a) <: AbstractVector && typeof(a) != Vector
+    #         collect(a)
+    #     else
+    #         a
+    #     end, args)
 
     if st in (:contour, :histogram2d)
         style = []

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -415,6 +415,7 @@ function plotly_data(series::Series, letter::Symbol, data)
     end
 end
 plotly_data(v) = v !== nothing ? collect(v) : v
+plotly_data(v::AbstractArray) = v
 plotly_data(surf::Surface) = surf.surf
 plotly_data(v::AbstractArray{R}) where {R<:Rational} = float(v)
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -351,7 +351,7 @@ end
 
 
 function plotly_colorscale(grad::ColorGradient, α)
-    [[grad.values[i], rgba_string(plot_color(grad.colors[i], α))] for i in 1:length(grad.colors)]
+    [[grad.values[i], rgba_string(plot_color(grad.colors[i], α))] for i in eachindex(grad.colors)]
 end
 plotly_colorscale(c::Colorant,α) = plotly_colorscale(_as_gradient(c),α)
 function plotly_colorscale(c::AbstractVector{<:RGBA}, α)
@@ -392,7 +392,7 @@ end
 # we split by NaNs and then construct/destruct the shapes to get the closed coords
 function plotly_close_shapes(x, y)
     xs, ys = nansplit(x), nansplit(y)
-    for i=1:length(xs)
+    for i=eachindex(xs)
         shape = Shape(xs[i], ys[i])
         xs[i], ys[i] = coords(shape)
     end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -187,7 +187,7 @@ end
 # end
 
 function get_locator_and_formatter(vals::AVec)
-    pyticker."FixedLocator"(1:length(vals)), pyticker."FixedFormatter"(vals)
+    pyticker."FixedLocator"(eachindex(vals)), pyticker."FixedFormatter"(vals)
 end
 
 function add_pyfixedformatter(cbar, vals::AVec)
@@ -535,7 +535,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             shapes = series[:markershape]
             msc = py_markerstrokecolor(series)
             lw = py_thickness_scale(plt, series[:markerstrokewidth])
-            for i=1:length(y)
+            for i=eachindex(y)
                 extrakw[:c] = _cycle(markercolor, i)
 
                 push!(handle, ax."scatter"(_cycle(x,i), _cycle(y,i);
@@ -564,7 +564,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
 
             delete!(extrakw, :c)
 
-            for i=1:length(y)
+            for i=eachindex(y)
                 cur_marker = py_marker(_cycle(shapes,i))
 
                 if ( cur_marker == prev_marker )
@@ -1013,7 +1013,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             kw = KW()
             if !isempty(sp[:zaxis][:discrete_values]) && colorbar_series[:seriestype] == :heatmap
                 locator, formatter = get_locator_and_formatter(sp[:zaxis][:discrete_values])
-                # kw[:values] = 1:length(sp[:zaxis][:discrete_values])
+                # kw[:values] = eachindex(sp[:zaxis][:discrete_values])
                 kw[:values] = sp[:zaxis][:continuous_values]
                 kw[:ticks] = locator
                 kw[:format] = formatter

--- a/src/components.jl
+++ b/src/components.jl
@@ -187,7 +187,7 @@ end
 function scale!(shape::Shape, x::Real, y::Real = x, c = center(shape))
     sx, sy = coords(shape)
     cx, cy = c
-    for i=1:length(sx)
+    for i=eachindex(sx)
         sx[i] = (sx[i] - cx) * x + cx
         sy[i] = (sy[i] - cy) * y + cy
     end
@@ -202,7 +202,7 @@ end
 "translate a Shape in space"
 function translate!(shape::Shape, x::Real, y::Real = x)
     sx, sy = coords(shape)
-    for i=1:length(sx)
+    for i=eachindex(sx)
         sx[i] += x
         sy[i] += y
     end
@@ -230,7 +230,7 @@ end
 function rotate!(shape::Shape, Θ::Real, c = center(shape))
     x, y = coords(shape)
     cx, cy = c
-    for i=1:length(x)
+    for i=eachindex(x)
         xi = rotate_x(x[i], y[i], Θ, cx, cy)
         yi = rotate_y(x[i], y[i], Θ, cx, cy)
         x[i], y[i] = xi, yi

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -545,7 +545,7 @@ function test_examples(pkgname::Symbol; debug = false, disp = true, sleep = noth
                                         skip = [], only = nothing)
   Plots._debugMode.on = debug
   plts = Dict()
-  for i in 1:length(_examples)
+  for i in eachindex(_examples)
     only !== nothing && !(i in only) && continue
     i in skip && continue
     try

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -12,7 +12,7 @@ function _expand_seriestype_array(plotattributes::KW, args)
     if typeof(sts) <: AbstractArray
         delete!(plotattributes, :seriestype)
         rd = Vector{RecipeData}(undef, size(sts, 1))
-        for r in 1:size(sts, 1)
+        for r in axes(sts, 1)
             dc = copy(plotattributes)
             dc[:seriestype] = sts[r:r,:]
             rd[r] = RecipeData(dc, args)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -364,7 +364,7 @@ end
             0.5 * _bar_width
         end
     else
-        Float64[0.5_cycle(bw,i) for i=1:length(procx)]
+        Float64[0.5_cycle(bw,i) for i=eachindex(procx)]
     end
 
     # make fillto a vector... default fills to 0
@@ -998,7 +998,7 @@ function get_xy(o::OHLC, x, xdiff)
 end
 
 # get the joined vector
-function get_xy(v::AVec{OHLC}, x = 1:length(v))
+function get_xy(v::AVec{OHLC}, x = eachindex(v))
     xdiff = 0.3ignorenan_mean(abs.(diff(x)))
     x_out, y_out = zeros(0), zeros(0)
     for (i,ohlc) in enumerate(v)
@@ -1056,8 +1056,8 @@ end
     @assert length(g.args) == 1 && typeof(g.args[1]) <: AbstractMatrix
     seriestype := :spy
     mat = g.args[1]
-    n,m = size(mat)
-    Plots.SliceIt, 1:m, 1:n, Surface(mat)
+    n,m = axes(mat)
+    Plots.SliceIt, m, n, Surface(mat)
 end
 
 @recipe function f(::Type{Val{:spy}}, x,y,z)
@@ -1185,7 +1185,7 @@ end
     seriestype := :shape
 
 	# create a filled polygon for each item
-    for c=1:size(weights,2)
+    for c=axes(weights,2)
         sx = vcat(weights[:,c], c==1 ? zeros(n) : reverse(weights[:,c-1]))
         sy = vcat(returns, reverse(returns))
         @series Plots.isvertical(plotattributes) ? (sx, sy) : (sy, sx)
@@ -1206,9 +1206,9 @@ julia> areaplot(1:3, [1 2 3; 7 8 9; 4 5 6], seriescolor = [:red :green :blue], f
 
 @recipe function f(a::AreaPlot)
     data = cumsum(a.args[end], dims=2)
-    x = length(a.args) == 1 ? (1:size(data, 1)) : a.args[1]
+    x = length(a.args) == 1 ? (axes(data, 1)) : a.args[1]
     seriestype := :line
-    for i in 1:size(data, 2)
+    for i in axes(data, 2)
         @series begin
             fillrange := i > 1 ? data[:,i-1] : 0
             x, data[:,i]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,7 +43,7 @@ function barHack(; kw...)
   # estimate the edges
   dists = diff(midpoints) * 0.5
   edges = zeros(length(midpoints)+1)
-  for i in 1:length(edges)
+  for i in eachindex(edges)
     if i == 1
       edge = midpoints[1] - dists[1]
     elseif i == length(edges)
@@ -56,7 +56,7 @@ function barHack(; kw...)
 
   x = Float64[]
   y = Float64[]
-  for i in 1:length(heights)
+  for i in eachindex(heights)
     e1, e2 = edges[i:i+1]
     append!(x, [e1, e1, e2, e2])
     append!(y, [fillrange, heights[i], heights[i], fillrange])
@@ -197,7 +197,7 @@ function iter_segments(series::Series)
         return UnitRange{Int}[]
     elseif has_attribute_segments(series)
         if series[:seriestype] in (:scatter, :scatter3d)
-            return [[i] for i in 1:length(y)]
+            return [[i] for i in eachindex(y)]
         else
             return [i:(i + 1) for i in 1:(length(y) - 1)]
         end


### PR DESCRIPTION
Updates plots in many places to use the generalized arrays interface for array indices, thus automatically supporting anything that implements the AbstractArray interface. This involves e.g.:
- replace many uses of size with axes
- replace 1:length(v) with eachindex(v),
- replace zeros(Int, length(v)) with similar(Array{Int}, axes(v))

(see https://docs.julialang.org/en/latest/devdocs/offset-arrays/#Generalizing-existing-code-1)

This PR mostly brings #999 up-to-date.