### PR TITLE
only show plotly plots as html in Juno

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -860,6 +860,8 @@ end
 
 # ----------------------------------------------------------------
 
+Base.showable(::MIME"application/prs.juno.plotpane+html", plt::Plot{PlotlyBackend}) = true
+
 function _show(io::IO, ::MIME"application/vnd.plotly.v1+json", plot::Plot{PlotlyBackend})
     plotly_show_js(io, plot)
 end

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -52,3 +52,5 @@ function closeall(::PlotlyJSBackend)
         close(current().o)
     end
 end
+
+Base.showable(::MIME"application/prs.juno.plotpane+html", plt::Plot{PlotlyJSBackend}) = true

--- a/src/output.jl
+++ b/src/output.jl
@@ -262,6 +262,6 @@ function _showjuno(io::IO, m::MIME"image/svg+xml", plt)
   end
 end
 
-Base.showable(::MIME"application/prs.juno.plotpane+html", plt::Plot) = showable(MIME"text/html"(), plt)
+Base.showable(::MIME"application/prs.juno.plotpane+html", plt::Plot) = false
 
 _showjuno(io::IO, m, plt) = _show(io, m, plt)


### PR DESCRIPTION
Should help with https://github.com/JuliaPlots/Plots.jl/issues/2297#issuecomment-582341068 and generally be more correct.