### PR TITLE
use -O1 for code in Plots.jl

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -1,5 +1,9 @@
 module Plots
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
+    @eval Base.Experimental.@optlevel 1
+end
+
 const _current_plots_version = VersionNumber(split(first(filter(line -> occursin("version", line), readlines(normpath(@__DIR__, "..", "Project.toml")))), "\"")[2])
 
 using Reexport


### PR DESCRIPTION
On julia master this reduces the time to first plot for me by about 5 seconds. So far I have not detected any measurable slowdowns e.g. for plotting many points (the drawing itself inside gksterm is by far the limiting factor).