### PR TITLE
change z buffer for surface plots

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -558,6 +558,7 @@ function pgfx_series_coordinates!(st_val::Val{:surface}, segment_opt, opt, args)
         "surf" => nothing,
         "mesh/rows" => length(opt[:x]),
         "mesh/cols" => length(opt[:y]),
+        "z buffer" => "sort",
     )
     return PGFPlotsX.Coordinates(args...)
 end


### PR DESCRIPTION
This fixes the [example](https://docs.juliaplots.org/latest/backends/#Fine-tuning-1) of the docs.