### PR TITLE
Change color handling of error recipes

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1028,7 +1028,7 @@ end
 
 function error_style!(plotattributes::AKW)
     plotattributes[:seriestype] = :path
-    plotattributes[:linecolor] = plotattributes[:markerstrokecolor]
+    plotattributes[:markercolor] = plotattributes[:markerstrokecolor] 
     plotattributes[:linewidth] = plotattributes[:markerstrokewidth]
     plotattributes[:label] = ""
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -71,8 +71,9 @@ const POTENTIAL_VECTOR_ARGUMENTS = [
     :marker_z,
     :markerstrokecolor,
     :markerstrokealpha,
+    :xerror,
     :yerror,
-    :yerror,
+    :zerror,
     :series_annotations,
     :fillrange,
 ]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -75,7 +75,11 @@ function iter_segments(series::Series)
         if series[:seriestype] in (:scatter, :scatter3d)
             return [[i] for i in eachindex(y)]
         else
-            return [i:(i + 1) for i in firstindex(y):lastindex(y)-1]
+            if any(isnan,y)
+                return [iter_segments(y)...]
+            else
+                return [i:(i + 1) for i in firstindex(y):lastindex(y)-1]
+            end
         end
     else
         segs = UnitRange{Int}[]
@@ -439,7 +443,7 @@ end
     get_clims(::Series, op=Plots.ignorenan_extrema)
 
 Finds the limits for the colorbar by taking the "z-values" for the series and passing them into `op`,
-which must return the tuple `(zmin, zmax)`. The default op is the extrema of the finite 
+which must return the tuple `(zmin, zmax)`. The default op is the extrema of the finite
 values of the input.
 """
 function get_clims(series::Series, op=ignorenan_extrema)


### PR DESCRIPTION
This doesn't address the initial issue, that you get surprising output from
```julia
using Plots, Measurements
scatter( [1±2, 2±0.5, 3±0.1], color = [:red, :red, :blue], leg = false)
```
but at least one can fix it by being explicit
```julia
scatter( [2,3,4], [1±2, 2±0.5, 3±0.1], markercolor = [:red, :red, :blue], markerstrokecolor = :black, linecolor = :magenta, leg = false)
```
Still a bit mysterious, what happens, when you pass a vector to markerstrokecolor, but still better than before IMO.

fix: https://github.com/JuliaPlots/Plots.jl/issues/2429