### PR TITLE
Fix #2849: Cater guide in plot area calculations

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1027,15 +1027,20 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     dy = gr_point_mult(sp) * sp[:legendfontsize] * 1.75
     legendh = dy * legendn
     leg_str = string(sp[:legend])
+
+    xaxis, yaxis = sp[:xaxis], sp[:yaxis]
+    xmirror = xaxis[:guide_position] == :top || (xaxis[:guide_position] == :auto && xaxis[:mirror] == true)
+    ymirror = yaxis[:guide_position] == :right || (yaxis[:guide_position] == :auto && yaxis[:mirror] == true)
+
     if occursin("outer", leg_str)
         if occursin("right", leg_str)
-            viewport_plotarea[2] -= total_legendw + x_legend_offset # Lessen plot max width to make space for outer legend
+            viewport_plotarea[2] -= total_legendw + x_legend_offset
         elseif occursin("left", leg_str)
-            viewport_plotarea[1] += total_legendw + x_legend_offset # Increase plot min width to make space for outer legend
+            viewport_plotarea[1] += total_legendw + x_legend_offset + !ymirror * gr_axis_width(sp, sp[:yaxis])
         elseif occursin("top", leg_str)
             viewport_plotarea[4] -= legendh + dy + y_legend_offset
         elseif occursin("bottom", leg_str)
-            viewport_plotarea[3] += legendh + dy + y_legend_offset
+            viewport_plotarea[3] += legendh + dy + y_legend_offset + !xmirror * gr_axis_height(sp, sp[:xaxis])
         end
     end
     if sp[:legend] == :inline


### PR DESCRIPTION
Fixes #2849.
Last follow up PR to #2807. 

When approved, I will make a PR to update test images.

Before (Left):
![2849-before-left](https://user-images.githubusercontent.com/38937684/88478431-a974c180-cf61-11ea-8645-852b99ce8ae1.png)

After (Left):
![2849-after-left](https://user-images.githubusercontent.com/38937684/88478432-b0033900-cf61-11ea-9d0d-cafe354ed247.png)

Before (Bottom):
![2849-before-bottom](https://user-images.githubusercontent.com/38937684/88478433-b72a4700-cf61-11ea-9eff-acb3ed4089c4.png)

After (Bottom):
![2849-after-bottom](https://user-images.githubusercontent.com/38937684/88478438-bc879180-cf61-11ea-9c45-78ed0f64a924.png)
