### PR TITLE
Fix #2330, #2202: Position legends closer to the borders

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -565,7 +565,8 @@ gr_view_xcenter(viewport_plotarea) = 0.5 * (viewport_plotarea[1] + viewport_plot
 gr_view_ycenter(viewport_plotarea) = 0.5 * (viewport_plotarea[3] + viewport_plotarea[4])
 
 function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
-    legend_leftw, legend_rightw, legend_textw, x_legend_offset, y_legend_offset = w
+    legend_leftw, legend_rightw, legend_textw, x_legend_offset = w
+    legend_dy, legendh, y_legend_offset = h 
     s = sp[:legend]
     typeof(s) <: Symbol || return gr_legend_pos(s, w, h, viewport_plotarea)
     str = string(s)
@@ -595,19 +596,19 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
     end
     if occursin("top", str)
         if s == :outertop
-            ypos = viewport_plotarea[4] + 0.02 + h + xmirror * gr_axis_height(sp, sp[:xaxis])
+            ypos = viewport_plotarea[4] + y_legend_offset + legendh + xmirror * gr_axis_height(sp, sp[:xaxis])
         else
             ypos = viewport_plotarea[4] - y_legend_offset
         end
     elseif occursin("bottom", str)
         if s == :outerbottom
-            ypos = viewport_plotarea[3] - 0.05 - !xmirror * gr_axis_height(sp, sp[:xaxis])
+            ypos = viewport_plotarea[3] - y_legend_offset - legendh - !xmirror * gr_axis_height(sp, sp[:xaxis])
         else
-            ypos = viewport_plotarea[3] + h + y_legend_offset
+            ypos = viewport_plotarea[3] + legendh + y_legend_offset
         end
     else
         # Adding min y to shift legend pos to correct graph (#2377)
-        ypos = (viewport_plotarea[4]-viewport_plotarea[3])/2 + h/2 + viewport_plotarea[3]
+        ypos = (viewport_plotarea[4]-viewport_plotarea[3])/2 + legendh/2 + viewport_plotarea[3]
     end
     (xpos,ypos)
 end
@@ -1014,7 +1015,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     total_legendw = legend_textw + legend_leftw + legend_rightw
 
     x_legend_offset = (viewport_plotarea[2] - viewport_plotarea[1]) / 30
-    y_legend_offset = (viewport_plotarea[4] - viewport_plotarea[3]) / 15
+    y_legend_offset = (viewport_plotarea[4] - viewport_plotarea[3]) / 30
 
     dy = gr_point_mult(sp) * sp[:legendfontsize] * 1.75
     legendh = dy * legendn
@@ -1025,9 +1026,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         elseif occursin("left", leg_str)
             viewport_plotarea[1] += total_legendw + x_legend_offset # Increase plot min width to make space for outer legend
         elseif occursin("top", leg_str)
-            viewport_plotarea[4] -= legendh + 0.03
+            viewport_plotarea[4] -= legendh + dy + y_legend_offset
         elseif occursin("bottom", leg_str)
-            viewport_plotarea[3] += legendh + 0.04
+            viewport_plotarea[3] += legendh + dy + y_legend_offset
         end
     end
     if sp[:legend] == :inline
@@ -1850,7 +1851,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         if w > 0
             dy = gr_point_mult(sp) * sp[:legendfontsize] * 1.75
             h = dy*n
-            xpos, ypos = gr_legend_pos(sp, [legend_leftw, legend_rightw, legend_textw, x_legend_offset, y_legend_offset], h, viewport_plotarea) # Passing legend width components instead of legend text width
+            xpos, ypos = gr_legend_pos(sp, [legend_leftw, legend_rightw, legend_textw, x_legend_offset, y_legend_offset], [dy, h, y_legend_offset], viewport_plotarea) # Passing legend width components instead of legend text width
             GR.setfillintstyle(GR.INTSTYLE_SOLID)
             gr_set_fillcolor(sp[:background_color_legend])
             GR.fillrect(xpos - legend_leftw, xpos + legend_textw + legend_rightw, ypos + dy, ypos - dy * n) # Allocating white space for actual legend width here

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -568,6 +568,8 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
     s = sp[:legend]
     typeof(s) <: Symbol || return gr_legend_pos(s, w, h, viewport_plotarea)
     str = string(s)
+    x_legend_offset = (viewport_plotarea[2] - viewport_plotarea[1]) / 30
+    y_legend_offset = (viewport_plotarea[4] - viewport_plotarea[3]) / 15
     if str == "best"
         str = "topright"
     end
@@ -581,13 +583,13 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
             # As per https://github.com/jheinen/GR.jl/blob/master/src/jlgr.jl#L525
             xpos = viewport_plotarea[2] + 0.11 + ymirror * gr_axis_width(sp, sp[:yaxis])
         else
-            xpos = viewport_plotarea[2] - 0.01 - w
+            xpos = viewport_plotarea[2] - x_legend_offset - w
         end
     elseif occursin("left", str)
         if occursin("outer", str)
             xpos = viewport_plotarea[1] - 0.05 - w - !ymirror * gr_axis_width(sp, sp[:yaxis])
         else
-            xpos = viewport_plotarea[1] + 0.08 + 0.01
+            xpos = viewport_plotarea[1] + 0.08 + x_legend_offset
         end
     else
         xpos = (viewport_plotarea[2]-viewport_plotarea[1])/2 - w/2 + 0.04 + viewport_plotarea[1]
@@ -596,13 +598,13 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
         if s == :outertop
             ypos = viewport_plotarea[4] + 0.02 + h + xmirror * gr_axis_height(sp, sp[:xaxis])
         else
-            ypos = viewport_plotarea[4] - 0.01
+            ypos = viewport_plotarea[4] - y_legend_offset
         end
     elseif occursin("bottom", str)
         if s == :outerbottom
             ypos = viewport_plotarea[3] - 0.05 - !xmirror * gr_axis_height(sp, sp[:xaxis])
         else
-            ypos = viewport_plotarea[3] + h + 0.01
+            ypos = viewport_plotarea[3] + h + y_legend_offset
         end
     else
         # Adding min y to shift legend pos to correct graph (#2377)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -581,28 +581,28 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
             # As per https://github.com/jheinen/GR.jl/blob/master/src/jlgr.jl#L525
             xpos = viewport_plotarea[2] + 0.11 + ymirror * gr_axis_width(sp, sp[:yaxis])
         else
-            xpos = viewport_plotarea[2] - 0.05 - w
+            xpos = viewport_plotarea[2] - 0.01 - w
         end
     elseif occursin("left", str)
         if occursin("outer", str)
             xpos = viewport_plotarea[1] - 0.05 - w - !ymirror * gr_axis_width(sp, sp[:yaxis])
         else
-            xpos = viewport_plotarea[1] + 0.11
+            xpos = viewport_plotarea[1] + 0.08 + 0.01
         end
     else
-        xpos = (viewport_plotarea[2]-viewport_plotarea[1])/2 - w/2 +.04 + viewport_plotarea[1]
+        xpos = (viewport_plotarea[2]-viewport_plotarea[1])/2 - w/2 + 0.04 + viewport_plotarea[1]
     end
     if occursin("top", str)
         if s == :outertop
             ypos = viewport_plotarea[4] + 0.02 + h + xmirror * gr_axis_height(sp, sp[:xaxis])
         else
-            ypos = viewport_plotarea[4] - 0.06
+            ypos = viewport_plotarea[4] - 0.01
         end
     elseif occursin("bottom", str)
         if s == :outerbottom
             ypos = viewport_plotarea[3] - 0.05 - !xmirror * gr_axis_height(sp, sp[:xaxis])
         else
-            ypos = viewport_plotarea[3] + h + 0.06
+            ypos = viewport_plotarea[3] + h + 0.01
         end
     else
         # Adding min y to shift legend pos to correct graph (#2377)


### PR DESCRIPTION
Fix #2330 
Fix #2202
Images below for plot made using this snippet _(changing legend in each case)_: 
```
plot([scatter(rand(10,2), rand(10,2), legend=:topleft) for i = 1:5]...,
	 layout=(1,5), size=(2000, 400))
```

__Bottom Left:__
- Before:
![bottomleft-before](https://user-images.githubusercontent.com/38937684/85286580-53b58100-b4ac-11ea-81ab-255c248ee22d.png)
- After:
![bottomleft-after](https://user-images.githubusercontent.com/38937684/85286614-60d27000-b4ac-11ea-9ea7-b01dc575c89e.png)

__Bottom Right:__
- Before:
![bottomright-before](https://user-images.githubusercontent.com/38937684/85286681-80699880-b4ac-11ea-8ac1-9051f1992009.png)
- After:
![bottomright-after](https://user-images.githubusercontent.com/38937684/85286691-852e4c80-b4ac-11ea-899b-20ec3bff1a9d.png)

__Top Left:__
- Before:
![topleft-before](https://user-images.githubusercontent.com/38937684/85286700-8b242d80-b4ac-11ea-8516-f71a54d14429.png)

- After:
![topleft-after](https://user-images.githubusercontent.com/38937684/85286724-98d9b300-b4ac-11ea-8239-a72cb9e5f5d7.png)

__Top Right:__
- Before:
![topright-before](https://user-images.githubusercontent.com/38937684/85286732-9bd4a380-b4ac-11ea-8f0c-9b9de9f8a95c.png)

- After:
![topright-after](https://user-images.githubusercontent.com/38937684/85286738-9e36fd80-b4ac-11ea-8024-4fe520e60c9f.png)

Needs review.