### PR TITLE
Fix pipeline

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -18,7 +18,7 @@ using Base.Meta
 import Showoff
 import StatsBase
 import JSON
-import RecipePipeline: _process_userrecipes, _process_plotrecipe,
+import RecipePipeline: _process_userrecipe, _process_plotrecipe,
                     _process_seriesrecipe, _preprocess_args,
                     preprocessArgs!, is_st_supported,
                     recipe_pipeline!,

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -21,7 +21,7 @@ import JSON
 import RecipePipeline: _process_userrecipe, _process_plotrecipe,
                     _process_seriesrecipe, _preprocess_args,
                     preprocessArgs!, is_st_supported,
-                    recipe_pipeline!,
+                    finalize_subplot!, recipe_pipeline!,
                     _recipe_init!, _recipe_after_user!,
                     _recipe_after_plot!, _recipe_before_series!,
                     _recipe_finish!

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -1,5 +1,5 @@
 
-function finalize_subplot!(plt, plotattributes::AKW)
+function finalize_subplot!(plt::Plot, st, plotattributes::AKW)
     sp = _prepare_subplot(plt, plotattributes)
     _prepare_annotations(sp, plotattributes)
     _expand_subplot_extrema(sp, plotattributes, st)


### PR DESCRIPTION
Together with the fixes in RecipePipeline, `plot(1:5, 1:5)` now works.
Further implementation details need to be discussed.