### PR TITLE
Isen dev

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1113,7 +1113,13 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             end
             pyaxis."label"."set_fontsize"(py_thickness_scale(plt, axis[:guidefontsize]))
             pyaxis."label"."set_family"(axis[:guidefontfamily])
-            pyaxis."label"."set_rotation"(axis[:guidefontrotation])
+
+            if (letter == :y && !RecipesPipeline.is3d(sp))
+                pyaxis."label"."set_rotation"(axis[:guidefontrotation] + 90)
+            else
+                pyaxis."label"."set_rotation"(axis[:guidefontrotation])
+            end
+
             for lab in getproperty(ax, Symbol("get_", letter, "ticklabels"))()
                 lab."set_fontsize"(py_thickness_scale(plt, axis[:tickfontsize]))
                 lab."set_family"(axis[:tickfontfamily])


### PR DESCRIPTION
markerstrokealpha is no longer ignored: https://github.com/JuliaPlots/Plots.jl/issues/2447
Though, does not work in GR.
Omitting `markerstrokealpha` from keywords still works (naturally).

```
scatter(rand(3), rand(3), markerstrokealpha = .5, m=:star, 
markersize=100, markerstrokewidth=10, lw=10)
```

![Figure_1](https://user-images.githubusercontent.com/24591123/79069737-881dfb80-7d0b-11ea-9fd4-7b515ecffa81.png)
