### PR TITLE
PyPlot: z-axis guidefontrotation only works for short labels Fix 2641

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1074,6 +1074,10 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             end
             pyaxis."label"."set_fontsize"(py_thickness_scale(plt, axis[:guidefontsize]))
             pyaxis."label"."set_family"(axis[:guidefontfamily])
+            
+            if (RecipesPipeline.is3d(sp))
+                pyaxis."set_rotate_label"(false)
+            end
 
             if (letter == :y && !RecipesPipeline.is3d(sp))
                 pyaxis."label"."set_rotation"(axis[:guidefontrotation] + 90)


### PR DESCRIPTION
Fixes https://github.com/JuliaPlots/Plots.jl/issues/2641
Justification:
https://stackoverflow.com/questions/21918380/rotating-axes-label-text-in-3d-matplotlib

PyPlot attempts to be smart and modifies user guidefont rotations if they are "out of bounds". This forces the rotations, so that everything is in the users hands.
```
plot(rand(10), rand(10), rand(10), st = :surface, zguide = "aaaaaaaaaaaaaaaa", yguide="aaa", xguide="a", zguidefontrotation = 180)
```
![image](https://user-images.githubusercontent.com/24591123/80994552-c70d2000-8e77-11ea-8c07-a53928be874e.png)
