### PR TITLE
Fix nightly tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,6 +49,7 @@ RecipesPipeline = "0.1.7"
 Reexport = "0.2"
 Requires = "1"
 Showoff = "0.3.1"
+StableRNGs = "0.1.1"
 StatsBase = "0.32, 0.33"
 julia = "1"
 
@@ -63,6 +64,7 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PGFPlotsX = "8314cec4-20b6-5062-9cdb-752b83310925"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -70,4 +72,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 
 [targets]
-test = ["Distributions", "FileIO", "Gtk", "ImageMagick", "Images", "LibGit2", "OffsetArrays", "PGFPlotsX", "HDF5", "RDatasets", "StaticArrays", "StatsPlots", "Test", "UnicodePlots", "VisualRegressionTests"]
+test = ["Distributions", "FileIO", "Gtk", "ImageMagick", "Images", "LibGit2", "OffsetArrays", "PGFPlotsX", "HDF5", "RDatasets", "StableRNGs", "StaticArrays", "StatsPlots", "Test", "UnicodePlots", "VisualRegressionTests"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ import ImageMagick
 using VisualRegressionTests
 using Plots
 using Random
+using StableRNGs
 using Test
 using FileIO
 using Gtk


### PR DESCRIPTION
The numbers generated by `rand` and `randn` have changed for bigger vectors on julia 1.5 (https://github.com/JuliaLang/julia/pull/33721 and https://github.com/JuliaLang/julia/pull/35078).
This uses https://github.com/rfourquet/StableRNGs.jl to produce reproducable random numbers across different julia versions in the tests.
New test images: https://github.com/JuliaPlots/PlotReferenceImages.jl/pull/74