### PR TITLE
Make type recipes aware of current axes.

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -224,6 +224,24 @@ end
 # don't do anything for ints or floats
 _apply_type_recipe(plotattributes, v::AbstractArray{T}, letter) where {T<:Union{Integer,AbstractFloat}} = v
 
+# axis args before type recipes should still be mapped to all axes
+function _preprocess_axis_args!(plotattributes)
+    replaceAliases!(plotattributes, _keyAliases)
+    for (k, v) in plotattributes
+        if haskey(_axis_defaults, k)
+            pop!(plotattributes, k)
+            for l in (:x, :y, :z)
+                lk = Symbol(l, k)
+                haskey(plotattributes, lk) || (plotattributes[lk] = v)
+            end
+        end
+    end
+end
+function _preprocess_axis_args!(plotattributes, letter)
+    plotattributes[:letter] = letter
+    _preprocess_axis_args!(plotattributes)
+end
+
 # axis args in type recipes should only be applied to the current axis
 function _postprocess_axis_args!(plotattributes, letter)
     pop!(plotattributes, :letter)
@@ -233,21 +251,6 @@ function _postprocess_axis_args!(plotattributes, letter)
             if haskey(_axis_defaults, k)
                 pop!(plotattributes, k)
                 lk = Symbol(letter, k)
-                haskey(plotattributes, lk) || (plotattributes[lk] = v)
-            end
-        end
-    end
-end
-
-# axis args before type recipes should still be mapped to all axes
-function _preprocess_axis_args!(plotattributes, letter)
-    replaceAliases!(plotattributes, _keyAliases)
-    plotattributes[:letter] = letter
-    for (k, v) in plotattributes
-        if haskey(_axis_defaults, k)
-            pop!(plotattributes, k)
-            for l in (:x, :y, :z)
-                lk = Symbol(l, k)
                 haskey(plotattributes, lk) || (plotattributes[lk] = v)
             end
         end

--- a/src/series.jl
+++ b/src/series.jl
@@ -20,6 +20,7 @@ function prepareSeriesData(a::AbstractArray{<:MaybeNumber})
     f = isimmutable(a) ? replace : replace!
     a = f(x -> ismissing(x) || isinf(x) ? NaN : x, map(float, a))
 end
+prepareSeriesData(a::AbstractArray{<:Missing}) = fill(NaN, axes(a))
 prepareSeriesData(a::AbstractArray{<:MaybeString}) = replace(x -> ismissing(x) ? "" : x, a)
 prepareSeriesData(s::Surface{<:AMat{<:MaybeNumber}}) = Surface(prepareSeriesData(s.surf))
 prepareSeriesData(s::Surface) = s  # non-numeric Surface, such as an image
@@ -222,7 +223,7 @@ end
 # end
 
 # don't do anything for ints or floats
-_apply_type_recipe(plotattributes, v::AbstractArray{T}, letter) where {T<:Union{Integer,AbstractFloat}} = v
+_apply_type_recipe(plotattributes, v::AbstractArray{<:DataPoint}, letter) = v
 
 # axis args before type recipes should still be mapped to all axes
 function _preprocess_axis_args!(plotattributes)


### PR DESCRIPTION
Temporarily store the current axis letter symbol in `plotattributes`, so type recipes can use this information.

An example where this could be useful:
Consider a `Measurement` type with `value` and `uncertainty`
```julia
struct Measurement
    val::Float64
    err::Float64
end

value(m::Measurement) = m.val
uncertainty(m::Measurement) = m.err
```
Now we can define a vector type recipe.
```julia
@recipe function f(::Type{T}, m::T) where T <: AbstractArray{<:Measurement}
    error_sym = Symbol(plotattributes[:letter], :error)
    plotattributes[error_sym] = uncertainty.(m)
    value.(m)
end
```
This is probably more composible and convenient for package authors than defining user recipes for all combinations of signatures, as it is done in [Measurements.jl](https://github.com/JuliaPhysics/Measurements.jl/blob/master/src/plot-recipes.jl) right now.

```julia
ms1 = Measurement.(10rand(10), rand(10))
ms2 = Measurement.(10rand(10), rand(10))
```
```julia
scatter(ms1)
```
![yerror](https://user-images.githubusercontent.com/16589944/77536182-3caac700-6e9c-11ea-8f6f-57cd0f4ffd7d.png)
```julia
scatter(ms1, rand(10))
```
![xerror](https://user-images.githubusercontent.com/16589944/77536271-6237d080-6e9c-11ea-8ad6-a629a306dc5f.png)
```julia
scatter(ms1, ms2)
```
![xyerror](https://user-images.githubusercontent.com/16589944/77536288-67951b00-6e9c-11ea-9b23-92395d769b1c.png)
