### PR TITLE
better exponents

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -181,16 +181,10 @@ function optimal_ticks_and_labels(sp::Subplot, axis::Axis, ticks = nothing)
 
     labels = if any(isfinite, unscaled_ticks)
         formatter = axis[:formatter]
-        if formatter == :auto
-            # the default behavior is to make strings of the scaled values and then apply the labelfunc
-            map(labelfunc(scale, backend()), Showoff.showoff(scaled_ticks, :auto))
-        elseif formatter == :plain
-            # Leave the numbers in plain format
-            map(labelfunc(scale, backend()), Showoff.showoff(scaled_ticks, :plain))
-        elseif formatter == :scientific
-            Showoff.showoff(unscaled_ticks, :scientific)
-	elseif formatter == :latex
-	    map(x -> string("\$", replace(convert_sci_unicode(x), '×' => "\\times"), "\$"), Showoff.showoff(unscaled_ticks, :auto))
+        if formatter in (:auto, :plain, :scientific, :engineering)
+            map(labelfunc(scale, backend()), Showoff.showoff(scaled_ticks, formatter))
+        elseif formatter == :latex
+            map(x -> string("\$", replace(convert_sci_unicode(x), '×' => "\\times"), "\$"), Showoff.showoff(unscaled_ticks, :auto))
         else
             # there was an override for the formatter... use that on the unscaled ticks
             map(formatter, unscaled_ticks)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -182,7 +182,7 @@ function labelfunc(scale::Symbol, backend::PyPlotBackend)
     elseif scale == :ln
         x -> PyPlot.LaTeXStrings.latexstring("e^{$x}")
     else
-        string
+        x -> PyPlot.LaTeXStrings.latexstring(convert_sci_unicode(x))
     end
 end
 


### PR DESCRIPTION
PyPlot improved exponents, additionally brought `:engineering` notation support.

`:engineering` is same as `:scientific` but it makes the powers of 10 being always divisible by 3