### PR TITLE
reduce markershape

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -259,7 +259,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                         if marker isa Shape
                             x = marker.x
                             y = marker.y
-                            scale_factor = 0.025
+                            scale_factor = 0.00125
                             mark_size = opt[:markersize] * scale_factor
                             path = join(
                                 [


### PR DESCRIPTION
I still don't get this sentence from the docs:

> Note: The center is (0,0) and the size is expected to be rougly the area of the unit circle.

The unit circle in this plot would be 4 times as big as the picture.