### PR TITLE
add non-array version for hline and vline

### DIFF
--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -176,6 +176,9 @@ julia> hline([-1,0,2])
 ```
 """
 @shorthands hline
+hline(x::RecipesPipeline.DataPoint; kwargs...) = hline([x]; kwargs...)
+hline!(x::RecipesPipeline.DataPoint; kwargs...) = hline!([x]; kwargs...)
+hline!(plt, x::RecipesPipeline.DataPoint; kwargs...) = hline!(plt, [x]; kwargs...)
 
 """
     vline(x)
@@ -190,6 +193,9 @@ julia> vline([-1,0,2])
 ```
 """
 @shorthands vline
+vline(x::RecipesPipeline.DataPoint; kwargs...) = vline([x]; kwargs...)
+vline!(x::RecipesPipeline.DataPoint; kwargs...) = vline!([x]; kwargs...)
+vline!(plt, x::RecipesPipeline.DataPoint; kwargs...) = vline!(plt, [x]; kwargs...)
 
 """
     hspan(y)


### PR DESCRIPTION
Not sure if we want this but this would be an easy workaround only for the hline/vline shorthands for #2129 and #2575.

allows e.g.
```julia
plt = plot(rand(10))
hline!(0.5)
vline!(plt, 7)
```

I am really sceptical about this, because
```julia
plot(1, st = :hline)
```
does something different from
```julia
hline(1)
```