### PR TITLE
add legend line in GR for 3d paths

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1878,7 +1878,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                     st == :shape && gr_polyline(x, y)
                 end
 
-                if st in (:path, :straightline)
+                if st in (:path, :straightline, :path3d)
                     gr_set_transparency(lc, get_linealpha(series))
                     if series[:fillrange] === nothing || series[:ribbon] !== nothing
                         GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])


### PR DESCRIPTION
Fix: https://github.com/JuliaPlots/Plots.jl/issues/1776
before:
![gr3d_before](https://user-images.githubusercontent.com/16589944/84884490-15762700-b092-11ea-9064-8db185394681.png)
now:
![gr3d_after](https://user-images.githubusercontent.com/16589944/84884513-2030bc00-b092-11ea-9330-694cc0754bdc.png)
