### PR TITLE
fix type restriction in process_clims

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -420,7 +420,7 @@ ylims(sp_idx::Int = 1) = ylims(current(), sp_idx)
 zlims(sp_idx::Int = 1) = zlims(current(), sp_idx)
 
 # These functions return an operator for use in `get_clims(::Seres, op)`
-process_clims(lims::NTuple{2,<:Number}) = (zlims -> ifelse.(isfinite.(lims), lims, zlims)) ∘ ignorenan_extrema
+process_clims(lims::Tuple{<:Number,<:Number}) = (zlims -> ifelse.(isfinite.(lims), lims, zlims)) ∘ ignorenan_extrema
 process_clims(s::Union{Symbol,Nothing,Missing}) = ignorenan_extrema
 # don't specialize on ::Function otherwise python functions won't work
 process_clims(f) = f

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,9 +179,9 @@ end
         @test isequal(collect(zip(Plots.unzip(z)...)), z)
         @test isequal(collect(zip(Plots.unzip(GeometryTypes.Point.(z))...)), z)
     end
-    op1 = process_clims((1.0, 2.0))
-    op2 = process_clims((1, 2.0))
+    op1 = Plots.process_clims((1.0, 2.0))
+    op2 = Plots.process_clims((1, 2.0))
     data = randn(100, 100)
     @test op1(data) == op2(data)
-    @test process_clims(nothing) == process_clims(missing) == process_clims(:auto)
+    @test Plots.process_clims(nothing) == Plots.process_clims(missing) == Plots.process_clims(:auto)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,4 +179,9 @@ end
         @test isequal(collect(zip(Plots.unzip(z)...)), z)
         @test isequal(collect(zip(Plots.unzip(GeometryTypes.Point.(z))...)), z)
     end
+    op1 = process_clims((1.0, 2.0))
+    op2 = process_clims((1, 2.0))
+    data = randn(100, 100)
+    @test op1(data) == op2(data)
+    @test process_clims(nothing) == process_clims(missing) == process_clims(:auto)
 end


### PR DESCRIPTION
Noticed a bug in the code I added here (classic!)

Previously if you used mixed types in the tuple call it would fail eg.
`process_clims((1, 3.0))` would produce a `MethodError`

This loosens the type restriction (should have been this way from the beginning!).