### PR TITLE
Treat types without length as a single element

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -591,7 +591,9 @@ annotations(sa::SeriesAnnotations) = sa
 function process_annotation(sp::Subplot, xs, ys, labs, font = font())
     anns = []
     labs = makevec(labs)
-    for i in 1:max(length(xs), length(ys), length(labs))
+    xlength = length(methods(length, (typeof(xs),))) == 0 ? 1 : length(xs)
+    ylength = length(methods(length, (typeof(ys),))) == 0 ? 1 : length(ys)
+    for i in 1:max(xlength, ylength, length(labs))
         x, y, lab = _cycle(xs, i), _cycle(ys, i), _cycle(labs, i)
         if lab == :auto
             alphabet = "abcdefghijklmnopqrstuvwxyz"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using FileIO
 using Gtk
 using LibGit2
 using GeometryTypes
+using Dates
 
 include("test_pgfplotsx.jl")
 
@@ -65,6 +66,21 @@ img_tol = is_ci() ? 10e-2 : 10e-2
         @test isa(p, Plots.Plot) == true
         @test isa(display(p), Nothing) == true
         p = bar(randn(10))
+        @test isa(p, Plots.Plot) == true
+        @test isa(display(p), Nothing) == true
+        p = plot([1, 2], [3, 4])
+        annotate!(p, [(1.5, 3.2, Plots.text("Test", :red, :center))])
+        hline!(p, [3.1])
+        @test isa(p, Plots.Plot) == true
+        @test isa(display(p), Nothing) == true
+        p = plot([Dates.Date(2019, 1, 1), Dates.Date(2019, 2, 1)], [3, 4])
+        hline!(p, [3.1])
+        annotate!(p, [(Dates.Date(2019, 1, 15), 3.2, Plots.text("Test", :red, :center))])
+        @test isa(p, Plots.Plot) == true
+        @test isa(display(p), Nothing) == true
+        p = plot([Dates.Date(2019, 1, 1), Dates.Date(2019, 2, 1)], [3, 4])
+        annotate!(p, [(Dates.Date(2019, 1, 15), 3.2, Plots.text("Test", :red, :center))])
+        hline!(p, [3.1])
         @test isa(p, Plots.Plot) == true
         @test isa(display(p), Nothing) == true
     end


### PR DESCRIPTION
Fixes #2350
Workaround for types like Dates.Date which can be used for coordinates but doesn't have Base.length defined.