### PR TITLE
Allow labels and titles to be passed as vectors on all backends

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1103,6 +1103,10 @@ function RecipesPipeline.preprocess_attributes!(plotattributes::AKW)
         plotattributes[:colorbar] = convertLegendValue(plotattributes[:colorbar])
     end
 
+    if haskey(plotattributes, :label) && plotattributes[:label] isa AbstractVector
+        plotattributes[:label] = permutedims(plotattributes[:label])
+    end
+
     # framestyle
     if haskey(plotattributes, :framestyle) && haskey(_framestyleAliases, plotattributes[:framestyle])
         plotattributes[:framestyle] = _framestyleAliases[plotattributes[:framestyle]]

--- a/src/args.jl
+++ b/src/args.jl
@@ -1103,8 +1103,11 @@ function RecipesPipeline.preprocess_attributes!(plotattributes::AKW)
         plotattributes[:colorbar] = convertLegendValue(plotattributes[:colorbar])
     end
 
-    if haskey(plotattributes, :label) && plotattributes[:label] isa AbstractVector
-        plotattributes[:label] = permutedims(plotattributes[:label])
+    # transpose vectors that are most certainly meant as row vector inputs
+    for k in (:label, :title)
+        if haskey(plotattributes, k) && plotattributes[k] isa AbstractVector
+            plotattributes[k] = permutedims(plotattributes[k])
+        end
     end
 
     # framestyle

--- a/test/test_pgfplotsx.jl
+++ b/test/test_pgfplotsx.jl
@@ -73,11 +73,11 @@ end
          zcolor = abs.(y .- 0.5),
          m = (:hot, 0.8, Plots.stroke(1, :green)),
          ms = 10 * abs.(y .- 0.5) .+ 4,
-         lab = ["grad", "", "ient"],
+         lab = "grad",
       )
       Plots._update_plot_object(pl)
       axis = Plots.pgfx_axes(pl.o)[1]
-      @test count(x -> x isa PGFPlotsX.LegendEntry, axis.contents) == 6
+      @test count(x -> x isa PGFPlotsX.LegendEntry, axis.contents) == 5
       @test count(x -> x isa PGFPlotsX.Plot, axis.contents) == 108 # each marker is its own plot, fillranges create 2 plot-objects
       marker = axis.contents[15]
       @test marker isa PGFPlotsX.Plot


### PR DESCRIPTION
fix #901

I know Plots has the "columns are series" philosophy but especially for titles and labels another interpretation than having each element of a vector map to a series/subplot does not really make sense and having to `permutedims` vectors of strings when passing multiple labels at once is a recurring gripe. So I think we can make an exception here.

See also https://github.com/JuliaPlots/Plots.jl/pull/2183 and https://github.com/JuliaPlots/Plots.jl/issues/901#issuecomment-616550691