### PR TITLE
[WIP] Fix #1881, Ticks are now visible for filled contours without grid=:none parameter

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1148,7 +1148,6 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                     linestyle = py_linestyle(:line, axis[:gridstyle]),
                     linewidth = py_thickness_scale(plt, axis[:gridlinewidth]),
                     alpha = axis[:gridalpha])
-                ax."set_axisbelow"(true)
             else
                 pyaxis."grid"(false)
             end


### PR DESCRIPTION
Fixes #1881 

I discussed this issue with @isentropic and he suggested to add a `zorder` argument in the below call:
https://github.com/JuliaPlots/Plots.jl/blob/47590b2538b9d0387b14d46eb49e7257f904dde6/src/backends/pyplot.jl#L850
I tried adding `zorder` with a high value in other places too but it didn't work. 

Turned out the axes were drawn below the countors when `grid` was set to true:
https://github.com/JuliaPlots/Plots.jl/blob/47590b2538b9d0387b14d46eb49e7257f904dde6/src/backends/pyplot.jl#L1144-L1151
and hence the ticks were also hiding:
![fig](https://user-images.githubusercontent.com/28972442/85395195-6217a180-b56d-11ea-91ba-924c7dce7993.png)

Removing this line:
https://github.com/JuliaPlots/Plots.jl/blob/47590b2538b9d0387b14d46eb49e7257f904dde6/src/backends/pyplot.jl#L1151

or setting `ax."set_axisbelow"(true)` to `false` is producing the following results:
![Figure_1](https://user-images.githubusercontent.com/28972442/85395006-1f55c980-b56d-11ea-8b1a-c3b2b4abb7fa.png)

If this is the right solution, I will update the same for other backends too.