### PR TITLE
don't reset defaults with backend()

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -680,15 +680,14 @@ function default(k::Symbol, v)
     k in _suppress_warnings || error("Unknown key: ", k)
 end
 
-function default(; kw...)
-    if isempty(kw)
+function default(; reset = true, kw...)
+    if reset && isempty(kw)
         reset_defaults()
-    else
-        kw = KW(kw)
-        RecipesPipeline.preprocess_attributes!(kw)
-        for (k,v) in kw
-            default(k, v)
-        end
+    end
+    kw = KW(kw)
+    RecipesPipeline.preprocess_attributes!(kw)
+    for (k,v) in kw
+        default(k, v)
     end
 end
 

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -30,7 +30,7 @@ macro init_backend(s)
     esc(quote
         struct $T <: AbstractBackend end
         export $sym
-        $sym(; kw...) = (default(; kw...); backend($T()))
+        $sym(; kw...) = (default(; reset = false, kw...); backend($T()))
         backend_name(::$T) = Symbol($str)
         backend_package_name(pkg::$T) = backend_package_name(Symbol($str))
         push!(_backends, Symbol($str))


### PR DESCRIPTION
With  #2611 `plotly()` or `pgfplotsx()` etc reset the defaults. This means that everything in `PLOTS_DEFAULTS` is ignored after switching backends.
This fixes the issue.