### PR TITLE
Fix shape markers for GR

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -305,15 +305,27 @@ end
 # ---------------------------------------------------------
 
 # draw ONE Shape
-function gr_draw_marker(xi, yi, msize, shape::Shape)
+function gr_draw_marker(series, xi, yi, clims, i, msize, shape::Shape)
     sx, sy = coords(shape)
     # convert to ndc coords (percentages of window)
     GR.selntran(0)
     w, h = gr_plot_size
     f = msize / (w + h)
     xi, yi = GR.wctondc(xi, yi)
-    GR.fillarea(xi .+ sx .* f,
-                yi .+ sy .* f)
+    xs = xi .+ sx .* f
+    ys = yi .+ sy .* f
+
+    # draw the interior
+    mc = get_markercolor(series, clims, i)
+    gr_set_fill(mc)
+    gr_set_transparency(mc, get_markeralpha(series, i))
+    GR.fillarea(xs, ys)
+
+    # draw the shapes
+    msc = get_markerstrokecolor(series, i)
+    gr_set_line(get_markerstrokewidth(series, i), :solid, msc)
+    gr_set_transparency(msc, get_markerstrokealpha(series, i))
+    GR.polyline(xs, ys)
     GR.selntran(1)
 end
 
@@ -323,7 +335,11 @@ function nominal_size()
 end
 
 # draw ONE symbol marker
-function gr_draw_marker(xi, yi, msize::Number, shape::Symbol)
+function gr_draw_marker(series, xi, yi, clims, i, msize::Number, shape::Symbol)
+    GR.setborderwidth(series[:markerstrokewidth]);
+    gr_set_bordercolor(get_markerstrokecolor(series, i));
+    gr_set_markercolor(get_markercolor(series, clims, i));
+    gr_set_transparency(get_markeralpha(series, i))
     GR.setmarkertype(gr_markertype[shape])
     GR.setmarkersize(0.3msize / nominal_size())
     GR.polymarker([xi], [yi])
@@ -341,13 +357,7 @@ function gr_draw_markers(series::Series, x, y, clims, msize = series[:markersize
         for i=eachindex(x)
             msi = _cycle(msize, i)
             shape = _cycle(shapes, i)
-i
-            GR.setborderwidth(series[:markerstrokewidth]);
-            gr_set_bordercolor(get_markerstrokecolor(series, i));
-            gr_set_markercolor(get_markercolor(series, clims, i));
-            gr_set_transparency(get_markeralpha(series, i))
-
-            gr_draw_marker(x[i], y[i], msi, shape)
+            gr_draw_marker(series, x[i], y[i], clims, i, msi, shape)
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -693,6 +693,10 @@ function get_markerstrokealpha(series, i::Int = 1)
     _cycle(series[:markerstrokealpha], i)
 end
 
+function get_markerstrokewidth(series, i::Int = 1)
+    _cycle(series[:markerstrokewidth], i)
+end
+
 function has_attribute_segments(series::Series)
     # we want to check if a series needs to be split into segments just because
     # of its attributes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ include("imgcomp.jl")
 Random.seed!(1234)
 default(show=false, reuse=true)
 is_ci() = get(ENV, "CI", "false") == "true"
-img_tol = is_ci() ? 10e-2 : 10e-2
+img_tol = is_ci() ? 1e-2 : 1e-3
 
 @testset "Backends" begin
 


### PR DESCRIPTION
This allows to plot empty shapes as markers in GR.
```julia
using Plots
circle = Shape(Plots.partialcircle(0, 2π))
plot(1:10, marker = (circle, :transparent, 10))
```
![marker](https://user-images.githubusercontent.com/16589944/75614250-262c7c80-5b37-11ea-8661-cc843a37367d.png)

Furthermore this fixes reference image 21.
![ref21](https://user-images.githubusercontent.com/16589944/75614264-3c3a3d00-5b37-11ea-8381-e5ae3f1146e5.png)
