### PR TITLE
Fix #2808: Make legend width proportional to plot size

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1014,9 +1014,11 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
         GR.selntran(1)
         GR.restorestate()
     end
+
+    legend_width_factor = (viewport_plotarea[2] - viewport_plotarea[1]) / 50 # Determines the width of legend box
     legend_textw = legendw
-    legend_rightw = 0.02 # To be made dynamic in a follow up PR
-    legend_leftw = 0.08 # To be made dynamic in a follow up PR
+    legend_rightw = legend_width_factor
+    legend_leftw = legend_width_factor * 4
     total_legendw = legend_textw + legend_leftw + legend_rightw
 
     x_legend_offset = (viewport_plotarea[2] - viewport_plotarea[1]) / 30
@@ -1895,9 +1897,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                 if st in (:path, :straightline, :path3d)
                     gr_set_transparency(lc, get_linealpha(series))
                     if series[:fillrange] === nothing || series[:ribbon] !== nothing
-                        GR.polyline([xpos - 0.07, xpos - 0.01], [ypos, ypos])
+                        GR.polyline([xpos - legend_width_factor * 3, xpos - legend_width_factor], [ypos, ypos])
                     else
-                        GR.polyline([xpos - 0.07, xpos - 0.01], [ypos+0.4dy, ypos+0.4dy])
+                        GR.polyline([xpos - legend_width_factor * 3, xpos - legend_width_factor], [ypos+0.4dy, ypos+0.4dy])
                     end
                 end
 
@@ -1910,7 +1912,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
                         0, 0.8 * sp[:legendfontsize] * msw / 8
                     end
                     gr_draw_markers(
-                        series, xpos - 0.035, ypos, clims, s, sw
+                        series, xpos - legend_width_factor * 2, ypos, clims, s, sw
                     )
                 end
 


### PR DESCRIPTION
Fix #2808 partially.
The marker scaling on window resizing still needs to be looked into. (Maybe in a separate PR?)

Before (Marker):
![2808-before](https://user-images.githubusercontent.com/38937684/88037749-c030a800-cb5e-11ea-91a7-19a249ec0d62.png)

After (Marker):
![2808-after](https://user-images.githubusercontent.com/38937684/88037777-c9ba1000-cb5e-11ea-8c14-32131e428b60.png)

Before (Line):
![2808-lines-before](https://user-images.githubusercontent.com/38937684/88037800-d0488780-cb5e-11ea-9970-0735c5842118.png)

After (Line):
![2808-lines-after](https://user-images.githubusercontent.com/38937684/88037819-d76f9580-cb5e-11ea-8009-6efd318c5f33.png)
