### PR TITLE
Implement zerror and surface type recipe fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Plots"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 author = ["Tom Breloff (@tbreloff)"]
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/args.jl
+++ b/src/args.jl
@@ -267,6 +267,7 @@ const _series_defaults = KW(
     :bar_edges         => false,
     :xerror            => nothing,
     :yerror            => nothing,
+    :zerror            => nothing,
     :ribbon            => nothing,
     :quiver            => nothing,
     :arrow             => nothing,   # allows for adding arrows to line/path... call `arrow(args...)`
@@ -593,6 +594,7 @@ add_aliases(:color_palette, :palette)
 add_aliases(:overwrite_figure, :clf, :clearfig, :overwrite, :reuse)
 add_aliases(:xerror, :xerr, :xerrorbar)
 add_aliases(:yerror, :yerr, :yerrorbar, :err, :errorbar)
+add_aliases(:zerror, :zerr, :zerrorbar)
 add_aliases(:quiver, :velocity, :quiver2d, :gradient, :vectorfield)
 add_aliases(:normalize, :norm, :normed, :normalized)
 add_aliases(:show_empty_bins, :showemptybins, :showempty, :show_empty)

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -211,7 +211,7 @@ const _base_supported_args = [
     :seriestype,
     :seriescolor, :seriesalpha,
     :smooth,
-    :xerror, :yerror,
+    :xerror, :yerror, :zerror,
     :subplot,
     :x, :y, :z,
     :show, :size,

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -946,6 +946,43 @@ const _examples = PlotExample[
             end,
         ],
     ),
+    PlotExample(
+        "Error bars and array type recipes",
+        "",
+        [
+            quote
+                begin
+                    struct Measurement <: Number
+                        val::Float64
+                        err::Float64
+                    end
+                    value(m::Measurement) = m.val
+                    uncertainty(m::Measurement) = m.err
+
+                    @recipe function f(::Type{T}, m::T) where T <: AbstractArray{<:Measurement}
+                        if !(get(plotattributes, :seriestype, :path) in [:contour, :contourf, :contour3d, :heatmap, :surface, :wireframe, :image])
+                            error_sym = Symbol(plotattributes[:letter], :error)
+                            plotattributes[error_sym] = uncertainty.(m)
+                        end
+                        value.(m)
+                    end
+
+                    x = Measurement.(10sort(rand(10)), rand(10))
+                    y = Measurement.(10sort(rand(10)), rand(10))
+                    z = Measurement.(10sort(rand(10)), rand(10))
+                    surf = Measurement.((1:10) .* (1:10)', rand(10,10))
+
+                    plot(
+                        scatter(x, [x y], msw = 0),
+                        scatter(x, y, z, msw = 0),
+                        heatmap(x, y, surf),
+                        wireframe(x, y, surf),
+                        legend = :topleft
+                    )
+                end
+            end,
+        ],
+    ),
 ]
 
 # Some constants for PlotDocs and PlotReferenceImages

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -159,7 +159,7 @@ end
 function _add_errorbar_kw(kw_list::Vector{KW}, kw::AKW)
     # handle error bars by creating new recipedata data... these will have
     # the same recipedata index as the recipedata they are copied from
-    for esym in (:xerror, :yerror)
+    for esym in (:xerror, :yerror, :zerror)
         if get(kw, esym, nothing) !== nothing
             # we make a copy of the KW and apply an errorbar recipe
             errkw = copy(kw)

--- a/src/series.jl
+++ b/src/series.jl
@@ -219,13 +219,14 @@ end
 _apply_type_recipe(
     plotattributes,
     v::Surface{<:AMat{<:Union{AbstractFloat, Integer, AbstractString, Missing}}},
+    letter,
 ) = v
-function _apply_type_recipe(plotattributes, v::Surface)
-    ret = _apply_type_recipe(plotattributes, v.surf)
+function _apply_type_recipe(plotattributes, v::Surface, letter)
+    ret = _apply_type_recipe(plotattributes, v.surf, letter)
     if typeof(ret) <: Formatted
         Formatted(Surface(ret.data), ret.formatter)
     else
-        Surface(ret.data)
+        Surface(ret)
     end
 end
 


### PR DESCRIPTION
```julia
using Plots

struct Measurement <: Number
    val::Float64
    err::Float64
end
value(m::Measurement) = m.val
uncertainty(m::Measurement) = m.err

@recipe function f(::Type{T}, m::T) where T <: AbstractArray{<:Measurement}
    if !(get(plotattributes, :seriestype, :path) in [:contour, :contourf, :contour3d, :heatmap, :surface, :wireframe, :image])
        error_sym = Symbol(plotattributes[:letter], :error)
        plotattributes[error_sym] = uncertainty.(m)
    end
    value.(m)
end

x = Measurement.(10sort(rand(10)), rand(10))
y = Measurement.(10sort(rand(10)), rand(10))
z = Measurement.(10sort(rand(10)), rand(10))
surf = Measurement.((1:10) .* (1:10)', rand(10,10))

plot(
    scatter(x, [x y], msw = 0),
    scatter(x, y, z, msw = 0),
    heatmap(x, y, surf),
    wireframe(x, y, surf),
    legend = :topleft
)
```
![](https://raw.githubusercontent.com/JuliaPlots/PlotReferenceImages.jl/master/Plots/gr/1.0.3/ref45.png)

cc: @briochemc