### PR TITLE
don't add .tex to .tikz

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -45,6 +45,7 @@ end
 eps(fn::AbstractString) = eps(current(), fn)
 
 function tex(plt::Plot, fn::AbstractString)
+  fn = addExtension(fn, "tex")
   io = open(fn, "w")
   show(io, MIME("application/x-tex"), plt)
   close(io)
@@ -102,7 +103,7 @@ end
 function addExtension(fn::AbstractString, ext::AbstractString)
   try
     oldext = getExtension(fn)
-    if oldext == ext
+    if _savemap[oldext] == ext
       return fn
     else
       return "$fn.$ext"

--- a/src/output.jl
+++ b/src/output.jl
@@ -103,7 +103,7 @@ end
 function addExtension(fn::AbstractString, ext::AbstractString)
   try
     oldext = getExtension(fn)
-    if _savemap[oldext] == ext
+    if string(_savemap[oldext]) == ext
       return fn
     else
       return "$fn.$ext"

--- a/src/output.jl
+++ b/src/output.jl
@@ -45,7 +45,6 @@ end
 eps(fn::AbstractString) = eps(current(), fn)
 
 function tex(plt::Plot, fn::AbstractString)
-  fn = addExtension(fn, "tex")
   io = open(fn, "w")
   show(io, MIME("application/x-tex"), plt)
   close(io)


### PR DESCRIPTION
If we reach this point, we already checked if the extension is existent.
This used to append `.tex` if saving as `.tikz` file, which is unwanted.
ref: https://github.com/KristofferC/PGFPlotsX.jl/issues/222