### PR TITLE
[pyplot] marker adjustments in the legend

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1303,25 +1303,29 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
             if should_add_to_legend(series)
                 clims = get_clims(sp, series)
                 # add a line/marker and a label
-                push!(handles, if series[:seriestype] == :shape || series[:fillrange] !== nothing
-                    pypatches."Patch"(
-                        edgecolor = py_color(single_color(get_linecolor(series, clims)), get_linealpha(series)),
-                        facecolor = py_color(single_color(get_fillcolor(series, clims)), get_fillalpha(series)),
-                        linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
-                        linestyle = py_linestyle(series[:seriestype], get_linestyle(series))
-                    )
-                elseif series[:seriestype] in (:path, :straightline, :scatter)
-                    PyPlot.plt."Line2D"((0,1),(0,0),
-                        color = py_color(single_color(get_linecolor(series, clims)), get_linealpha(series)),
-                        linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
-                        linestyle = py_linestyle(:path, get_linestyle(series)),
-                        marker = py_marker(_cycle(series[:markershape], 1)),  # Need to adjust markersize to match the legend box size
-                        markeredgecolor = py_color(single_color(get_markerstrokecolor(series)), get_markerstrokealpha(series)),
-                        markerfacecolor = py_color(single_color(get_markercolor(series, clims)), get_markeralpha(series))
-                    )
-                else
-                    series[:serieshandle][1]
-                end)
+                push!(handles,
+                    if series[:seriestype] == :shape || series[:fillrange] !== nothing
+                        pypatches."Patch"(
+                            edgecolor = py_color(single_color(get_linecolor(series, clims)), get_linealpha(series)),
+                            facecolor = py_color(single_color(get_fillcolor(series, clims)), get_fillalpha(series)),
+                            linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
+                            linestyle = py_linestyle(series[:seriestype], get_linestyle(series))
+                        )
+                    elseif series[:seriestype] in (:path, :straightline, :scatter)
+                        PyPlot.plt."Line2D"((0,1),(0,0),
+                            color = py_color(single_color(get_linecolor(series, clims)), get_linealpha(series)),
+                            linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
+                            linestyle = py_linestyle(:path, get_linestyle(series)),
+                            marker = py_marker(_cycle(series[:markershape], 1)),
+                            # markersize = py_thickness_scale(plt, series[:markersize]), # In case we decide that markersize needs to be scaled in the legend too
+                            markeredgecolor = py_color(single_color(get_markerstrokecolor(series)), get_markerstrokealpha(series)),
+                            markerfacecolor = py_color(single_color(get_markercolor(series, clims)), get_markeralpha(series)),
+                            markeredgewidth = py_thickness_scale(plt, series[:markerstrokewidth])
+                        )
+                    else
+                        series[:serieshandle][1]
+                    end
+                )
                 push!(labels, series[:label])
             end
         end


### PR DESCRIPTION
The `markerstroke` width is now adjusted in the legend for pyplot (with and without `thickness scaling`)