### PR TITLE
Fix GR scientific notation for explicit ticks

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1158,7 +1158,7 @@ function convert_sci_unicode(label::AbstractString)
     for key in keys(unicode_dict)
         label = replace(label, key => unicode_dict[key])
     end
-    if occursin("10^{", label)
+    if occursin("×10^{", label)
         label = string(label, "}")
     end
     label


### PR DESCRIPTION
Fixes rendering of explicitly specified ticks in scientific notation in GR, e.g.
```
y = (1:4).*10_000
plot(y, yticks = y)
```
The real change is just removing the `if axis[:ticks] in (:auto, :native)` check. The rest is just cleanup.