### PR TITLE
Fix #2848: Legend :top should start below axis spine

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -600,7 +600,7 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
         if s == :outertop
             ypos = viewport_plotarea[4] + y_legend_offset + legendh + xmirror * gr_axis_height(sp, sp[:xaxis])
         else
-            ypos = viewport_plotarea[4] - y_legend_offset
+            ypos = viewport_plotarea[4] - y_legend_offset - legend_dy
         end
     elseif occursin("bottom", str)
         if s == :outerbottom

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -585,7 +585,7 @@ function gr_legend_pos(sp::Subplot, w, h, viewport_plotarea)
             # As per https://github.com/jheinen/GR.jl/blob/master/src/jlgr.jl#L525
             xpos = viewport_plotarea[2] + x_legend_offset + legend_leftw + ymirror * gr_axis_width(sp, sp[:yaxis])
         else
-            xpos = viewport_plotarea[2] - legend_rightw - legend_textw
+            xpos = viewport_plotarea[2] - legend_rightw - legend_textw - x_legend_offset
         end
     elseif occursin("left", str)
         if occursin("outer", str)


### PR DESCRIPTION
Fix #2848.

Before:
![2848-before](https://user-images.githubusercontent.com/38937684/88038284-76948d00-cb5f-11ea-8043-2df8c725597d.png)

After:
![2848-after](https://user-images.githubusercontent.com/38937684/88038300-7a281400-cb5f-11ea-8759-8d83fe3a3284.png)
