### PR TITLE
Layouting

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -107,11 +107,11 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
             bb = bbox(sp)
             sp_width = width(bb)
             sp_height = height(bb)
-            dx, dy = bb.x0
+            dx, dy = bbox(sp).x0
             # TODO: does this hold at every scale?
-            if sp[:legend] in (:outertopright, nothing)
-                dx *= 1.2
-            end
+            # if sp[:legend] in (:outertopright, nothing)
+            #     dx *= 1.2
+            # end
             cstr = plot_color(sp[:background_color_legend])
             a = alpha(cstr)
             fg_alpha = alpha(plot_color(sp[:foreground_color_legend]))

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -106,10 +106,18 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
         for sp in plt.subplots
             bb1 = sp.plotarea
             bb2 = bbox(sp)
-            sp_width = (width(bb1) + width(bb2)) / 2
-            sp_height = (height(bb1) + height(bb2)) / 2
-            dx, dy = bbox(sp).x0
-            
+            sp_width = width(bb2)
+            sp_height = height(bb2)
+            dx, dy = bb2.x0
+            lpad = leftpad(sp) + sp[:left_margin]
+            rpad = rightpad(sp) + sp[:right_margin]
+            tpad = toppad(sp) + sp[:top_margin]
+            bpad = bottompad(sp) + sp[:bottom_margin]
+            dx += lpad
+            dy += tpad
+            axis_height = sp_height - (tpad + bpad)
+            axis_width = sp_width - (rpad + lpad)
+
             cstr = plot_color(sp[:background_color_legend])
             a = alpha(cstr)
             fg_alpha = alpha(plot_color(sp[:foreground_color_legend]))
@@ -162,9 +170,9 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 "xshift" => string(dx),
                 "yshift" => string(-dy),
             )
-            sp_width > 0 * mm ? push!(axis_opt, "width" => string(sp_width)) :
+            sp_width > 0 * mm ? push!(axis_opt, "width" => string(axis_width)) :
             nothing
-            sp_height > 0 * mm ? push!(axis_opt, "height" => string(sp_height)) :
+            sp_height > 0 * mm ? push!(axis_opt, "height" => string(axis_height)) :
             nothing
             # legend position
             if sp[:legend] isa Tuple
@@ -1137,12 +1145,12 @@ end
 # Set the (left, top, right, bottom) minimum padding around the plot area
 # to fit ticks, tick labels, guides, colorbars, etc.
 function _update_min_padding!(sp::Subplot{PGFPlotsXBackend})
-    # TODO: make padding more intelligent
-    # TODO: how to include margins properly?
-    # sp.minpad = (50mm + sp[:left_margin],
-    #              0mm + sp[:top_margin],
-    #              50mm + sp[:right_margin],
-    #              0mm + sp[:bottom_margin])
+    leg = sp[:legend]
+    if leg in (:best, :outertopright, :outerright, :outerbottomright) || (leg isa Tuple && leg[1] >= 1)
+        sp.minpad = (0mm, 0mm, 5mm, 0mm)
+    else
+        sp.minpad = (0mm, 0mm, 0mm, 0mm)
+    end
 end
 
 function _create_backend_figure(plt::Plot{PGFPlotsXBackend})

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -104,14 +104,12 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
         end
 
         for sp in plt.subplots
-            bb = bbox(sp)
-            sp_width = width(bb)
-            sp_height = height(bb)
+            bb1 = sp.plotarea
+            bb2 = bbox(sp)
+            sp_width = (width(bb1) + width(bb2)) / 2
+            sp_height = (height(bb1) + height(bb2)) / 2
             dx, dy = bbox(sp).x0
-            # TODO: does this hold at every scale?
-            # if sp[:legend] in (:outertopright, nothing)
-            #     dx *= 1.2
-            # end
+            
             cstr = plot_color(sp[:background_color_legend])
             a = alpha(cstr)
             fg_alpha = alpha(plot_color(sp[:foreground_color_legend]))

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -958,6 +958,7 @@ _backend_skips = Dict(
     :pgfplots => [2, 5, 6, 10, 16, 20, 22, 23, 25, 28, 30, 31, 34, 37, 38, 39],
     :pgfplotsx => [ 6, # images
                     10, # histogram2d
+                    16, # pgfplots thinks the upper panel is too small
                     22, # contourf
                     23, # pie
                     32, # spy


### PR DESCRIPTION
Should fix layouting. Currently looks not too bad, but e.g.
```julia
plot(randn(100, 5), layout=@layout([a{0.1h}; b [c; d e]]), t=[:line :histogram :scatter :steppre :bar], leg=false, ticks=nothing, border=:none)
```
errors.

Fix: https://github.com/JuliaPlots/Plots.jl/issues/2482