### PR TITLE
Don't use `-pix_fmt yuv420p` when calling ffmpeg

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -98,7 +98,7 @@ function buildanimation(anim::Animation, fn::AbstractString,
             ffmpeg_exe(`-v $verbose_level -framerate $framerate -loop $loop -i $(animdir)/%06d.png -i "$(animdir)/palette.bmp" -lavfi "paletteuse=dither=sierra2_4a" -y $fn`)
         end
     else
-        ffmpeg_exe(`-v $verbose_level -framerate $framerate -loop $loop -i $(animdir)/%06d.png -pix_fmt yuv420p -y $fn`)
+        ffmpeg_exe(`-v $verbose_level -framerate $framerate -loop $loop -i $(animdir)/%06d.png -y $fn`)
     end
 
     show_msg && @info("Saved animation to ", fn)


### PR DESCRIPTION
The `yuv420p` format errors when the plot width/height is an odd number. This is especially annoying since the size sometimes differs slightly from what is specified in the `size` keyword, so it can't be reliably used to force an even number of pixels.
Testing locally with some graphs and heatmaps, the videos look fine without specifying `pix_fmt`.