### PR TITLE
pyplot hexbin

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -612,7 +612,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             alpha = series[:fillalpha],
             cmap = py_fillcolormap(series),  # applies to the pcolorfast object
             zorder = series[:series_plotindex],
-            extrakw...  # for some reason vmin and vmax are NaN??? hexbin works without passing vmin and vmax
+            # extrakw...  # We are not supporting clims for hexbin as calculation of bins is not trivial
         )
         push!(handles, handle)
     end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -612,7 +612,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             alpha = series[:fillalpha],
             cmap = py_fillcolormap(series),  # applies to the pcolorfast object
             zorder = series[:series_plotindex],
-            # extrakw...  # for some reason vmin and vmax are NaN???
+            extrakw...  # for some reason vmin and vmax are NaN??? hexbin works without passing vmin and vmax
         )
         push!(handles, handle)
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -460,7 +460,7 @@ end
 @deps plots_heatmap shape
 is_3d(::Type{Val{:plots_heatmap}}) = true
 RecipesPipeline.is_surface(::Type{Val{:plots_heatmap}}) = true
-
+RecipesPipeline.is_surface(::Type{Val{:hexbin}}) = true
 # ---------------------------------------------------------------------------
 # Histograms
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -448,7 +448,7 @@ values of the input.
 """
 function get_clims(series::Series, op=ignorenan_extrema)
     zmin, zmax = Inf, -Inf
-    z_colored_series = (:contour, :contour3d, :heatmap, :histogram2d, :surface)
+    z_colored_series = (:contour, :contour3d, :heatmap, :histogram2d, :surface, :hexbin)
     for vals in (series[:seriestype] in z_colored_series ? series[:z] : nothing, series[:line_z], series[:marker_z], series[:fill_z])
         if (typeof(vals) <: AbstractSurface) && (eltype(vals.surf) <: Union{Missing, Real})
             zmin, zmax = _update_clims(zmin, zmax, op(vals.surf)...)


### PR DESCRIPTION
Fixing https://github.com/JuliaPlots/Plots.jl/issues/2491
Currently after my accidental direct commit https://github.com/JuliaPlots/Plots.jl/commit/28ebc0ccd893f39ab9518d181ef8c3852ab02454  this works:

```
 hexbin(rand(1000), rand(1000), thickness_scaling=2, bins=(5,8))
```
Note, color is wrong
![image](https://user-images.githubusercontent.com/24591123/81213910-0f604580-9012-11ea-9fd9-c7a620403fb5.png)

However, specifying color directly helps
```
hexbin(rand(1000), rand(1000), thickness_scaling=2, bins=(5,8), c=:blues)
```
![image](https://user-images.githubusercontent.com/24591123/81214076-43d40180-9012-11ea-9491-00165a46bd92.png)

Additionally, `clims` are not calculated correctly too.
I cannot find `hexbin` recipe to try to understand how it gets processed in the `recipes.jl`

