### PR TITLE
Fix #2377, #2785, #2369: Legend positioning fix for multiple plots

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -605,7 +605,8 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
             ypos = viewport_plotarea[3] + h + 0.06
         end
     else
-        ypos = (viewport_plotarea[4]-viewport_plotarea[3])/2 + h/2
+        # Adding min y to shift legend pos to correct graph (#2377)
+        ypos = (viewport_plotarea[4]-viewport_plotarea[3])/2 + h/2 + viewport_plotarea[3]
     end
     (xpos,ypos)
 end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -590,7 +590,7 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
             xpos = viewport_plotarea[1] + 0.11
         end
     else
-        xpos = (viewport_plotarea[2]-viewport_plotarea[1])/2 - w/2 +.04
+        xpos = (viewport_plotarea[2]-viewport_plotarea[1])/2 - w/2 +.04 + viewport_plotarea[1]
     end
     if occursin("top", str)
         if s == :outertop


### PR DESCRIPTION
Before images can be seen at the issues themselves.
Fixes #2377 
After:
![image](https://user-images.githubusercontent.com/38937684/84694924-74894e00-af63-11ea-9143-742fbd06e932.png)


Fixes #2785 
After:
![image](https://user-images.githubusercontent.com/38937684/84695017-9e427500-af63-11ea-8344-f7bea5c300fa.png)


Fixes #2369 
After:
![image](https://user-images.githubusercontent.com/38937684/84695168-da75d580-af63-11ea-9d32-387e11ac92cd.png)


Needs review.