### PR TITLE
Added webm support for animations.

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -108,6 +108,7 @@ export
     gif,
     mov,
     mp4,
+    webm,
     animate,
     @animate,
     @gif,

--- a/src/animation.jl
+++ b/src/animation.jl
@@ -24,6 +24,7 @@ end
 giffn() = (isijulia() ? "tmp.gif" : tempname()*".gif")
 movfn() = (isijulia() ? "tmp.mov" : tempname()*".mov")
 mp4fn() = (isijulia() ? "tmp.mp4" : tempname()*".mp4")
+webmfn() = (isijulia() ? "tmp.webm" : tempname()*".webm")
 
 mutable struct FrameIterator
     itr
@@ -63,6 +64,7 @@ file_extension(fn) = Base.Filesystem.splitext(fn)[2][2:end]
 gif(anim::Animation, fn = giffn(); kw...) = buildanimation(anim, fn; kw...)
 mov(anim::Animation, fn = movfn(); kw...) = buildanimation(anim, fn, false; kw...)
 mp4(anim::Animation, fn = mp4fn(); kw...) = buildanimation(anim, fn, false; kw...)
+webm(anim::Animation, fn = webmfn(); kw...) = buildanimation(anim, fn, false; kw...)
 
 ffmpeg_framerate(fps) = "$fps"
 ffmpeg_framerate(fps::Rational) = "$(fps.num)/$(fps.den)"
@@ -110,8 +112,8 @@ function Base.show(io::IO, ::MIME"text/html", agif::AnimatedGif)
     ext = file_extension(agif.filename)
     if ext == "gif"
         html = "<img src=\"data:image/gif;base64," * base64encode(read(agif.filename)) * "\" />"
-    elseif ext in ("mov", "mp4")
-        mimetype = ext == "mov" ? "video/quicktime" : "video/mp4"
+    elseif ext in ("mov", "mp4","webm")
+        mimetype = ext == "mov" ? "video/quicktime" : "video/$ext"
         html = "<video controls><source src=\"data:$mimetype;base64," *
                base64encode(read(agif.filename)) *
                "\" type = \"$mimetype\"></video>"


### PR DESCRIPTION
I tested it with the [circle example](https://docs.juliaplots.org/latest/animations/) (s/gif/webm/) and that seemed to work just fine.

However when I tried testing it in a Jupyter notebook (for viewing) the webm function didn't seem to be exported properly (while it is properly exported and usable in the REPL). This blocks the testing on that front (for me at least), unless anyone has a solution for that?