### PR TITLE
New recipe: lens

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -311,6 +311,21 @@ const _examples = PlotExample[
         ],
     ),
     PlotExample(
+        "Lens",
+        "A lens lets you easyli magnify a region of a plot. x and y coordinates refer to the to be magnified region and the via the `inset` keyword the subplot index and the bounding box (in relative coordinates) of the inset plot with the magnified plot can be specified. Additional attributes count for the inset plot.",
+        [
+            quote
+                begin
+                    plot([(0, 0), (0, 0.9), (1, 0.9), (2, 1), (3, 0.9), (80, 0)])
+                    plot!([(0, 0), (0, 0.9), (2, 0.9), (3, 1), (4, 0.9), (80, 0)])
+                    plot!([(0, 0), (0, 0.9), (3, 0.9), (4, 1), (5, 0.9), (80, 0)])
+                    plot!([(0, 0), (0, 0.9), (4, 0.9), (5, 1), (6, 0.9), (80, 0)])
+                    lens!([1, 6], [0.9, 1.1], inset = (1, bbox(0.5, 0.0, 0.4, 0.4)))
+                end
+            end
+        ],
+    ),
+        * PlotExample(
         "Adding to subplots",
         """
         Note here the automatic grid layout, as well as the order in which new series are added

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -315,7 +315,7 @@ const _examples = PlotExample[
         "A lens lets you easily magnify a region of a plot. x and y coordinates refer to the to be magnified region and the via the `inset` keyword the subplot index and the bounding box (in relative coordinates) of the inset plot with the magnified plot can be specified. Additional attributes count for the inset plot.",
         [quote
                 begin
-                    plot([(0, 0), (0, 0.9), (1, 0.9), (2, 1), (3, 0.9), (80, 0)])
+                    plot([(0, 0), (0, 0.9), (1, 0.9), (2, 1), (3, 0.9), (80, 0)], legend = :outertopright)
                     plot!([(0, 0), (0, 0.9), (2, 0.9), (3, 1), (4, 0.9), (80, 0)])
                     plot!([(0, 0), (0, 0.9), (3, 0.9), (4, 1), (5, 0.9), (80, 0)])
                     plot!([(0, 0), (0, 0.9), (4, 0.9), (5, 1), (6, 0.9), (80, 0)])

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -311,23 +311,6 @@ const _examples = PlotExample[
         ],
     ),
     PlotExample(
-        "Lens",
-        "A lens lets you easily magnify a region of a plot. x and y coordinates refer to the to be magnified region and the via the `inset` keyword the subplot index and the bounding box (in relative coordinates) of the inset plot with the magnified plot can be specified. Additional attributes count for the inset plot.",
-        [quote
-                begin
-                    plot([(0, 0), (0, 0.9), (1, 0.9), (2, 1), (3, 0.9), (80, 0)], legend = :outertopright)
-                    plot!([(0, 0), (0, 0.9), (2, 0.9), (3, 1), (4, 0.9), (80, 0)])
-                    plot!([(0, 0), (0, 0.9), (3, 0.9), (4, 1), (5, 0.9), (80, 0)])
-                    plot!([(0, 0), (0, 0.9), (4, 0.9), (5, 1), (6, 0.9), (80, 0)])
-                    lens!(
-                        [1, 6],
-                        [0.9, 1.1],
-                        inset = (1, bbox(0.5, 0.0, 0.4, 0.4)),
-                    )
-                end
-            end],
-    ),
-    PlotExample(
         "Adding to subplots",
         """
         Note here the automatic grid layout, as well as the order in which new series are added
@@ -868,6 +851,28 @@ const _examples = PlotExample[
                     )
                 end
             ),
+        ],
+    ),
+    PlotExample(
+        "Lens",
+        "A lens lets you easily magnify a region of a plot. x and y coordinates refer to the to be magnified region and the via the `inset` keyword the subplot index and the bounding box (in relative coordinates) of the inset plot with the magnified plot can be specified. Additional attributes count for the inset plot.",
+        [
+            quote
+                begin
+                    plot(
+                        [(0, 0), (0, 0.9), (1, 0.9), (2, 1), (3, 0.9), (80, 0)],
+                        legend = :outertopright,
+                    )
+                    plot!([(0, 0), (0, 0.9), (2, 0.9), (3, 1), (4, 0.9), (80, 0)])
+                    plot!([(0, 0), (0, 0.9), (3, 0.9), (4, 1), (5, 0.9), (80, 0)])
+                    plot!([(0, 0), (0, 0.9), (4, 0.9), (5, 1), (6, 0.9), (80, 0)])
+                    lens!(
+                        [1, 6],
+                        [0.9, 1.1],
+                        inset = (1, bbox(0.5, 0.0, 0.4, 0.4)),
+                    )
+                end
+            end,
         ],
     ),
 ]

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -312,20 +312,22 @@ const _examples = PlotExample[
     ),
     PlotExample(
         "Lens",
-        "A lens lets you easyli magnify a region of a plot. x and y coordinates refer to the to be magnified region and the via the `inset` keyword the subplot index and the bounding box (in relative coordinates) of the inset plot with the magnified plot can be specified. Additional attributes count for the inset plot.",
-        [
-            quote
+        "A lens lets you easily magnify a region of a plot. x and y coordinates refer to the to be magnified region and the via the `inset` keyword the subplot index and the bounding box (in relative coordinates) of the inset plot with the magnified plot can be specified. Additional attributes count for the inset plot.",
+        [quote
                 begin
                     plot([(0, 0), (0, 0.9), (1, 0.9), (2, 1), (3, 0.9), (80, 0)])
                     plot!([(0, 0), (0, 0.9), (2, 0.9), (3, 1), (4, 0.9), (80, 0)])
                     plot!([(0, 0), (0, 0.9), (3, 0.9), (4, 1), (5, 0.9), (80, 0)])
                     plot!([(0, 0), (0, 0.9), (4, 0.9), (5, 1), (6, 0.9), (80, 0)])
-                    lens!([1, 6], [0.9, 1.1], inset = (1, bbox(0.5, 0.0, 0.4, 0.4)))
+                    lens!(
+                        [1, 6],
+                        [0.9, 1.1],
+                        inset = (1, bbox(0.5, 0.0, 0.4, 0.4)),
+                    )
                 end
-            end
-        ],
+            end],
     ),
-        * PlotExample(
+    PlotExample(
         "Adding to subplots",
         """
         Note here the automatic grid layout, as well as the order in which new series are added

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -909,15 +909,37 @@ end
     bbx1 = xl1 + left(inset_bbox).value * (xl2 - xl1)
     bbx2 = bbx1 + width(inset_bbox).value * (xl2 - xl1)
     yl1, yl2 = ylims(plt.subplots[sp_index])
-    bby1 = yl1 + bottom(inset_bbox).value * (yl2 - yl1)
+    bby1 = yl1 + (1 - bottom(inset_bbox).value) * (yl2 - yl1)
     bby2 = bby1 + height(inset_bbox).value * (yl2 - yl1)
     bbx = bbx1 + width(inset_bbox).value * (xl2 - xl1) / 2
+    bby = bby1 + height(inset_bbox).value * (yl2 - yl1) / 2
     lens_index = last(plt.subplots)[:subplot_index] + 1
-    @show plotattributes[:plot_object].subplots
-    @show inset_bbox
-    @show sp[:left_margin]
     x1, x2 = plotattributes[:x]
     y1, y2 = plotattributes[:y]
+    seriestype := :path
+    label := ""
+    linecolor := :lightgray
+    bbx_mag = (x1 + x2) / 2
+    bby_mag = (y1 + y2) / 2
+    xi_lens, yi_lens = intersection_point(bbx_mag, bby_mag, bbx, bby, abs(bby2 - bby1), abs(bbx2 - bbx1))
+    xi_mag, yi_mag = intersection_point(bbx, bby, bbx_mag, bby_mag, abs(y2 - y1), abs(x2 - x1))
+    # add lines
+    if xl1 < xi_lens < xl2 &&
+        yl1 < yi_lens < yl2
+        @series begin
+            subplot := sp_index
+            x := [xi_mag, xi_lens]
+            y := [yi_mag, yi_lens]
+            ()
+        end
+    end
+    # add magnification shape
+    @series begin
+        subplot := sp_index
+        x := [x1, x1, x2, x2, x1]
+        y := [y1, y2, y2, y1, y1]
+        ()
+    end
     # add subplot
     for series in sp.series_list
         @series begin
@@ -929,26 +951,34 @@ end
             ()
         end
     end
-    # TODO: compute better linking
-    seriestype := :path
-    label := ""
-    linecolor := :lightgray
-    # add lines
-    if xl1 < bbx < xl2 &&
-        yl1 < bby1 < yl2
-        @series begin
-            subplot := sp_index
-            x := [(x1 + x2) / 2, bbx]
-            y := [y2, bby1]
-            ()
+end
+
+function intersection_point(xA, yA, xB, yB, h, w)
+    s = (yA - yB) / (xA - xB)
+    @show s, xA, yA, xB, yB, h, w
+    hh = h / 2
+    hw = w / 2
+    # left or right?
+    if -hh <= s * hw <= hh
+        if xA > xB
+            # right
+            println("right")
+            return xB + hw, yB + s * hw
+        else # left
+            println("left")
+            return xB - hw, yB - s * hw
         end
-    end
-    # add magnification shape
-    @series begin
-        subplot := sp_index
-        x := [x1, x1, x2, x2, x1]
-        y := [y1, y2, y2, y1, y1]
-        ()
+    # top or bot?
+    elseif -hw <= hh/s <= hw
+        if yA > yB
+            # top
+            println("top")
+            return xB + hh/s, yB + hh
+        else
+            # bottom
+            println("bottom")
+            return xB - hh/s, yB - hh
+        end
     end
 end
 # ---------------------------------------------------------------------------

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -904,14 +904,26 @@ end
 @recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)
     # TODO: validate input
     @show plt.series_list[end][:seriestype]
+    @show plotattributes[:inset_subplots]
     @show plotattributes
     x1, x2 = plotattributes[:x]
     y1, y2 = plotattributes[:y]
     # TODO: add subplot
+    for series in plt.series_list
+        @series begin
+            plotattributes = copy(series.plotattributes)
+            subplot := 2
+            label := ""
+            xlims := (x1, x2)
+            ylims := (y1, y2)
+            ()
+        end
+    end
     # TODO: add lines
     seriestype := :path
     label := ""
     linecolor := :lightgray
+    subplot := 1
     @series begin
         plotattributes[:x] = [x2, 4]
         plotattributes[:y] = [y2, 10]

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -903,30 +903,38 @@ end
 # lens! - magnify a region of a plot
 @recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)
     # TODO: validate input
-    @show plt.series_list[end][:seriestype]
-    @show plotattributes[:inset_subplots]
+    sp_index, sp_bbox = plotattributes[:inset_subplots]
+    xl1, xl2 = xlims(plt.subplots[sp_index])
+    bbx1 = xl1 + left(sp_bbox).value * (xl2 - xl1)
+    bbx2 = bbx1 + width(sp_bbox).value * (xl2 - xl1)
+    yl1, yl2 = ylims(plt.subplots[sp_index])
+    bby1 = yl1 + bottom(sp_bbox).value * (yl2 - yl1)
+    bby2 = bby1 + height(sp_bbox).value * (yl2 - yl1)
+    bbx = bbx1 + width(sp_bbox).value * (xl2 - xl1) / 2
     @show plotattributes
     x1, x2 = plotattributes[:x]
     y1, y2 = plotattributes[:y]
-    # TODO: add subplot
+    # add subplot
     for series in plt.series_list
         @series begin
+            inset_index = plotattributes[:series_plotindex]
             plotattributes = copy(series.plotattributes)
-            subplot := 2
+            subplot := inset_index
             label := ""
             xlims := (x1, x2)
             ylims := (y1, y2)
             ()
         end
     end
-    # TODO: add lines
+    # add lines
+    # TODO: compute better linking
     seriestype := :path
     label := ""
     linecolor := :lightgray
     subplot := 1
     @series begin
-        plotattributes[:x] = [x2, 4]
-        plotattributes[:y] = [y2, 10]
+        plotattributes[:x] = [(x1 + x2) / 2, bbx]
+        plotattributes[:y] = [y2, bby1]
         ()
     end
     # add magnification shape

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -904,8 +904,10 @@ end
 lens!(args...;kwargs...) = plot!(args...; seriestype=:lens, kwargs...)
 export lens!
 @recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)
-    # TODO: validate input
     sp_index, inset_bbox = plotattributes[:inset_subplots]
+    if !(width(inset_bbox) isa Measures.Length{:w,<:Real})
+        throw(ArgumentError("Inset bounding box needs to in relative coordinates."))
+    end
     sp = plt.subplots[sp_index]
     xl1, xl2 = xlims(plt.subplots[sp_index])
     bbx1 = xl1 + left(inset_bbox).value * (xl2 - xl1)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -901,6 +901,8 @@ end
 
 # ---------------------------------------------------------------------------
 # lens! - magnify a region of a plot
+lens!(args...;kwargs...) = plot!(args...; seriestype=:lens, kwargs...)
+export lens!
 @recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)
     # TODO: validate input
     sp_index, inset_bbox = plotattributes[:inset_subplots]
@@ -955,28 +957,23 @@ end
 
 function intersection_point(xA, yA, xB, yB, h, w)
     s = (yA - yB) / (xA - xB)
-    @show s, xA, yA, xB, yB, h, w
     hh = h / 2
     hw = w / 2
     # left or right?
     if -hh <= s * hw <= hh
         if xA > xB
             # right
-            println("right")
             return xB + hw, yB + s * hw
         else # left
-            println("left")
             return xB - hw, yB - s * hw
         end
     # top or bot?
     elseif -hw <= hh/s <= hw
         if yA > yB
             # top
-            println("top")
             return xB + hh/s, yB + hh
         else
             # bottom
-            println("bottom")
             return xB - hh/s, yB - hh
         end
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -945,7 +945,7 @@ export lens!
     # add subplot
     for series in sp.series_list
         @series begin
-            plotattributes = copy(series.plotattributes)
+            plotattributes = merge(plotattributes, copy(series.plotattributes))
             subplot := lens_index
             label := ""
             xlims := (x1, x2)
@@ -953,6 +953,10 @@ export lens!
             ()
         end
     end
+    backup = copy(plotattributes)
+    empty!(plotattributes)
+    seriestype := :path
+    series_plotindex := backup[:series_plotindex]
 end
 
 function intersection_point(xA, yA, xB, yB, h, w)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -900,6 +900,30 @@ end
 
 
 # ---------------------------------------------------------------------------
+# lens! - magnify a region of a plot
+@recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)
+    # TODO: validate input
+    @show plt.series_list[end][:seriestype]
+    @show plotattributes
+    x1, x2 = plotattributes[:x]
+    y1, y2 = plotattributes[:y]
+    # TODO: add subplot
+    # TODO: add lines
+    seriestype := :path
+    label := ""
+    linecolor := :lightgray
+    @series begin
+        plotattributes[:x] = [x2, 4]
+        plotattributes[:y] = [y2, 10]
+        ()
+    end
+    # add magnification shape
+    # seriestype := plt.series_list[end][:seriestype]
+    plotattributes[:x] = [x1, x1, x2, x2, x1]
+    plotattributes[:y] = [y1, y2, y2, y1, y1]
+    ()
+end
+# ---------------------------------------------------------------------------
 # contourf - filled contours
 
 @recipe function f(::Type{Val{:contourf}}, x, y, z)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -903,18 +903,19 @@ end
 # lens! - magnify a region of a plot
 @recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)
     # TODO: validate input
-    sp_index, sp_bbox = plotattributes[:inset_subplots]
+    sp_index, inset_bbox = plotattributes[:inset_subplots]
     sp = plt.subplots[sp_index]
     xl1, xl2 = xlims(plt.subplots[sp_index])
-    bbx1 = xl1 + left(sp_bbox).value * (xl2 - xl1)
-    bbx2 = bbx1 + width(sp_bbox).value * (xl2 - xl1)
+    bbx1 = xl1 + left(inset_bbox).value * (xl2 - xl1)
+    bbx2 = bbx1 + width(inset_bbox).value * (xl2 - xl1)
     yl1, yl2 = ylims(plt.subplots[sp_index])
-    bby1 = yl1 + bottom(sp_bbox).value * (yl2 - yl1)
-    bby2 = bby1 + height(sp_bbox).value * (yl2 - yl1)
-    bbx = bbx1 + width(sp_bbox).value * (xl2 - xl1) / 2
+    bby1 = yl1 + bottom(inset_bbox).value * (yl2 - yl1)
+    bby2 = bby1 + height(inset_bbox).value * (yl2 - yl1)
+    bbx = bbx1 + width(inset_bbox).value * (xl2 - xl1) / 2
     lens_index = last(plt.subplots)[:subplot_index] + 1
     @show plotattributes[:plot_object].subplots
-    @show plt.subplots[1].plotarea
+    @show inset_bbox
+    @show sp[:left_margin]
     x1, x2 = plotattributes[:x]
     y1, y2 = plotattributes[:y]
     # add subplot

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -912,18 +912,7 @@ end
     bby1 = yl1 + bottom(sp_bbox).value * (yl2 - yl1)
     bby2 = bby1 + height(sp_bbox).value * (yl2 - yl1)
     bbx = bbx1 + width(sp_bbox).value * (xl2 - xl1) / 2
-    ghost_index = last(plt.subplots)[:subplot_index] + 1
-    lens_index = ghost_index + 1
-    ghost_sp = Subplot{typeof(backend())}(sp, Series[], sp.minpad, defaultbox, sp.plotarea,
-        merge(sp.attr, KW(
-            :subplot_index => ghost_index,
-            :relative_bbox => bbox(0.0,0.0,1.0,1.0),
-            :background_color_subplot => RGBA(1.,0.,1.,0.),
-        )),
-        nothing, plt
-    )
-    push!(plt.inset_subplots, ghost_sp)
-    push!(plt.subplots, ghost_sp)
+    lens_index = last(plt.subplots)[:subplot_index] + 1
     @show plotattributes[:plot_object].subplots
     @show plt.subplots[1].plotarea
     x1, x2 = plotattributes[:x]
@@ -944,20 +933,18 @@ end
     label := ""
     linecolor := :lightgray
     # add lines
-    @series begin
-        # inset_subplots := (sp_index, bbox(0., 0., 1.0,1.0))
-        grid := :none
-        framestyle := :none
-        subplot := ghost_index
-        x := [(x1 + x2) / 2, bbx]
-        y := [y2, bby1]
-        ()
+    if xl1 < bbx < xl2 &&
+        yl1 < bby1 < yl2
+        @series begin
+            subplot := sp_index
+            x := [(x1 + x2) / 2, bbx]
+            y := [y2, bby1]
+            ()
+        end
     end
     # add magnification shape
     @series begin
         subplot := sp_index
-        grid := true
-        framestyle := :box
         x := [x1, x1, x2, x2, x1]
         y := [y1, y2, y2, y1, y1]
         ()


### PR DESCRIPTION
The lens recipe should magnify a certain region and show it in an inset plot.
Current API is
```julia
pl = plot((1:5).^2)
plot!(pl, [1.2, 2.8], [3.4, 7.8], seriestype=:lens, inset=(1,bbox(0.4,0.,0.5,0.5)))
```
Where you pass the magnifying region as `x` and `y` values and the location of the inset as usually. 
Currently only relative bounding boxes are supported. Location of the linking line has to be improved.
Also drawing of the linking line should actually be outside of any plot, so it doesn't infer with axis limits of the parent plot, but I don't know if this is possible.
fixes #541