### PR TITLE
fix gr image lims

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1060,11 +1060,8 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         if st == :pie
             draw_axes = false
         end
-        if st == :heatmap
+        if st in (:heatmap, :image)
             outside_ticks = true
-            for ax in (sp[:xaxis], sp[:yaxis])
-                v = series[ax[:letter]]
-            end
             x, y = heatmap_edges(series[:x], sp[:xaxis][:scale], series[:y], sp[:yaxis][:scale], size(series[:z]))
             xy_lims = x[1], x[end], y[1], y[end]
             expand_extrema!(sp[:xaxis], x)
@@ -1786,8 +1783,10 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
         elseif st == :image
             z = transpose_z(series, series[:z].surf, true)'
+            x, y = heatmap_edges(series[:x], sp[:xaxis][:scale], series[:y], sp[:yaxis][:scale], size(z))
             w, h = size(z)
-            xmin, xmax = ignorenan_extrema(series[:x]); ymin, ymax = ignorenan_extrema(series[:y])
+            xmin, xmax = ignorenan_extrema(x)
+            ymin, ymax = ignorenan_extrema(y)
             rgba = gr_color.(z)
             GR.drawimage(xmin, xmax, ymax, ymin, w, h, rgba)
         end


### PR DESCRIPTION
Changes
```julia
using Plots, Colors
plot(rand(RGB, 4, 4))
```
from
![imagelims_old](https://user-images.githubusercontent.com/16589944/75912477-9269f180-5e51-11ea-8990-9cfa3795559c.png)

to
![imagelims_new](https://user-images.githubusercontent.com/16589944/75912490-98f86900-5e51-11ea-981b-cfba33952a1b.png)

and
```julia
plot(rand(RGB, 1, 5))
```
from
![imagelims1D_old](https://user-images.githubusercontent.com/16589944/75912525-a7df1b80-5e51-11ea-9c49-de410f09f270.png)

to
![imagelims1D_new](https://user-images.githubusercontent.com/16589944/75912547-b2011a00-5e51-11ea-83f2-62ecdff3cf16.png)
