### PR TITLE
axis limits = :symmetric

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -530,7 +530,6 @@ function axis_limits(sp, letter, should_widen = default_should_widen(sp[Symbol(l
     ex = axis[:extrema]
     amin, amax = ex.emin, ex.emax
     lims = axis[:lims]
-    @show lims
     has_user_lims = (isa(lims, Tuple) || isa(lims, AVec)) && length(lims) == 2
     if has_user_lims
         lmin, lmax = lims

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -530,15 +530,23 @@ function axis_limits(sp, letter, should_widen = default_should_widen(sp[Symbol(l
     ex = axis[:extrema]
     amin, amax = ex.emin, ex.emax
     lims = axis[:lims]
+    @show lims
     has_user_lims = (isa(lims, Tuple) || isa(lims, AVec)) && length(lims) == 2
     if has_user_lims
         lmin, lmax = lims
-        if lmin != :auto && isfinite(lmin)
+        if lmin == :auto
+        elseif isfinite(lmin)
             amin = lmin
         end
-        if lmax != :auto && isfinite(lmax)
+        if lmax == :auto
+        elseif isfinite(lmax)
             amax = lmax
         end
+    end
+    if lims == :symmetric
+        aval = max(abs(amin), abs(amax))
+        amin = -aval
+        amax = aval
     end
     if amax <= amin && isfinite(amin)
         amax = amin + 1.0

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -31,3 +31,8 @@ end
     @test xticks(p) == yticks(p) == zticks(p) == [ticks1, ticks2]
     @test xticks(p[1]) == yticks(p[1]) == zticks(p[1]) == ticks1
 end
+
+@testset "Axis limits" begin
+    pl = plot(1:5, xlims=:symmetric, widen = false)
+    @test Plots.xlims(pl) == (-5, 5)
+end


### PR DESCRIPTION
I am not so sure about this one.
It is only a subset of @mkborregaard's ideal scenario (https://github.com/JuliaPlots/Plots.jl/issues/2505#issuecomment-604491221) and that we should also support `xlims = (:symmetric, 5)` or `xlims = (:symmetric, :round)`.
But that is a bit tricky.