### PR TITLE
improve nonuniform heatmap performance on GR

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -943,6 +943,12 @@ function is_equally_spaced(v)
     all(d .≈ d[1])
 end
 
+remap(x, lo, hi) = (x - lo) / (hi - lo)
+function get_z_normalized(z, clims...)
+    isnan(z) && return 256 / 255
+    return remap(clamp(z, clims...), clims...)
+end
+
 function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     _update_min_padding!(sp)
 
@@ -1712,8 +1718,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     if something(series[:fillalpha],1) < 1
                         @warn "GR: transparency not supported in non-uniform heatmaps. Alpha values ignored."
                     end
-                    colors = get(fillgrad, z, clims)
-                    z_normalized = map(c -> c == invisible() ? 256/255 : PlotUtils.getinverse(fillgrad, c), colors)
+                    z_normalized = get_z_normalized.(z, zmin, zmax)
                     rgba = Int32[round(Int32, 1000 + _i * 255) for _i in z_normalized]
                     GR.nonuniformcellarray(x, y, w, h, rgba)
                 end


### PR DESCRIPTION
fix #2759

before:
```julia
julia> @time display(heatmap(log.(1:400), log.(1:500), rand(500, 400)))
Plot{Plots.GRBackend() n=1}
 22.206663 seconds (35.39 M allocations: 2.229 GiB, 1.01% gc time)
```
now:
```julia
julia> @time display(heatmap(log.(1:400), log.(1:500), rand(500, 400)))
Plot{Plots.GRBackend() n=1}
  0.216954 seconds (1.49 M allocations: 36.690 MiB)
```