### PR TITLE
Plotly fixed version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .DS_Store
 examples/.ipynb_checkpoints/*
 examples/meetup/.ipynb_checkpoints/*
-deps/plotly-latest.min.js
+deps/plotly-1.54.2.min.js
 deps/build.log
 deps/deps.jl
 Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .DS_Store
 examples/.ipynb_checkpoints/*
 examples/meetup/.ipynb_checkpoints/*
-deps/plotly-1.54.2.min.js
+deps/plotly-*
 deps/build.log
 deps/deps.jl
 Manifest.toml

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,12 +1,12 @@
 
-#TODO: download https://cdn.plot.ly/plotly-latest.min.js to deps/ if it doesn't exist
+#TODO: download https://cdn.plot.ly/plotly-1.54.2.min.js to deps/ if it doesn't exist
 file_path = ""
 if get(ENV, "PLOTS_HOST_DEPENDENCY_LOCAL", "false") == "true"
     global file_path
-    local_fn = joinpath(dirname(@__FILE__), "plotly-latest.min.js")
+    local_fn = joinpath(dirname(@__FILE__), "plotly-1.54.2.min.js")
     if !isfile(local_fn)
-        @info("Cannot find deps/plotly-latest.min.js... downloading latest version.")
-        download("https://cdn.plot.ly/plotly-latest.min.js", local_fn)
+        @info("Cannot find deps/plotly-1.54.2.min.js... downloading latest version.")
+        download("https://cdn.plot.ly/plotly-1.54.2.min.js", local_fn)
         isfile(local_fn) && (file_path = local_fn)
     else
         file_path = local_fn

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -828,7 +828,7 @@ const ijulia_initialized = Ref(false)
 function plotly_html_head(plt::Plot)
     local_file = ("file:///" * plotly_local_file_path)
     plotly =
-        use_local_dependencies[] ? local_file : "https://cdn.plot.ly/plotly-latest.min.js"
+        use_local_dependencies[] ? local_file : "https://cdn.plot.ly/plotly-1.54.2.min.js"
 
     include_mathjax = get(plt[:extra_plot_kwargs], :include_mathjax, "")
     mathjax_file = include_mathjax != "cdn" ? ("file://" * include_mathjax) : "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"


### PR DESCRIPTION
Currently, Plots.jl loads `https://cdn.plot.ly/plotly-latest.min.js`, which is an unbounded dependency of this project - when plotly releases `2.0`, for example, Julia code using Plots.jl might no longer work - even if their dependency on `Plots.jl` has its version fixed.

To keep getting plotly's latest features, you could (test and) update the dependency version inside `Plots.jl` whenever you see fit.