### PR TITLE
Tick marks now scale according to thickness_scaling

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1101,7 +1101,10 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 ticks[2][ticks[1] .== 0] .= ""
             end
             axis[:ticks] != :native ? py_set_ticks(ax, ticks, letter) : nothing
-            pyaxis."set_tick_params"(direction = axis[:tick_direction] == :out ? "out" : "in")
+
+            intensity = 0.5  # This value corresponds to scaling of other grid elements
+            pyaxis."set_tick_params"(direction = axis[:tick_direction] == :out ? "out" : "in", width=py_thickness_scale(plt, intensity))
+
             getproperty(ax, Symbol("set_", letter, "label"))(axis[:guide])
             if get(axis.plotattributes, :flip, false)
                 getproperty(ax, Symbol("invert_", letter, "axis"))()


### PR DESCRIPTION
`scatter(rand(3), thickness_scaling=3)`

Before:

![before](https://user-images.githubusercontent.com/24591123/79776360-9786ef80-8370-11ea-8604-a2d86231e0d5.png)

After;
![after](https://user-images.githubusercontent.com/24591123/79776392-a4a3de80-8370-11ea-8d0e-13051189472f.png)

Subtle, but becomes obvious for larger `thickness_scaling` values

Relevant to https://github.com/JuliaPlots/Plots.jl/issues/2592