### PR TITLE
fix wrong image limits in pyplot (fix #2864)

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -276,7 +276,6 @@ end
 function py_bbox_axis(ax, letter)
     ticks = py_bbox_ticks(ax, letter)
     labels = py_bbox_axislabel(ax, letter)
-    # letter == "x" && @show ticks labels ticks+labels
     ticks + labels
 end
 
@@ -728,7 +727,6 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     end
 
     if st == :image
-        # @show typeof(z)
         xmin, xmax = ignorenan_extrema(series[:x])
         ymin, ymax = ignorenan_extrema(series[:y])
         dx = (xmax - xmin) / (length(series[:x]) - 1) / 2

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -729,7 +729,10 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
 
     if st == :image
         # @show typeof(z)
-        xmin, xmax = ignorenan_extrema(series[:x]); ymin, ymax = ignorenan_extrema(series[:y])
+        xmin, xmax = ignorenan_extrema(series[:x])
+        ymin, ymax = ignorenan_extrema(series[:y])
+        dx = (xmax - xmin) / (length(series[:x]) - 1) / 2
+        dy = (ymax - ymin) / (length(series[:y]) - 1) / 2
         img = Array(transpose_z(series, z.surf))
         z = if eltype(img) <: Colors.AbstractGray
             float(img)
@@ -743,7 +746,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             cmap = py_colormap(cgrad(plot_color([:black, :white]))),
             vmin = 0.0,
             vmax = 1.0,
-            extent = (xmin-0.5, xmax+0.5, ymax+0.5, ymin-0.5)
+            extent = (xmin - dx, xmax + dx, ymax + dy, ymin - dy)
         )
         push!(handles, handle)
 


### PR DESCRIPTION
Changes
```julia
using Plots
pyplot()

x = y = range(0, 1, length = 10)
z = rand(RGBA, 10, 10)

plot(x, y, z)
plot!(identity, 0, 1, lc = :black, lw = 3)
```
from
![pyplot-image_old](https://user-images.githubusercontent.com/16589944/87708089-7a609200-c7a2-11ea-8cce-b8b4a564f81f.png)
to
![pyplot-image_new](https://user-images.githubusercontent.com/16589944/87708117-83516380-c7a2-11ea-8255-0d05c7123852.png)

fixes #2864