### PR TITLE
pyplot colorbar fixes

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -583,6 +583,7 @@ add_aliases(:fill_z, :fillz, :fz, :surfacecolor, :surfacecolour, :sc, :surfcolor
 add_aliases(:legend, :leg, :key)
 add_aliases(:legendtitle, :legend_title, :labeltitle, :label_title, :leg_title, :key_title)
 add_aliases(:colorbar, :cb, :cbar, :colorkey)
+add_aliases(:colorbar_title, :colorbartitle, :cb_title, :cbtitle, :cbartitle, :cbar_title, :colorkeytitle, :colorkey_title)
 add_aliases(:clims, :clim, :cbarlims, :cbar_lims, :climits, :color_limits)
 add_aliases(:smooth, :regression, :reg)
 add_aliases(:levels, :nlevels, :nlev, :levs)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1007,9 +1007,9 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             # note: the colorbar axis is positioned independently from the subplot axis
             fig = plt.o
 
-            #  There is no point specifying colorbar size, hence rand(4) as it will get
+            #  There is no point in specifying colorbar size, hence zeros(4). It will get
             #  updated at function _update_plot_object(plt::Plot{PyPlotBackend})
-            cbax = fig."add_axes"(rand(4), label = string(gensym()))
+            cbax = fig."add_axes"(zeros(4), label = string(gensym()))
             cb = fig."colorbar"(handle; cax = cbax, kw...)
             cb."set_label"(sp[:colorbar_title],size=py_thickness_scale(plt, sp[:yaxis][:guidefontsize]),family=sp[:yaxis][:guidefontfamily], color = py_color(sp[:yaxis][:guidefontcolor]))
 

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1396,6 +1396,14 @@ function _update_plot_object(plt::Plot{PyPlotBackend})
         figw, figh = figw*px, figh*px
         pcts = bbox_to_pcts(sp.plotarea, figw, figh)
         ax."set_position"(pcts)
+
+        if haskey(sp.attr, :cbar_ax) && RecipesPipeline.is3d(sp)   # 2D plots are completely handled by axis dividers
+            cbw = sp.attr[:cbar_width]
+            # this is the bounding box of just the colors of the colorbar (not labels)
+            cb_bbox = BoundingBox(right(sp.bbox)-cbw - 2mm, top(sp.bbox) + 2mm, _cbar_width-1mm, height(sp.bbox) -  4mm)
+            pcts = bbox_to_pcts(cb_bbox, figw, figh)
+            sp.attr[:cbar_ax]."set_position"(pcts)
+        end
     end
     PyPlot.draw()
 end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1005,12 +1005,19 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             kw[:spacing] = "proportional"
 
             fig = plt.o
-            divider = axes_grid1.make_axes_locatable(ax)
-            # width = axes_grid1.axes_size.AxesY(ax, aspect=1.0 / 3.5)
-            # pad = axes_grid1.axes_size.Fraction(0.5, width)  # Colorbar is spaced 0.5 of its size away from the ax
-            # cbax = divider.append_axes("right", size=width, pad=pad)   # This approach does not work well in subplots
-            cbax = divider.append_axes("right", size="5%", pad=0.05)  # Reasonable value works most of the usecases
-            cb = fig."colorbar"(handle; cax=cbax, kw...)
+
+            if RecipesPipeline.is3d(sp)
+                cbax = fig."add_axes"([0.9, 0.1, 0.03, 0.8])
+                cb = fig."colorbar"(handle; cax=cbax, kw...)
+            else
+                # divider approach works only with 2d plots
+                divider = axes_grid1.make_axes_locatable(ax)
+                # width = axes_grid1.axes_size.AxesY(ax, aspect=1.0 / 3.5)
+                # pad = axes_grid1.axes_size.Fraction(0.5, width)  # Colorbar is spaced 0.5 of its size away from the ax
+                # cbax = divider.append_axes("right", size=width, pad=pad)   # This approach does not work well in subplots
+                cbax = divider.append_axes("right", size="5%", pad="2.5%")  # Reasonable value works most of the usecases
+                cb = fig."colorbar"(handle; cax=cbax, kw...)
+            end
 
             cb."set_label"(sp[:colorbar_title],size=py_thickness_scale(plt, sp[:yaxis][:guidefontsize]),family=sp[:yaxis][:guidefontfamily], color = py_color(sp[:yaxis][:guidefontcolor]))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -983,7 +983,7 @@ px2inch(px::Real)       = float(px / PX_PER_INCH)
 inch2mm(inches::Real)   = float(inches * MM_PER_INCH)
 mm2inch(mm::Real)       = float(mm / MM_PER_INCH)
 px2mm(px::Real)         = float(px * MM_PER_PX)
-mm2px(mm::Real)         = float(px / MM_PER_PX)
+mm2px(mm::Real)         = float(mm / MM_PER_PX)
 
 
 "Smallest x in plot"


### PR DESCRIPTION
Fix: https://github.com/JuliaPlots/Plots.jl/issues/1755
Fix: https://github.com/JuliaPlots/Plots.jl/issues/2198
Fix: https://github.com/JuliaPlots/Plots.jl/issues/484
Some improvements to pyplot colorbars, because colorbars deserve some <3

There were multiple issues with them

```
plot(rand(10), line_z=1e10.*rand(10), title="asd", titlefont=50)
```
Before:
![image](https://user-images.githubusercontent.com/24591123/82541203-097a7080-9b8b-11ea-9d14-17f341dfb214.png)

After:
![image](https://user-images.githubusercontent.com/24591123/82541142-f4054680-9b8a-11ea-8beb-228afa903147.png)

However `dpi` option still very buggy
https://github.com/JuliaPlots/Plots.jl/issues/2198

I cannot figure out why this happens, perhaps @daschw could help out?