### PR TITLE
Add support for mathjax (latex) and extra_plot_kwargs in plotly backend

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -374,6 +374,7 @@ function _initialize_backend(pkg::PlotlyBackend)
     catch
         @info "For saving to png with the Plotly backend ORCA has to be installed."
     end
+    push!(_plot_defaults, :include_mathjax => "")
 end
 
 const _plotly_attr = merge_with_base_supported([
@@ -417,6 +418,7 @@ const _plotly_attr = merge_with_base_supported([
     :tick_direction,
     :camera,
     :contour_labels,
+    :include_mathjax,
   ])
 
 const _plotly_seriestype = [

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -374,7 +374,6 @@ function _initialize_backend(pkg::PlotlyBackend)
     catch
         @info "For saving to png with the Plotly backend ORCA has to be installed."
     end
-    push!(_plot_defaults, :include_mathjax => "")
 end
 
 const _plotly_attr = merge_with_base_supported([
@@ -418,7 +417,6 @@ const _plotly_attr = merge_with_base_supported([
     :tick_direction,
     :camera,
     :contour_labels,
-    :include_mathjax,
   ])
 
 const _plotly_seriestype = [

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -328,7 +328,7 @@ function plotly_layout(plt::Plot)
             plotattributes_out[:direction] = "counterclockwise"
         end
 
-        plotattributes_out
+        plotattributes_out = recursive_merge(plotattributes_out, sp.attr[:extra_kwargs])
     end
 
     # turn off hover if nothing's using it

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -328,7 +328,7 @@ function plotly_layout(plt::Plot)
             plotattributes_out[:direction] = "counterclockwise"
         end
 
-        plotattributes_out = recursive_merge(plotattributes_out, sp.attr[:extra_kwargs])
+        plotattributes_out
     end
 
     # turn off hover if nothing's using it

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -810,7 +810,7 @@ html_body(plt::Plot{PlotlyBackend}) = plotly_html_body(plt)
 const ijulia_initialized = Ref(false)
 
 function plotly_html_head(plt::Plot)
-    local_file = ("file://" * plotly_local_file_path)
+    local_file = ("file:///" * plotly_local_file_path)
     plotly =
         use_local_dependencies[] ? local_file : "https://cdn.plot.ly/plotly-latest.min.js"
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -814,9 +814,9 @@ function plotly_html_head(plt::Plot)
     plotly =
         use_local_dependencies[] ? local_file : "https://cdn.plot.ly/plotly-latest.min.js"
 
-    include_mathjax = get(plt.attr, :include_mathjax, "")
+    include_mathjax = get(plt[:extra_plot_kwargs], :include_mathjax, "")
     mathjax_file = include_mathjax != "cdn" ? ("file://" * include_mathjax) : "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"
-    mathjax_head = include_mathjax == "" ? "" : "<script async src=\"$mathjax_file\"></script>\n\t\t"
+    mathjax_head = include_mathjax == "" ? "" : "<script src=\"$mathjax_file\"></script>\n\t\t"
 
     if isijulia() && !ijulia_initialized[]
         # using requirejs seems to be key to load a js depency in IJulia!

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -813,6 +813,11 @@ function plotly_html_head(plt::Plot)
     local_file = ("file://" * plotly_local_file_path)
     plotly =
         use_local_dependencies[] ? local_file : "https://cdn.plot.ly/plotly-latest.min.js"
+
+    include_mathjax = get(plt.attr, :include_mathjax, "")
+    mathjax_file = include_mathjax != "cdn" ? ("file://" * include_mathjax) : "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"
+    mathjax_head = include_mathjax == "" ? "" : "<script async src=\"$mathjax_file\"></script>\n\t\t"
+
     if isijulia() && !ijulia_initialized[]
         # using requirejs seems to be key to load a js depency in IJulia!
         # https://requirejs.org/docs/start.html
@@ -826,7 +831,7 @@ function plotly_html_head(plt::Plot)
         """)
         ijulia_initialized[] = true
     end
-    return "<script src=$(repr(plotly))></script>"
+    return "$mathjax_head<script src=$(repr(plotly))></script>"
 end
 
 function plotly_html_body(plt, style = nothing)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -336,7 +336,7 @@ function plotly_layout(plt::Plot)
         plotattributes_out[:hovermode] = "none"
     end
 
-    plotattributes_out
+    plotattributes_out = recursive_merge(plotattributes_out, plt.attr[:extra_plot_kwargs])
 end
 
 function plotly_layout_json(plt::Plot)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -302,6 +302,11 @@ Base.convert(::Type{Vector{T}}, rng::AbstractRange{S}) where {T<:Real,S<:Real} =
 
 Base.merge(a::AbstractVector, b::AbstractVector) = sort(unique(vcat(a,b)))
 
+# recursively merge kw-dicts, e.g. for merging extra_kwargs / extra_plot_kwargs in plotly)
+recursive_merge(x::AbstractDict...) = merge(recursive_merge, x...)
+# if values are not AbstractDicts, take the last definition (as does merge)
+recursive_merge(x...) = x[end]
+
 nanpush!(a::AbstractVector, b) = (push!(a, NaN); push!(a, b))
 nanappend!(a::AbstractVector, b) = (push!(a, NaN); append!(a, b))
 


### PR DESCRIPTION
Currently, the plotly backend does not support latexstrings in the Juno IDE, whereas it works in IJulia, if the correct fonts are copied into the mathjax folder.

I propose to add an `:include_mathjax ` plot attribute that works similar to the python version:

- `:include_mathjax == ""` (default): no mathjax header)
- `:include_mathjax == "cdn"` include the standard online version of the header
- `:include_mathjax == "`<filename?config=xyz>"` include a user-defined file

Unfortunately, the x-axis fails to display properly with mathjax enabled. This can be worked around by removing :domain from the attributes and adding :automargin for :yaxis. That also helps in the case of large number at the y-axis.

I have therefore also implemented `extra_plot_kwargs` for the plotly backend.

Here are three example plots that demonstrate the usage:
```
using Plots, LaTeXStrings
plotly()

# if Conda and IJulia are installed, then the mathjax files are locally available
# one might think of adding an option "local" that includes the following line ...
import Conda.ROOTENV
function local_mathjax()
    joinpath(ROOTENV, "Lib", "site-packages", "notebook", "static", "components", "MathJax",
            "MathJax.js?config=TeX-AMS-MML_HTMLorMML-full")
end

p = Plots.plot(1:4, [[1,4,9,16]*10000, [0.5, 2, 4.5, 8]],
    labels = [L"\alpha_{1c} = 352 \pm 11 \text{ km s}^{-1}";
              L"\beta_{1c} = 25 \pm 11 \text{ km s}^{-1}"] |> permutedims,
    xlabel = L"\sqrt{(n_\text{c}(t|{T_\text{early}}))}",
    ylabel = L"d, r \text{ (solar radius)}",
    yformatter = :plain
)

p = Plots.plot(1:4, [[1,4,9,16]*10000, [0.5, 2, 4.5, 8]],
    include_mathjax = local_mathjax(),
    labels = [L"\alpha_{1c} = 352 \pm 11 \text{ km s}^{-1}";
              L"\beta_{1c} = 25 \pm 11 \text{ km s}^{-1}"] |> permutedims,
    xlabel = L"\sqrt{(n_\text{c}(t|{T_\text{early}}))}",
    ylabel = L"d, r \text{ (solar radius)}",
    yformatter = :plain
)

p = Plots.plot(1:4, [[1,4,9,16]*10000, [0.5, 2, 4.5, 8]],
    include_mathjax = local_mathjax(),
    labels = [L"\alpha_{1c} = 352 \pm 11 \text{ km s}^{-1}";
              L"\beta_{1c} = 25 \pm 11 \text{ km s}^{-1}"] |> permutedims,
    xlabel = L"\sqrt{(n_\text{c}(t|{T_\text{early}}))}",
    ylabel = L"d, r \text{ (solar radius)}",
    yformatter = :plain,
    extra_plot_kwargs = KW(:yaxis => KW(:automargin => true), :xaxis => KW(:domain => "auto"))
)
```
![mathjax_no_header](https://user-images.githubusercontent.com/31985040/82432857-ebc8e080-9a90-11ea-8c04-749d3100b3b4.png)
![mathjax_with_header](https://user-images.githubusercontent.com/31985040/82432873-f2efee80-9a90-11ea-8510-6f0bc5d595a1.png)
![mathjax_with_header_and_automargin](https://user-images.githubusercontent.com/31985040/82432889-f7b4a280-9a90-11ea-9046-874b2dbb417e.png)
