### PR TITLE
Warn on aliases in recipes

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -934,8 +934,8 @@ function _add_markershape(plotattributes::AKW)
 end
 
 "Handle all preprocessing of args... break out colors/sizes/etc and replace aliases."
-function preprocessArgs!(plotattributes::AKW, replace_aliases = true)
-    replace_aliases && replaceAliases!(plotattributes, _keyAliases)
+function preprocessArgs!(plotattributes::AKW)
+    replaceAliases!(plotattributes, _keyAliases)
 
     # clear all axis stuff
     # if haskey(plotattributes, :axis) && plotattributes[:axis] in (:none, nothing, false)

--- a/src/args.jl
+++ b/src/args.jl
@@ -460,6 +460,24 @@ is_axis_attr_noletter(k) = haskey(_axis_defaults, k)
 
 RecipesBase.is_key_supported(k::Symbol) = is_attr_supported(k)
 
+const _internal_args =
+    [:plot_object, :series_plotindex, :markershape_to_add, :letter, :idxfilter]
+const _magic_axis_args = [:axis, :tickfont, :guidefont]
+const _magic_subplot_args = [:titlefont, :legendfont, :legendtitlefont, ]
+const _magic_series_args = [:line, :marker, :fill]
+
+function is_default_attribute(k::Symbol)
+    k in _internal_args && return true
+    k in _all_args && return true
+    is_axis_attr(k) && return true
+    is_axis_attr_noletter(k) && return true
+    k in _magic_axis_args && return true
+    k in _magic_subplot_args && return true
+    k in _magic_series_args && return true
+    Symbol(chop(string(k); head = 1, tail = 0)) in _magic_axis_args && return true
+    return false
+end
+
 # -----------------------------------------------------------------------------
 
 makeplural(s::Symbol) = Symbol(string(s,"s"))
@@ -1014,6 +1032,16 @@ function preprocessArgs!(plotattributes::AKW, replace_aliases = true)
             args = pop_kw!(plotattributes, Symbol(letter, fontname), ())
             for arg in wraptuple(args)
                 processFontArg!(plotattributes, Symbol(letter, fontname), arg)
+            end
+        end
+    end
+    # handle axes guides
+    if haskey(plotattributes, :guide)
+        guide = pop!(plotattributes, :guide)
+        for letter in (:x, :y, :z)
+            guide_sym = Symbol(letter, :guide)
+            if !is_explicit(plotattributes, guide_sym)
+                plotattributes[guide_sym] = guide
             end
         end
     end

--- a/src/args.jl
+++ b/src/args.jl
@@ -466,12 +466,17 @@ const _magic_axis_args = [:axis, :tickfont, :guidefont]
 const _magic_subplot_args = [:titlefont, :legendfont, :legendtitlefont, ]
 const _magic_series_args = [:line, :marker, :fill]
 
-function is_default_attribute(k::Symbol)
+function is_noletter_attribute(k)
+    is_axis_attr_noletter(k) && return true
+    k in _magic_axis_args && return true
+    return false
+end
+
+function is_default_attribute(k)
     k in _internal_args && return true
     k in _all_args && return true
     is_axis_attr(k) && return true
-    is_axis_attr_noletter(k) && return true
-    k in _magic_axis_args && return true
+    is_noletter_attribute(k) && return true
     k in _magic_subplot_args && return true
     k in _magic_series_args && return true
     Symbol(chop(string(k); head = 1, tail = 0)) in _magic_axis_args && return true

--- a/src/args.jl
+++ b/src/args.jl
@@ -916,8 +916,8 @@ function _add_markershape(plotattributes::AKW)
 end
 
 "Handle all preprocessing of args... break out colors/sizes/etc and replace aliases."
-function preprocessArgs!(plotattributes::AKW)
-    replaceAliases!(plotattributes, _keyAliases)
+function preprocessArgs!(plotattributes::AKW, replace_aliases = true)
+    replace_aliases && replaceAliases!(plotattributes, _keyAliases)
 
     # clear all axis stuff
     # if haskey(plotattributes, :axis) && plotattributes[:axis] in (:none, nothing, false)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -96,7 +96,7 @@ function _process_userrecipe(plt::Plot, kw_list::Vector{KW}, recipedata::RecipeD
     # when the arg tuple is empty, that means there's nothing left to recursively
     # process... finish up and add to the kw_list
     kw = recipedata.plotattributes
-    preprocessArgs!(kw)
+    preprocessArgs!(kw, false)
     _preprocess_userrecipe(kw)
     warnOnUnsupported_scales(plt.backend, kw)
 
@@ -185,7 +185,7 @@ function _process_plotrecipe(plt::Plot, kw::AKW, kw_list::Vector{KW}, still_to_p
         st = kw[:seriestype] = get(_typeAliases, st, st)
         datalist = RecipesBase.apply_recipe(kw, Val{st}, plt)
         for data in datalist
-            preprocessArgs!(data.plotattributes)
+            preprocessArgs!(data.plotattributes, false)
             if data.plotattributes[:seriestype] == st
                 error("Plot recipe $st returned the same seriestype: $(data.plotattributes)")
             end
@@ -413,7 +413,7 @@ function _process_seriesrecipe(plt::Plot, plotattributes::AKW)
         # assuming there was no error, recursively apply the series recipes
         for data in datalist
             if isa(data, RecipeData)
-                preprocessArgs!(data.plotattributes)
+                preprocessArgs!(data.plotattributes, false)
                 if data.plotattributes[:seriestype] == st
                     error("The seriestype didn't change in series recipe $st.  This will cause a StackOverflow.")
                 end

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -122,7 +122,7 @@ function _process_userrecipe(plt::Plot, kw_list::Vector{KW}, recipedata::RecipeD
     # when the arg tuple is empty, that means there's nothing left to recursively
     # process... finish up and add to the kw_list
     kw = recipedata.plotattributes
-    preprocessArgs!(kw, false)
+    preprocessArgs!(kw)
     _preprocess_userrecipe(kw)
     warnOnUnsupported_scales(plt.backend, kw)
 
@@ -212,7 +212,7 @@ function _process_plotrecipe(plt::Plot, kw::AKW, kw_list::Vector{KW}, still_to_p
         datalist = RecipesBase.apply_recipe(kw, Val{st}, plt)
         warn_on_recipe_aliases!(datalist, :plot, st)
         for data in datalist
-            preprocessArgs!(data.plotattributes, false)
+            preprocessArgs!(data.plotattributes)
             if data.plotattributes[:seriestype] == st
                 error("Plot recipe $st returned the same seriestype: $(data.plotattributes)")
             end
@@ -442,7 +442,7 @@ function _process_seriesrecipe(plt::Plot, plotattributes::AKW)
         # assuming there was no error, recursively apply the series recipes
         for data in datalist
             if isa(data, RecipeData)
-                preprocessArgs!(data.plotattributes, false)
+                preprocessArgs!(data.plotattributes)
                 if data.plotattributes[:seriestype] == st
                     error("The seriestype didn't change in series recipe $st.  This will cause a StackOverflow.")
                 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1261,8 +1261,8 @@ end
     yflip := true
     aspect_ratio := 1
     rs, cs, zs = findnz(z.surf)
-    xlim := ignorenan_extrema(cs)
-    ylim := ignorenan_extrema(rs)
+    xlims := ignorenan_extrema(cs)
+    ylims := ignorenan_extrema(rs)
     if plotattributes[:markershape] == :none
         markershape := :circle
     end

--- a/src/series.jl
+++ b/src/series.jl
@@ -231,7 +231,7 @@ _apply_type_recipe(plotattributes, v::AbstractArray{<:DataPoint}, letter) = v
 # axis args before type recipes should still be mapped to all axes
 function _preprocess_axis_args!(plotattributes)
     for (k, v) in plotattributes
-        if haskey(_axis_defaults, k)
+        if is_noletter_attribute(k)
             pop!(plotattributes, k)
             for l in (:x, :y, :z)
                 lk = Symbol(l, k)
@@ -250,7 +250,7 @@ function _postprocess_axis_args!(plotattributes, letter)
     pop!(plotattributes, :letter)
     if letter in (:x, :y, :z)
         for (k, v) in plotattributes
-            if haskey(_axis_defaults, k)
+            if is_noletter_attribute(k)
                 pop!(plotattributes, k)
                 lk = Symbol(letter, k)
                 haskey(plotattributes, lk) || (plotattributes[lk] = v)

--- a/src/series.jl
+++ b/src/series.jl
@@ -178,6 +178,7 @@ end
 function _apply_type_recipe(plotattributes, v, letter)
     _preprocess_axis_args!(plotattributes, letter)
     rdvec = RecipesBase.apply_recipe(plotattributes, typeof(v), v)
+    warn_on_recipe_aliases!(plotattributes, :type, typeof(v))
     _postprocess_axis_args!(plotattributes, letter)
     return rdvec[1].args[1]
 end
@@ -189,11 +190,13 @@ function _apply_type_recipe(plotattributes, v::AbstractArray, letter)
     _preprocess_axis_args!(plotattributes, letter)
     # First we try to apply an array type recipe.
     w = RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
+    warn_on_recipe_aliases!(plotattributes, :type, typeof(v))
     # If the type did not change try it element-wise
     if typeof(v) == typeof(w)
         isempty(skipmissing(v)) && return Float64[]
         x = first(skipmissing(v))
         args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
+        warn_on_recipe_aliases!(plotattributes, :type, typeof(x))
         _postprocess_axis_args!(plotattributes, letter)
         if length(args) == 2 && all(arg -> arg isa Function, args)
             numfunc, formatter = args

--- a/src/series.jl
+++ b/src/series.jl
@@ -227,7 +227,6 @@ _apply_type_recipe(plotattributes, v::AbstractArray{<:DataPoint}, letter) = v
 
 # axis args before type recipes should still be mapped to all axes
 function _preprocess_axis_args!(plotattributes)
-    replaceAliases!(plotattributes, _keyAliases)
     for (k, v) in plotattributes
         if haskey(_axis_defaults, k)
             pop!(plotattributes, k)
@@ -247,7 +246,6 @@ end
 function _postprocess_axis_args!(plotattributes, letter)
     pop!(plotattributes, :letter)
     if letter in (:x, :y, :z)
-        replaceAliases!(plotattributes, _keyAliases)
         for (k, v) in plotattributes
             if haskey(_axis_defaults, k)
                 pop!(plotattributes, k)

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,8 +26,9 @@ struct Attr <: AbstractDict{Symbol,Any}
     defaults::KW
 end
 
-Base.getindex(attr::Attr, k) = haskey(attr.explicit,k) ?
-                                     attr.explicit[k] : attr.defaults[k]
+function Base.getindex(attr::Attr, k)
+    return haskey(attr.explicit, k) ? attr.explicit[k] : attr.defaults[k]
+end
 Base.haskey(attr::Attr, k) = haskey(attr.explicit,k) || haskey(attr.defaults,k)
 Base.get(attr::Attr, k, default) = haskey(attr, k) ? attr[k] : default
 function Base.get!(attr::Attr, k, default)
@@ -41,7 +42,7 @@ end
 function Base.delete!(attr::Attr, k)
     haskey(attr.explicit, k) && delete!(attr.explicit, k)
     haskey(attr.defaults, k) && delete!(attr.defaults, k)
-end 
+end
 Base.length(attr::Attr) = length(union(keys(attr.explicit), keys(attr.defaults)))
 function Base.iterate(attr::Attr)
     exp_keys = keys(attr.explicit)


### PR DESCRIPTION
So, I decided to warn if an alias is detected in a recipe, hint to the recipe signature, and recommend to use the default attribute. This way it's not breaking, but probably annoying enough for Recipe authors to switch to default attributes. Btw, even we used aliases in the spy recipe :smile: 

In action:
```julia
julia> using Plots

julia> struct MyVec
           v::Vector{Float64}
       end

julia> @recipe function f(vec::MyVec)
           color --> :red
           vec.v
       end

julia> plot(MyVec(rand(5)), color = :blue)
┌ Warning: Alias detected in recipe.
│ The attribute alias `color` is used in the user recipe for the signature (::Tuple{MyVec}).
│ To ensure expected behavior it is recommended to use the default attribute `seriescolor`.
└ @ Plots ~/.julia/dev/Plots/src/pipeline.jl:7

julia> struct MyType
           x::Float64
       end

julia> @recipe function f(::Type{MyType}, mt::MyType)
           color --> :red
           mt -> mt.x, x -> string(round(x, digits = 6))
       end

julia> plot(MyType.(rand(5)), color = :blue)
┌ Warning: Alias detected in recipe.
│ The attribute alias `color` is used in the type recipe for the signature (::Type{MyType}, ::MyType).
│ To ensure expected behavior it is recommended to use the default attribute `seriescolor`.
└ @ Plots ~/.julia/dev/Plots/src/pipeline.jl:7

julia> @recipe function f(::Type{T}, mtv::T) where T <: AbstractArray{MyType}
           color --> :red
           getproperty.(mtv, :x)
       end

julia> plot(MyType.(rand(5)), color = :blue)
┌ Warning: Alias detected in recipe.
│ The attribute alias `color` is used in the type recipe for the signature (::Type{Array{MyType,1}}, ::Array{MyType,1}).
│ To ensure expected behavior it is recommended to use the default attribute `seriescolor`.
└ @ Plots ~/.julia/dev/Plots/src/pipeline.jl:7

julia> @recipe function f(::Type{Val{:myplot}}, plt::AbstractPlot)
           st := :path
           color --> :red
       end

julia> plot(rand(5), st = :myplot, color = :blue)
┌ Warning: Alias detected in recipe.
│ The attribute alias `st` is used in the plot recipe for the signature (::Type{Val{:myplot}}, ::AbstractPlot).
│ To ensure expected behavior it is recommended to use the default attribute `seriestype`.
└ @ Plots ~/.julia/dev/Plots/src/pipeline.jl:7
┌ Warning: Alias detected in recipe.
│ The attribute alias `color` is used in the plot recipe for the signature (::Type{Val{:myplot}}, ::AbstractPlot).
│ To ensure expected behavior it is recommended to use the default attribute `seriescolor`.
└ @ Plots ~/.julia/dev/Plots/src/pipeline.jl:7

julia> @recipe function f(::Type{Val{:myseries}}, x, y, z)
           st := :path
           color --> :red
       end

julia> plot(rand(5), st = :myseries, color = :blue)
┌ Warning: Alias detected in recipe.
│ The attribute alias `st` is used in the series recipe for the signature (::Type{Val{:myseries}}, x, y, z).
│ To ensure expected behavior it is recommended to use the default attribute `seriestype`.
└ @ Plots ~/.julia/dev/Plots/src/pipeline.jl:7
┌ Warning: Alias detected in recipe.
│ The attribute alias `color` is used in the series recipe for the signature (::Type{Val{:myseries}}, x, y, z).
│ To ensure expected behavior it is recommended to use the default attribute `seriescolor`.
└ @ Plots ~/.julia/dev/Plots/src/pipeline.jl:7
```