### PR TITLE
fix errorbar color

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -973,8 +973,8 @@ const _examples = PlotExample[
                     surf = Measurement.((1:10) .* (1:10)', rand(10,10))
 
                     plot(
-                        scatter(x, [x y], msw = 0),
-                        scatter(x, y, z, msw = 0),
+                        scatter(x, [x y]),
+                        scatter(x, y, z),
                         heatmap(x, y, surf),
                         wireframe(x, y, surf),
                         legend = :topleft

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1027,8 +1027,23 @@ end
 # Error Bars
 
 function error_style!(plotattributes::AKW)
+    msc = plotattributes[:markerstrokecolor]
+    msc = if msc === :match
+        plotattributes[:subplot][:foreground_color_subplot]
+    elseif msc === :auto
+        get_series_color(
+            plotattributes[:linecolor],
+            plotattributes[:subplot],
+            plotattributes[:series_plotindex],
+            plotattributes[:seriestype],
+        )
+    else
+        msc
+    end
+
     plotattributes[:seriestype] = :path
-    plotattributes[:markercolor] = plotattributes[:markerstrokecolor]
+    plotattributes[:markercolor] = msc
+    plotattributes[:linecolor] = msc
     plotattributes[:linewidth] = plotattributes[:markerstrokewidth]
     plotattributes[:label] = ""
 end


### PR DESCRIPTION
```julia
using Plots

x = [0.5:10 1:10]
y = rand(10, 2) .+ [0 1]
err = [(rand(10), rand(10)) (rand(10), rand(10))]

plot(scatter(x, y, yerror = err), scatter(x, y, yerror = err, msc = :auto))
```

Before
![errorbar_old](https://user-images.githubusercontent.com/16589944/86474785-d8718c00-bd43-11ea-895d-d0c7462af636.png)

Now
![errorbar_new](https://user-images.githubusercontent.com/16589944/86474810-e45d4e00-bd43-11ea-8cbc-92fc7c7c549b.png)
