### PR TITLE
guidefontrotation fix for pyplot

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1110,6 +1110,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             end
             pyaxis."label"."set_fontsize"(py_thickness_scale(plt, axis[:guidefontsize]))
             pyaxis."label"."set_family"(axis[:guidefontfamily])
+            pyaxis."label"."set_rotation"(axis[:guidefontrotation])
             for lab in getproperty(ax, Symbol("get_", letter, "ticklabels"))()
                 lab."set_fontsize"(py_thickness_scale(plt, axis[:tickfontsize]))
                 lab."set_family"(axis[:tickfontfamily])


### PR DESCRIPTION
Fixes guide rotation for pyplot (https://github.com/JuliaPlots/Plots.jl/issues/1527)
plot(rand(10), rand(10), yguide="yguide", xguide="xguide", yguidefontrotation=45, xguidefontrotation="-45")
![Figure_1](https://user-images.githubusercontent.com/24591123/79062663-33608d80-7cd7-11ea-95da-c3698fd2ec45.png)
