### PR TITLE
Horizontal legends

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1208,12 +1208,16 @@ function convertLegendValue(val::Symbol)
         :none
     elseif val in (:right, :left, :top, :bottom, :inside, :best, :legend, :topright, :topleft, :bottomleft, :bottomright, :outertopright, :outertopleft, :outertop, :outerright, :outerleft, :outerbottomright, :outerbottomleft, :outerbottom, :inline)
         val
+    elseif val == :horizontal
+        -1
     else
         error("Invalid symbol for legend: $val")
     end
 end
+convertLegendValue(val::Real) = val
 convertLegendValue(val::Bool) = val ? :best : :none
 convertLegendValue(val::Nothing) = :none
+convertLegendValue(v::Union{Tuple, NamedTuple}) = convertLegendValue.(v)
 convertLegendValue(v::Tuple{S,T}) where {S<:Real, T<:Real} = v
 convertLegendValue(v::AbstractArray) = map(convertLegendValue, v)
 

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -139,6 +139,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 "point meta max" => get_clims(sp)[2],
                 "point meta min" => get_clims(sp)[1],
                 "legend cell align" => "left",
+                "legend columns" => pgfx_legend_col(sp[:legend]),
                 "title" => sp[:title],
                 "title style" => PGFPlotsX.Options(
                         pgfx_get_title_pos(title_loc)...,
@@ -788,6 +789,15 @@ function pgfx_linestyle(linewidth::Real, color, α = 1, linestyle = :solid)
         pgfx_get_linestyle(linestyle) => nothing,
     )
 end
+
+function pgfx_legend_col(s::Symbol)
+    if s == :horizontal
+        return -1
+    end
+    return 1
+end
+pgfx_legend_col(n) = n
+
 
 function pgfx_linestyle(plotattributes, i = 1)
     lw = pgfx_thickness_scaling(plotattributes) * get_linewidth(plotattributes, i)


### PR DESCRIPTION
While preparing an implementation for horizontal legends in the pgfplotsx backend I got an idea.

Because I wanted to avoid creating another keyword, I hijacked the `legend` keyword, so now I can create legend columns like
```
plot(rand(4,4), legend = :horizontal)
```
![h](https://user-images.githubusercontent.com/18145188/87044562-fed97080-c1f6-11ea-9035-72c6112d9ac2.png)

```
plot(rand(4,4), legend = 2)
```
![h2](https://user-images.githubusercontent.com/18145188/87044571-0436bb00-c1f7-11ea-9e10-42186eb779fc.png)

However, now I can't change the position of the legend at the same time.
So my idea was to always convert the input to named tuples, something like
|`legend` in | `legend` out |
|---|---|
| `:top` | `(pos = :top, columns = 1)`
| `:horizontal` | `(pos = :best, columns = -1)` |
| `(:top, 2)` | `(pos = :top, colums = 2)` |

And passing the NamedTuple would be also allowed. Do you think this is a good idea?