### PR TITLE
Support colons in layout keyword argument.

### DIFF
--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -487,6 +487,7 @@ function layout_args(sztup::NTuple{2, Integer})
 end
 
 layout_args(n_override::Integer, n::Integer) = layout_args(n)
+layout_args(n, sztup::NTuple{2, Integer}) = layout_args(sztup)
 
 function layout_args(n, sztup::Tuple{Colon, Integer})
     nc = sztup[2]

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -469,7 +469,7 @@ function layout_args(plotattributes::KW)
 end
 
 function layout_args(plotattributes::KW, n_override::Integer)
-    layout, n = layout_args(get(plotattributes, :layout, n_override))
+    layout, n = layout_args(n_override, get(plotattributes, :layout, n_override))
     if n != n_override
         error("When doing layout, n ($n) != n_override ($(n_override)).  You're probably trying to force existing plots into a layout that doesn't fit them.")
     end
@@ -481,12 +481,26 @@ function layout_args(n::Integer)
     GridLayout(nr, nc), n
 end
 
-function layout_args(sztup::NTuple{2,I}) where I<:Integer
+function layout_args(sztup::NTuple{2, Integer})
     nr, nc = sztup
     GridLayout(nr, nc), nr*nc
 end
 
-function layout_args(sztup::NTuple{3,I}) where I<:Integer
+layout_args(n_override::Integer, n::Integer) = layout_args(n)
+
+function layout_args(n, sztup::Tuple{Colon, Integer})
+    nc = sztup[2]
+    nr = ceil(Int, n / nc)
+    GridLayout(nr, nc), n
+end
+
+function layout_args(n, sztup::Tuple{Integer, Colon})
+    nr = sztup[1]
+    nc = ceil(Int, n / nr)
+    GridLayout(nr, nc), n
+end
+
+function layout_args(sztup::NTuple{3, Integer})
     n, nr, nc = sztup
     nr, nc = compute_gridsize(n, nr, nc)
     GridLayout(nr, nc), n

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -514,6 +514,8 @@ function layout_args(layout::GridLayout)
     layout, n
 end
 
+layout_args(n_override::Integer, layout::GridLayout) = layout_args(layout)
+
 layout_args(huh) = error("unhandled layout type $(typeof(huh)): $huh")
 
 


### PR DESCRIPTION
Allow more flexible layout specification for plot stacking: `plot(plt1, plt2, plt3; layout=(:,2))`. A colon in the layout tuple will be recalculated to the smallest value which will allow all plots to fit.

As per a suggestion by Spencer Russel in slack.

This does make the code a bit harder to follow so I'd be happy to make adjustments if anyone can see a neater solution. 