### PR TITLE
fixing default guidefontrotation direction for pyplot

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1113,7 +1113,13 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             end
             pyaxis."label"."set_fontsize"(py_thickness_scale(plt, axis[:guidefontsize]))
             pyaxis."label"."set_family"(axis[:guidefontfamily])
-            pyaxis."label"."set_rotation"(axis[:guidefontrotation])
+
+            if (letter == :y && !RecipesPipeline.is3d(sp))
+                pyaxis."label"."set_rotation"(axis[:guidefontrotation] + 90)
+            else
+                pyaxis."label"."set_rotation"(axis[:guidefontrotation])
+            end
+
             for lab in getproperty(ax, Symbol("get_", letter, "ticklabels"))()
                 lab."set_fontsize"(py_thickness_scale(plt, axis[:tickfontsize]))
                 lab."set_family"(axis[:tickfontfamily])


### PR DESCRIPTION
I forgot that I was working on the same branch when at #2567, so that PR should be ommited.

```
plot(1:10, 1:10, ylabel="ylab", xlabel="xlab")

plot(1:10, 1:10, 1:10, ylabel="ylab", xlabel="xlab",zlabel="zlab")

plot(1:10, 1:10, 1:10, ylabel="ylab", xlabel="xlab",zlabel="zlab", yguidefontrotation=15)
```
![Figure_1](https://user-images.githubusercontent.com/24591123/79220359-ce4f9800-7e8e-11ea-8e32-b7ec3f90a9c0.png)
![Figure_2](https://user-images.githubusercontent.com/24591123/79220362-cf80c500-7e8e-11ea-8532-99e0cc32a3a4.png)

![Figure_3](https://user-images.githubusercontent.com/24591123/79220426-ec1cfd00-7e8e-11ea-819c-431f43b5e0b7.png)