### PR TITLE
Various type recipe fixes

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -181,11 +181,11 @@ function _apply_type_recipe(plotattributes, v::AbstractArray)
     isempty(skipmissing(v)) && return Float64[]
     x = first(skipmissing(v))
     args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
-    if length(args) == 2 && typeof(args[1]) <: Function && typeof(args[2]) <: Function
+    if length(args) == 2 && all(arg -> arg isa Function, args)
         numfunc, formatter = args
         Formatted(map(numfunc, v), formatter)
     else
-        v
+        RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
     end
 end
 

--- a/src/series.jl
+++ b/src/series.jl
@@ -180,14 +180,16 @@ _apply_type_recipe(plotattributes, v) = RecipesBase.apply_recipe(plotattributes,
 function _apply_type_recipe(plotattributes, v::AbstractArray)
     # First we try to apply an array type recipe.
     w = RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
-    # If it did not change try it element-wise
-    if v == w
+    # If the type did not change try it element-wise
+    if typeof(v) == typeof(w)
         isempty(skipmissing(v)) && return Float64[]
         x = first(skipmissing(v))
         args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
         if length(args) == 2 && all(arg -> arg isa Function, args)
             numfunc, formatter = args
              return Formatted(map(numfunc, v), formatter)
+         else
+             return v
         end
     end
     return w

--- a/src/series.jl
+++ b/src/series.jl
@@ -172,12 +172,18 @@ end
 # this should catch unhandled "series recipes" and error with a nice message
 @recipe f(::Type{V}, x, y, z) where {V<:Val} = error("The backend must not support the series type $V, and there isn't a series recipe defined.")
 
-_apply_type_recipe(plotattributes, v) = RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
+function _apply_type_recipe(plotattributes, v, letter)
+    _handle_axis_args!(plotattributes)
+    rdvec = RecipesBase.apply_recipe(plotattributes, typeof(v), v)
+    _handle_axis_args!(plotattributes, letter)
+    return rdvec[1].args[1]
+end
 
 # Handle type recipes when the recipe is defined on the elements.
 # This sort of recipe should return a pair of functions... one to convert to number,
 # and one to format tick values.
-function _apply_type_recipe(plotattributes, v::AbstractArray)
+function _apply_type_recipe(plotattributes, v::AbstractArray, letter)
+    _handle_axis_args!(plotattributes)
     # First we try to apply an array type recipe.
     w = RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
     # If the type did not change try it element-wise
@@ -185,6 +191,7 @@ function _apply_type_recipe(plotattributes, v::AbstractArray)
         isempty(skipmissing(v)) && return Float64[]
         x = first(skipmissing(v))
         args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
+        _handle_axis_args!(plotattributes, letter)
         if length(args) == 2 && all(arg -> arg isa Function, args)
             numfunc, formatter = args
              return Formatted(map(numfunc, v), formatter)
@@ -192,6 +199,7 @@ function _apply_type_recipe(plotattributes, v::AbstractArray)
              return v
         end
     end
+    _handle_axis_args!(plotattributes, letter)
     return w
 end
 
@@ -212,16 +220,44 @@ end
 # end
 
 # don't do anything for ints or floats
-_apply_type_recipe(plotattributes, v::AbstractArray{T}) where {T<:Union{Integer,AbstractFloat}} = v
+_apply_type_recipe(plotattributes, v::AbstractArray{T}, letter) where {T<:Union{Integer,AbstractFloat}} = v
+
+# axis args in type recipes should only be applied to the current axis
+function _handle_axis_args!(plotattributes, letter)
+    if letter in (:x, :y, :z)
+        replaceAliases!(plotattributes, _keyAliases)
+        for (k, v) in plotattributes
+            if haskey(_axis_defaults, k)
+                pop!(plotattributes, k)
+                lk = Symbol(letter, k)
+                haskey(plotattributes, lk) || (plotattributes[lk] = v)
+            end
+        end
+    end
+end
+
+# axis args before type recipes should still be mapped to all axes
+function _handle_axis_args!(plotattributes)
+    replaceAliases!(plotattributes, _keyAliases)
+    for (k, v) in plotattributes
+        if haskey(_axis_defaults, k)
+            pop!(plotattributes, k)
+            for letter in (:x, :y, :z)
+                lk = Symbol(letter, k)
+                haskey(plotattributes, lk) || (plotattributes[lk] = v)
+            end
+        end
+    end
+end
 
 # handle "type recipes" by converting inputs, and then either re-calling or slicing
 @recipe function f(x, y, z)
     did_replace = false
-    newx = _apply_type_recipe(plotattributes, x)
+    newx = _apply_type_recipe(plotattributes, x, :x)
     x === newx || (did_replace = true)
-    newy = _apply_type_recipe(plotattributes, y)
+    newy = _apply_type_recipe(plotattributes, y, :y)
     y === newy || (did_replace = true)
-    newz = _apply_type_recipe(plotattributes, z)
+    newz = _apply_type_recipe(plotattributes, z, :z)
     z === newz || (did_replace = true)
     if did_replace
         newx, newy, newz
@@ -231,9 +267,9 @@ _apply_type_recipe(plotattributes, v::AbstractArray{T}) where {T<:Union{Integer,
 end
 @recipe function f(x, y)
     did_replace = false
-    newx = _apply_type_recipe(plotattributes, x)
+    newx = _apply_type_recipe(plotattributes, x, :x)
     x === newx || (did_replace = true)
-    newy = _apply_type_recipe(plotattributes, y)
+    newy = _apply_type_recipe(plotattributes, y, :y)
     y === newy || (did_replace = true)
     if did_replace
         newx, newy
@@ -242,7 +278,7 @@ end
     end
 end
 @recipe function f(y)
-    newy = _apply_type_recipe(plotattributes, y)
+    newy = _apply_type_recipe(plotattributes, y, :y)
     if y !== newy
         newy
     else
@@ -255,7 +291,7 @@ end
 @recipe function f(v1, v2, v3, v4, vrest...)
     did_replace = false
     newargs = map(v -> begin
-        newv = _apply_type_recipe(plotattributes, v)
+        newv = _apply_type_recipe(plotattributes, v, :unknown)
         if newv !== v
             did_replace = true
         end

--- a/src/series.jl
+++ b/src/series.jl
@@ -178,15 +178,19 @@ _apply_type_recipe(plotattributes, v) = RecipesBase.apply_recipe(plotattributes,
 # This sort of recipe should return a pair of functions... one to convert to number,
 # and one to format tick values.
 function _apply_type_recipe(plotattributes, v::AbstractArray)
-    isempty(skipmissing(v)) && return Float64[]
-    x = first(skipmissing(v))
-    args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
-    if length(args) == 2 && all(arg -> arg isa Function, args)
-        numfunc, formatter = args
-        Formatted(map(numfunc, v), formatter)
-    else
-        RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
+    # First we try to apply an array type recipe.
+    w = RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
+    # If the type did not change try it element-wise
+    if v == w
+        isempty(skipmissing(v)) && return Float64[]
+        x = first(skipmissing(v))
+        args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
+        if length(args) == 2 && all(arg -> arg isa Function, args)
+            numfunc, formatter = args
+             return Formatted(map(numfunc, v), formatter)
+        end
     end
+    return w
 end
 
 # # special handling for Surface... need to properly unwrap and re-wrap

--- a/src/series.jl
+++ b/src/series.jl
@@ -180,7 +180,7 @@ _apply_type_recipe(plotattributes, v) = RecipesBase.apply_recipe(plotattributes,
 function _apply_type_recipe(plotattributes, v::AbstractArray)
     # First we try to apply an array type recipe.
     w = RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
-    # If the type did not change try it element-wise
+    # If it did not change try it element-wise
     if v == w
         isempty(skipmissing(v)) && return Float64[]
         x = first(skipmissing(v))


### PR DESCRIPTION
This allows
```julia
struct CustomDateTime
    dt::DateTime
end

@recipe function f(::Type{T}, v::T) where T <: AbstractVector{<:CustomDateTime}
    getproperty.(v, :dt)
end

times = CustomDateTime.(DateTime.(2011:2020))

plot(times, rand(10))
```
![vectorrecipes](https://user-images.githubusercontent.com/16589944/76913306-e693bd80-68b6-11ea-8762-56ab3a0cb521.png)

which before used to error:
```julia
ERROR: Cannot convert CustomDateTime to series data for plotting
```

fix https://github.com/JuliaPlots/Plots.jl/issues/766