### PR TITLE
pyplot: legend marker scales independently 

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -539,7 +539,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     label = series[:label],
                     zorder = series[:series_plotindex] + 0.5,
                     marker = py_marker(_cycle(shapes,i)),
-                    s =  py_thickness_scale(plt, _cycle(series[:markersize],i) .^ 2),
+                    s =  py_thickness_scale(plt, _cycle(series[:markersize],i)).^ 2,
                     facecolors = py_color(get_markercolor(series, i), get_markercoloralpha(series, i)),
                     edgecolors = msc,
                     linewidths = lw,
@@ -570,7 +570,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                   push!(cur_y_list, _cycle(y,i))
 
                   push!(cur_color_list, _cycle(markercolor, i))
-                  push!(cur_scale_list, py_thickness_scale(plt, _cycle(series[:markersize],i) .^ 2))
+                  push!(cur_scale_list, py_thickness_scale(plt, _cycle(series[:markersize],i)).^ 2)
 
                   continue
                 end
@@ -580,7 +580,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                   zorder = series[:series_plotindex] + 0.5,
                   marker = prev_marker,
                   s = cur_scale_list,
-                  edgecolors = py_color(get_markerstrokecolor(series), get_markerstrokealpha(series)),  # Do we need include i?
+                  edgecolors = py_color(get_markerstrokecolor(series), get_markerstrokealpha(series)),
                   linewidths = py_thickness_scale(plt, series[:markerstrokewidth]),
                   facecolors = cur_color_list,
                   extrakw...
@@ -590,7 +590,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                 cur_y_list = [_cycle(y,i)]
 
                 cur_color_list = [_cycle(markercolor, i)]
-                cur_scale_list = [py_thickness_scale(plt, _cycle(series[:markersize],i) .^ 2)]
+                cur_scale_list = [py_thickness_scale(plt, _cycle(series[:markersize],i)) .^ 2]
 
                 prev_marker = cur_marker
             end
@@ -615,7 +615,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                 label = series[:label],
                 zorder = series[:series_plotindex] + 0.5,
                 marker = py_marker(series[:markershape]),
-                s = py_thickness_scale(plt, series[:markersize] .^ 2),
+                s = py_thickness_scale(plt, series[:markersize]) .^2,
                 edgecolors = py_color(get_markerstrokecolor(series), get_markerstrokealpha(series)),
                 linewidths = py_thickness_scale(plt, series[:markerstrokewidth]),
                 extrakw...
@@ -1320,10 +1320,10 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                             linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
                             linestyle = py_linestyle(:path, get_linestyle(series)),
                             marker = py_marker(_cycle(series[:markershape], 1)),
-                            markersize = py_thickness_scale(plt, 6), # 6 looks same the default
+                            markersize = py_thickness_scale(plt, 6), # 6 looks same the default, do not put ^2
                             markeredgecolor = py_color(single_color(get_markerstrokecolor(series)), get_markerstrokealpha(series)),
                             markerfacecolor = py_color(single_color(get_markercolor(series, clims)), get_markeralpha(series)),
-                            markeredgewidth = py_thickness_scale(plt, 1)
+                            markeredgewidth = py_thickness_scale(plt, 1.1)  # scales better
                         )
                     else
                         series[:serieshandle][1]

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1317,13 +1317,13 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                     elseif series[:seriestype] in (:path, :straightline, :scatter)
                         PyPlot.plt."Line2D"((0,1),(0,0),
                             color = py_color(single_color(get_linecolor(series, clims)), get_linealpha(series)),
-                            linewidth = py_thickness_scale(plt, clamp(sp[:legendfontsize]/10, 0, 5)),
+                            linewidth = py_thickness_scale(plt, sp[:legendfontsize] / 8),
                             linestyle = py_linestyle(:path, get_linestyle(series)),
                             marker = py_marker(_cycle(series[:markershape], 1)),
-                            markersize = py_thickness_scale(plt, sp[:legendfontsize]),
+                            markersize = py_thickness_scale(plt, 0.8 * sp[:legendfontsize]),
                             markeredgecolor = py_color(single_color(get_markerstrokecolor(series)), get_markerstrokealpha(series)),
                             markerfacecolor = py_color(single_color(get_markercolor(series, clims)), get_markeralpha(series)),
-                            markeredgewidth = py_thickness_scale(plt, series[:markerstrokewidth] * sp[:legendfontsize] / series[:markersize])   # retain the markersize/markerstroke ratio from the markers on the plot
+                            markeredgewidth = py_thickness_scale(plt, 0.8 * series[:markerstrokewidth] * sp[:legendfontsize] / series[:markersize])   # retain the markersize/markerstroke ratio from the markers on the plot
                         )
                     else
                         series[:serieshandle][1]

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1317,7 +1317,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                     elseif series[:seriestype] in (:path, :straightline, :scatter)
                         PyPlot.plt."Line2D"((0,1),(0,0),
                             color = py_color(single_color(get_linecolor(series, clims)), get_linealpha(series)),
-                            linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
+                            linewidth = py_thickness_scale(plt, clamp(sp[:legendfontsize]/10, 0, 5)),
                             linestyle = py_linestyle(:path, get_linestyle(series)),
                             marker = py_marker(_cycle(series[:markershape], 1)),
                             markersize = py_thickness_scale(plt, sp[:legendfontsize]),

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1323,7 +1323,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                             markersize = py_thickness_scale(plt, 6), # 6 looks same the default, do not put ^2
                             markeredgecolor = py_color(single_color(get_markerstrokecolor(series)), get_markerstrokealpha(series)),
                             markerfacecolor = py_color(single_color(get_markercolor(series, clims)), get_markeralpha(series)),
-                            markeredgewidth = py_thickness_scale(plt, 1.1)  # scales better
+                            markeredgewidth = py_thickness_scale(plt, series[:markerstrokewidth] * 6 / series[:markersize])   # retain the markersize/markerstroke ratio from the markers on the plot
                         )
                     else
                         series[:serieshandle][1]

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1320,10 +1320,10 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                             linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
                             linestyle = py_linestyle(:path, get_linestyle(series)),
                             marker = py_marker(_cycle(series[:markershape], 1)),
-                            markersize = py_thickness_scale(plt, 6), # 6 looks same the default, do not put ^2
+                            markersize = py_thickness_scale(plt, sp[:legendfontsize]),
                             markeredgecolor = py_color(single_color(get_markerstrokecolor(series)), get_markerstrokealpha(series)),
                             markerfacecolor = py_color(single_color(get_markercolor(series, clims)), get_markeralpha(series)),
-                            markeredgewidth = py_thickness_scale(plt, series[:markerstrokewidth] * 6 / series[:markersize])   # retain the markersize/markerstroke ratio from the markers on the plot
+                            markeredgewidth = py_thickness_scale(plt, series[:markerstrokewidth] * sp[:legendfontsize] / series[:markersize])   # retain the markersize/markerstroke ratio from the markers on the plot
                         )
                     else
                         series[:serieshandle][1]

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1320,10 +1320,10 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
                             linewidth = py_thickness_scale(plt, clamp(get_linewidth(series), 0, 5)),
                             linestyle = py_linestyle(:path, get_linestyle(series)),
                             marker = py_marker(_cycle(series[:markershape], 1)),
-                            # markersize = py_thickness_scale(plt, series[:markersize]), # In case we decide that markersize needs to be scaled in the legend too
+                            markersize = py_thickness_scale(plt, 6), # 6 looks same the default
                             markeredgecolor = py_color(single_color(get_markerstrokecolor(series)), get_markerstrokealpha(series)),
                             markerfacecolor = py_color(single_color(get_markercolor(series, clims)), get_markeralpha(series)),
-                            markeredgewidth = py_thickness_scale(plt, series[:markerstrokewidth])
+                            markeredgewidth = py_thickness_scale(plt, 1)
                         )
                     else
                         series[:serieshandle][1]


### PR DESCRIPTION
Fix: https://github.com/JuliaPlots/Plots.jl/issues/2592
markers in the legend scale independently (cannot be modified by the user). pyplot
Here are examples:
```
# Default case
scatter(rand(3), thickness_scaling=1)
```
![Figure_1](https://user-images.githubusercontent.com/24591123/80063761-940e8680-8571-11ea-8f37-51fd11894582.png)
```
scatter(rand(3), thickness_scaling=4)
```
![Figure_2](https://user-images.githubusercontent.com/24591123/80063798-b1435500-8571-11ea-9cd4-254de55b80eb.png)

Since the user has explicit control of the marker parameters on the actual plot, changing them as `thickness_scaling` increases is not critical.

However, I still that the marker size on the actual plot should somehow scale too, but this needs discussion again.