### PR TITLE
Fix error when setting animation loop count

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -90,15 +90,15 @@ function buildanimation(anim::Animation, fn::AbstractString,
         if variable_palette
             # generate a colorpalette for each frame for highest quality, but larger filesize
             palette="palettegen=stats_mode=single[pal],[0:v][pal]paletteuse=new=1"
-            ffmpeg_exe(`-v $verbose_level -framerate $framerate -loop $loop -i $(animdir)/%06d.png -lavfi "$palette" -y $fn`)
+            ffmpeg_exe(`-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -lavfi "$palette" -loop $loop -y $fn`)
         else
             # generate a colorpalette first so ffmpeg does not have to guess it
             ffmpeg_exe(`-v $verbose_level -i $(animdir)/%06d.png -vf "palettegen=stats_mode=diff" -y "$(animdir)/palette.bmp"`)
             # then apply the palette to get better results
-            ffmpeg_exe(`-v $verbose_level -framerate $framerate -loop $loop -i $(animdir)/%06d.png -i "$(animdir)/palette.bmp" -lavfi "paletteuse=dither=sierra2_4a" -y $fn`)
+            ffmpeg_exe(`-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -i "$(animdir)/palette.bmp" -lavfi "paletteuse=dither=sierra2_4a" -loop $loop -y $fn`)
         end
     else
-        ffmpeg_exe(`-v $verbose_level -framerate $framerate -loop $loop -i $(animdir)/%06d.png -y $fn`)
+        ffmpeg_exe(`-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -loop $loop -y $fn`)
     end
 
     show_msg && @info("Saved animation to ", fn)


### PR DESCRIPTION
When creating an animation with a custom loop count, via, e.g., `gif(anim; loop=-1)`, so `mov(anim; loop=-1)`, FFMPEG throws the following error:

```
[image2 demuxer @ 000001fdf77ec280] Unable to parse option value "-1" as boolean
[image2 demuxer @ 000001fdf77ec280] Error setting option loop to value -1. 
```

This PR fixes the error by moving the `-loop` flag to after the `-i` input flag in the call to `ffmpeg_exe`. I believe the error is caused because the `-loop` flag occuring before `-i` controls how the input is interpreted, whereas the `-loop` flag occuring after `-i` controls how many loops are in the output.