### PR TITLE
pgfplotsx colorbar improvements

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -247,6 +247,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 push!(
                     axis_opt,
                     string("colorbar", pgfx_get_colorbar_pos(sp[:colorbar])) => nothing,
+                    "colorbar/width" => "2mm",
                     "colorbar style" => colorbar_style,
                     "point meta max" => get_clims(sp)[2],
                     "point meta min" => get_clims(sp)[1],

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -247,7 +247,6 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 push!(
                     axis_opt,
                     string("colorbar", pgfx_get_colorbar_pos(sp[:colorbar])) => nothing,
-                    "colorbar/width" => "2mm",
                     "colorbar style" => colorbar_style,
                     "point meta max" => get_clims(sp)[2],
                     "point meta min" => get_clims(sp)[1],

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -230,8 +230,6 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
             @label colorbar_end
 
             if hascolorbar(sp)
-                xcstr = plot_color(sp[:xaxis][:tickfontcolor])
-                ycstr = plot_color(sp[:yaxis][:tickfontcolor])
                 colorbar_style = PGFPlotsX.Options(
                     "title" => sp[:colorbar_title],
                     "xticklabel style" => pgfx_get_ticklabel_style(sp, sp[:xaxis]),


### PR DESCRIPTION
Allow to disable colorbar or set positions left, right, top and bottom. Furthermore, inherint colorbar ticklabel font from plot ticklabel font.

Before:
![pgfplotsx_colorbar_old](https://user-images.githubusercontent.com/16589944/81828267-e708a780-9539-11ea-92ed-f21412e23618.png)

Now: (difference is in the colorbar tick label font size)
![pgfplotsx_colorbar_new](https://user-images.githubusercontent.com/16589944/81828790-7b730a00-953a-11ea-96d7-3a109924acb2.png)

![pgfplotsx_colorbar_bottom](https://user-images.githubusercontent.com/16589944/81828811-829a1800-953a-11ea-8bde-c506264df5e0.png)

