### PR TITLE
Add fillalpha to :contourf seriestype for pyplot backend

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -661,6 +661,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             handle = ax."contourf"(x, y, z, levelargs...;
                 label = series[:label],
                 zorder = series[:series_plotindex] + 0.5,
+                alpha = series[:fillalpha],
                 extrakw...
             )
             push!(handles, handle)
@@ -1098,7 +1099,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             end
             pyaxis."label"."set_fontsize"(py_thickness_scale(plt, axis[:guidefontsize]))
             pyaxis."label"."set_family"(axis[:guidefontfamily])
-            
+
             if (RecipesPipeline.is3d(sp))
                 pyaxis."set_rotate_label"(false)
             end


### PR DESCRIPTION
Adds the option to pass `fillalpha` keyword to `pyplot` backend when using `:contourf` seriestype.
Example:
```
plot(..., seriestype=:contourf, fillalpha=0.3, linewidth=2)
```

![plot](https://user-images.githubusercontent.com/7093206/82923336-12988280-9f7b-11ea-8cb6-b2602119ba30.png)

(The surrounding line can be changed or removed using the `linewidth` keyword.)

