### PR TITLE
Add :mesh3d series type for Plotly

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -38,7 +38,7 @@ const _axesAliases = Dict{Symbol,Symbol}(
 )
 
 const _3dTypes = [
-    :path3d, :scatter3d, :surface, :wireframe, :contour3d, :volume
+    :path3d, :scatter3d, :surface, :wireframe, :contour3d, :volume, :mesh3d
 ]
 const _allTypes = vcat([
     :none, :line, :path, :steppre, :steppost, :sticks, :scatter,

--- a/src/args.jl
+++ b/src/args.jl
@@ -288,7 +288,7 @@ const _series_defaults = KW(
                                      #     one logical series to be broken up (path and markers, for example)
     :hover              => nothing,  # text to display when hovering over the data points
     :stride             => (1,1),    # array stride for wireframe/surface, the first element is the row stride and the second is the column stride.
-    :connections	=> nothing,  # tuple of arrays to specifiy connectivity of a 3d mesh
+    :connections	  => nothing,  # tuple of arrays to specifiy connectivity of a 3d mesh
     :extra_kwargs       => Dict()
 )
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -288,6 +288,7 @@ const _series_defaults = KW(
                                      #     one logical series to be broken up (path and markers, for example)
     :hover              => nothing,  # text to display when hovering over the data points
     :stride             => (1,1),    # array stride for wireframe/surface, the first element is the row stride and the second is the column stride.
+    :connections	=> nothing,  # tuple of arrays to specifiy connectivity of a 3d mesh
     :extra_kwargs       => Dict()
 )
 

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -429,6 +429,7 @@ const _plotly_seriestype = [
     :shape,
     :scattergl,
     :straightline,
+    :mesh3d
 ]
 const _plotly_style = [:auto, :solid, :dash, :dot, :dashdot]
 const _plotly_marker = [

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -574,11 +574,19 @@ function plotly_series(plt::Plot, series::Series)
     elseif st == :mesh3d
 	plotattributes_out[:type] = "mesh3d"
         plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
-        plotattributes_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
+        
+	if :i in keys(series[:extra_kwargs]) && :j in keys(series[:extra_kwargs]) && :k in keys(series[:extra_kwargs])
+		plotattributes_out[:i] = series[:extra_kwargs][:i]
+		plotattributes_out[:j] = series[:extra_kwargs][:j]
+		plotattributes_out[:k] = series[:extra_kwargs][:k]
+	end
+
+	plotattributes_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
         plotattributes_out[:opacity] = series[:fillalpha]
         if series[:fill_z] !== nothing
             plotattributes_out[:surfacecolor] = plotly_surface_data(series, series[:fill_z])
         end
+        plotattributes_out[:showscale] = false 
     else
         @warn("Plotly: seriestype $st isn't supported.")
         return KW()

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -552,7 +552,7 @@ function plotly_series(plt::Plot, series::Series)
         plotattributes_out[:showscale] = hascolorbar(sp) && hascolorbar(series)
 
     elseif st in (:surface, :wireframe)
-	plotattributes_out[:type] = "surface"
+	  plotattributes_out[:type] = "surface"
         plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
         if st == :wireframe
             plotattributes_out[:hidesurface] = true

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -574,11 +574,19 @@ function plotly_series(plt::Plot, series::Series)
     elseif st == :mesh3d
 	plotattributes_out[:type] = "mesh3d"
         plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
-        
-	if :i in keys(series[:extra_kwargs]) && :j in keys(series[:extra_kwargs]) && :k in keys(series[:extra_kwargs])
-		plotattributes_out[:i] = series[:extra_kwargs][:i]
-		plotattributes_out[:j] = series[:extra_kwargs][:j]
-		plotattributes_out[:k] = series[:extra_kwargs][:k]
+       
+	if series[:connections] != nothing
+		if typeof(series[:connections]) <: Tuple{Array,Array,Array} 
+			i,j,k = series[:connections]
+			if length(i) == length(j) == length(k)
+				throw(ArgumentError("Argument connections must consist of equally sized arrays."))
+			end
+			plotattributes_out[:i] = i
+			plotattributes_out[:j] = j
+			plotattributes_out[:k] = k
+		else
+			throw(ArgumentError("Argument connections has to be a tuple of three arrays."))
+		end
 	end
 
 	plotattributes_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -588,13 +588,13 @@ function plotly_series(plt::Plot, series::Series)
 			throw(ArgumentError("Argument connections has to be a tuple of three arrays."))
 		end
 	end
-
 	plotattributes_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
+	plotattributes_out[:color] = rgba_string(plot_color(series[:fillcolor], series[:fillalpha]))
         plotattributes_out[:opacity] = series[:fillalpha]
         if series[:fill_z] !== nothing
             plotattributes_out[:surfacecolor] = plotly_surface_data(series, series[:fill_z])
         end
-        plotattributes_out[:showscale] = false 
+        plotattributes_out[:showscale] = hascolorbar(sp) 
     else
         @warn("Plotly: seriestype $st isn't supported.")
         return KW()

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -489,7 +489,6 @@ as_gradient(grad, α) = cgrad(alpha = α)
 # get a dictionary representing the series params (plotattributes is the Plots-dict, plotattributes_out is the Plotly-dict)
 function plotly_series(plt::Plot, series::Series)
     st = series[:seriestype]
-    println(st)
 
     sp = series[:subplot]
     clims = get_clims(sp, series)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1,4 +1,3 @@
-
 # https://plot.ly/javascript/getting-started
 
 is_subplot_supported(::PlotlyBackend) = true
@@ -446,7 +445,7 @@ function plotly_data(series::Series, letter::Symbol, data)
        data
     end
 
-    if series[:seriestype] in (:heatmap, :contour, :surface, :wireframe)
+    if series[:seriestype] in (:heatmap, :contour, :surface, :wireframe, :mesh3d)
         plotly_surface_data(series, data)
     else
         plotly_data(data)
@@ -490,6 +489,7 @@ as_gradient(grad, α) = cgrad(alpha = α)
 # get a dictionary representing the series params (plotattributes is the Plots-dict, plotattributes_out is the Plotly-dict)
 function plotly_series(plt::Plot, series::Series)
     st = series[:seriestype]
+    println(st)
 
     sp = series[:subplot]
     clims = get_clims(sp, series)
@@ -553,7 +553,7 @@ function plotly_series(plt::Plot, series::Series)
         plotattributes_out[:showscale] = hascolorbar(sp) && hascolorbar(series)
 
     elseif st in (:surface, :wireframe)
-        plotattributes_out[:type] = "surface"
+	plotattributes_out[:type] = "surface"
         plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
         if st == :wireframe
             plotattributes_out[:hidesurface] = true
@@ -572,7 +572,14 @@ function plotly_series(plt::Plot, series::Series)
             end
             plotattributes_out[:showscale] = hascolorbar(sp)
         end
-
+    elseif st == :mesh3d
+	plotattributes_out[:type] = "mesh3d"
+        plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
+        plotattributes_out[:colorscale] = plotly_colorscale(series[:fillcolor], series[:fillalpha])
+        plotattributes_out[:opacity] = series[:fillalpha]
+        if series[:fill_z] !== nothing
+            plotattributes_out[:surfacecolor] = plotly_surface_data(series, series[:fill_z])
+        end
     else
         @warn("Plotly: seriestype $st isn't supported.")
         return KW()

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -578,7 +578,7 @@ function plotly_series(plt::Plot, series::Series)
 	if series[:connections] != nothing
 		if typeof(series[:connections]) <: Tuple{Array,Array,Array} 
 			i,j,k = series[:connections]
-			if length(i) == length(j) == length(k)
+			if !(length(i) == length(j) == length(k))
 				throw(ArgumentError("Argument connections must consist of equally sized arrays."))
 			end
 			plotattributes_out[:i] = i

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -512,30 +512,6 @@ const _examples = PlotExample[
         ],
     ),
     PlotExample(
-	"Mesh3d",
-	"Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically. You can also specify the connections using the connections keyword. This is only supported on the Plotly backend. The connections are specified using a tuple of arrays where each array contains the index of the first, second and third vertex of a triangle.",
-	[
-		:(
-		  begin
-			# specify the vertices
-			x=[0, 1, 2, 0]
-			y=[0, 0, 1, 2]
-			z=[0, 2, 0, 1]
-
-			# specify the triangles 
-			# every column is one triangle,
-			# where the values denote the indices of the vertices of the triangle 
-			i=[0, 0, 0, 1]
-			j=[1, 2, 3, 2]
-			k=[2, 3, 1, 3]
-
-			# the four triangles gives above give a tetrahedron
-			mesh3d(x,y,z;connections=(i,j,k))
-		  end
-		),
-	],
-    ),
-    PlotExample(
         "DataFrames",
         "Plot using DataFrame column symbols.",
         [
@@ -1019,16 +995,40 @@ const _examples = PlotExample[
             scatter!(Point2.(eachcol(rand(d,1000))), alpha=0.25)
         end]
     ),
+    PlotExample(
+	"Mesh3d",
+	"Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically. You can also specify the connections using the connections keyword. This is only supported on the Plotly backend. The connections are specified using a tuple of arrays where each array contains the index of the first, second and third vertex of a triangle.",
+	[
+		:(
+		  begin
+			# specify the vertices
+			x=[0, 1, 2, 0]
+			y=[0, 0, 1, 2]
+			z=[0, 2, 0, 1]
+
+			# specify the triangles 
+			# every column is one triangle,
+			# where the values denote the indices of the vertices of the triangle 
+			i=[0, 0, 0, 1]
+			j=[1, 2, 3, 2]
+			k=[2, 3, 1, 3]
+
+			# the four triangles gives above give a tetrahedron
+			mesh3d(x,y,z;connections=(i,j,k))
+		  end
+		),
+	],
+    ),
 ]
 
 # Some constants for PlotDocs and PlotReferenceImages
 _animation_examples = [2, 31]
 _backend_skips = Dict(
-    :gr => [25, 30],
-    :pyplot => [2, 25, 30, 31],
+    :gr => [25, 30, 47],
+    :pyplot => [2, 25, 30, 31, 47],
     :plotlyjs => [2, 21, 24, 25, 30, 31],
     :plotly => [2, 21, 24, 25, 30, 31],
-    :pgfplots => [2, 5, 6, 10, 16, 20, 22, 23, 25, 28, 30, 31, 34, 37, 38, 39],
+    :pgfplots => [2, 5, 6, 10, 16, 20, 22, 23, 25, 28, 30, 31, 34, 37, 38, 39, 47],
     :pgfplotsx => [
         2, # animation
         6, # images
@@ -1039,6 +1039,7 @@ _backend_skips = Dict(
         31, # animation
         32, # spy
         38, # histogram2d
+	47, # mesh3d
     ],
 )
 

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1044,7 +1044,7 @@ _backend_skips = Dict(
         31, # animation
         32, # spy
         38, # histogram2d
-	47, # mesh3d
+	 47, # mesh3d
     ],
 )
 

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -512,6 +512,30 @@ const _examples = PlotExample[
         ],
     ),
     PlotExample(
+	"Mesh3d",
+	"Plot a 3d mesh",
+	[
+		:(
+		  begin
+			# specify the vertices
+			x=[0, 1, 2, 0]
+			y=[0, 0, 1, 2]
+			z=[0, 2, 0, 1]
+
+			# specify the triangles 
+			# every column is one triangle,
+			# where the values denote the indices of the vertices of the triangle 
+			i=[0, 0, 0, 1]
+			j=[1, 2, 3, 2]
+			k=[2, 3, 1, 3]
+
+			# the four triangles gives above give a tetrahedron
+			mesh3d(x,y,z;connections=(i,j,k))
+		  end
+		),
+	],
+    ),
+    PlotExample(
         "DataFrames",
         "Plot using DataFrame column symbols.",
         [

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -513,7 +513,7 @@ const _examples = PlotExample[
     ),
     PlotExample(
 	"Mesh3d",
-	"Plot a 3d mesh",
+	"Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically. You can also specify the connections using the connections keyword. This is only supported on the Plotly backend. The connections are specified using a tuple of arrays where each array contains the index of the first, second and third vertex of a triangle.",
 	[
 		:(
 		  begin

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -997,7 +997,12 @@ const _examples = PlotExample[
     ),
     PlotExample(
 	"Mesh3d",
-	"Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically. You can also specify the connections using the connections keyword. This is only supported on the Plotly backend. The connections are specified using a tuple of arrays where each array contains the index of the first, second and third vertex of a triangle.",
+	"""
+	Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically.
+	You can also specify the connections using the connections keyword. This is only supported on the Plotly backend.
+	The connections are specified using a tuple of vectors. Each vector contains the 0-based indices of one point of a triangle,
+	such that elements at the same position of these vectors form a triangle. 
+	""",
 	[
 		:(
 		  begin

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -328,12 +328,16 @@ end
 
 function _override_seriestype_check(plotattributes::AKW, st::Symbol)
     # do we want to override the series type?
+    println(RecipesPipeline.is3d(st))
+    println(st)
     if !RecipesPipeline.is3d(st) && !(st in (:contour, :contour3d))
         z = plotattributes[:z]
         if !isa(z, Nothing) &&
-           (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z))
+           (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z)) &&
+	   st !== :mesh3d
             st = (st == :scatter ? :scatter3d : :path3d)
-            plotattributes[:seriestype] = st
+	    println("hello hello hello")
+	    plotattributes[:seriestype] = st
         end
     end
     st

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -331,8 +331,7 @@ function _override_seriestype_check(plotattributes::AKW, st::Symbol)
     if !RecipesPipeline.is3d(st) && !(st in (:contour, :contour3d))
         z = plotattributes[:z]
         if !isa(z, Nothing) &&
-           (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z)) &&
-	   st !== :mesh3d
+           (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z)) 
             st = (st == :scatter ? :scatter3d : :path3d)
 	    plotattributes[:seriestype] = st
         end

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -331,9 +331,9 @@ function _override_seriestype_check(plotattributes::AKW, st::Symbol)
     if !RecipesPipeline.is3d(st) && !(st in (:contour, :contour3d))
         z = plotattributes[:z]
         if !isa(z, Nothing) &&
-           (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z)) 
+           (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z))
             st = (st == :scatter ? :scatter3d : :path3d)
-	    plotattributes[:seriestype] = st
+            plotattributes[:seriestype] = st
         end
     end
     st

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -328,15 +328,12 @@ end
 
 function _override_seriestype_check(plotattributes::AKW, st::Symbol)
     # do we want to override the series type?
-    println(RecipesPipeline.is3d(st))
-    println(st)
     if !RecipesPipeline.is3d(st) && !(st in (:contour, :contour3d))
         z = plotattributes[:z]
         if !isa(z, Nothing) &&
            (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z)) &&
 	   st !== :mesh3d
             st = (st == :scatter ? :scatter3d : :path3d)
-	    println("hello hello hello")
 	    plotattributes[:seriestype] = st
         end
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1547,4 +1547,3 @@ julia> areaplot(1:3, [1 2 3; 7 8 9; 4 5 6], seriescolor = [:red :green :blue], f
     end
 end
 
-is_3d(::Type{Val{:mesh3d}}) = true

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1536,3 +1536,10 @@ julia> areaplot(1:3, [1 2 3; 7 8 9; 4 5 6], seriescolor = [:red :green :blue], f
 end
 
 is_3d(::Type{Val{:mesh3d}}) = true
+# ---------------------------------------------------------------------------
+# mesh 3d
+
+@recipe function f(::Type{Val{:mesh3d}}, x, y, z)
+    seriestype := :mesh3d
+    ()
+end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -926,8 +926,6 @@ end
 end
 
 
-# note: don't add dependencies because this really isn't a drop-in replacement
-
 # ---------------------------------------------------------------------------
 # scatter 3d
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1534,3 +1534,5 @@ julia> areaplot(1:3, [1 2 3; 7 8 9; 4 5 6], seriescolor = [:red :green :blue], f
         end
     end
 end
+
+is_3d(::Type{Val{:mesh3d}}) = true

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -914,6 +914,21 @@ end
 
 
 # ---------------------------------------------------------------------------
+# mesh 3d replacement for non-plotly backends
+
+@recipe function f(::Type{Val{:mesh3d}}, x, y, z; i=nothing,j=nothing,k=nothing)
+    # As long as no i,j,k are supplied this should work with PyPlot and GR
+    seriestype := :surface
+    if i != nothing || j != nothing || k != nothing
+    	throw(ArgumentError("Giving triangles using i,j,k is only supported on Plotly backend."))
+    end
+    ()
+end
+
+
+# note: don't add dependencies because this really isn't a drop-in replacement
+
+# ---------------------------------------------------------------------------
 # scatter 3d
 
 @recipe function f(::Type{Val{:scatter3d}}, x, y, z)
@@ -927,7 +942,6 @@ end
 end
 
 # note: don't add dependencies because this really isn't a drop-in replacement
-
 
 # ---------------------------------------------------------------------------
 # lens! - magnify a region of a plot

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -916,11 +916,11 @@ end
 # ---------------------------------------------------------------------------
 # mesh 3d replacement for non-plotly backends
 
-@recipe function f(::Type{Val{:mesh3d}}, x, y, z; i=nothing,j=nothing,k=nothing)
+@recipe function f(::Type{Val{:mesh3d}}, x, y, z)
     # As long as no i,j,k are supplied this should work with PyPlot and GR
     seriestype := :surface
-    if i != nothing || j != nothing || k != nothing
-    	throw(ArgumentError("Giving triangles using i,j,k is only supported on Plotly backend."))
+    if plotattributes[:connections] != nothing 
+    	throw(ArgumentError("Giving triangles using the connections argument is only supported on Plotly backend."))
     end
     ()
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1536,10 +1536,3 @@ julia> areaplot(1:3, [1 2 3; 7 8 9; 4 5 6], seriescolor = [:red :green :blue], f
 end
 
 is_3d(::Type{Val{:mesh3d}}) = true
-# ---------------------------------------------------------------------------
-# mesh 3d
-
-@recipe function f(::Type{Val{:mesh3d}}, x, y, z)
-    seriestype := :mesh3d
-    ()
-end

--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -328,13 +328,13 @@ Plot a 3d mesh. On Plotly the triangles can be specified using the i,j,k argumen
 ```Julia
 x=[0, 1, 2, 0]
 y=[0, 0, 1, 2]
-z=[2, 4, 2, 3]
+z=[0, 2, 0, 1]
 
 i=[0, 0, 0, 1]
 j=[1, 2, 3, 2]
 k=[2, 3, 1, 3]
 
-mesh3d(x,y,z;i,j,k)
+plot(x,y,z,seriestype=:mesh3d;connections=(i,j,k))
 ```
 """
 @shorthands mesh3d

--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -320,9 +320,9 @@ julia> scatter3d([0,1,2,3],[0,1,4,9],[0,1,8,27])
 
 """
     mesh3d(x,y,z)
-    mesh3d(x,y,z;i,j,k)
+    mesh3d(x,y,z; connections)
 
-Plot a 3d mesh. On Plotly the triangles can be specified using the i,j,k arguments.
+Plot a 3d mesh. On Plotly the triangles can be specified using the connections argument.
 
 # Example
 ```Julia

--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -319,6 +319,27 @@ julia> scatter3d([0,1,2,3],[0,1,4,9],[0,1,8,27])
 @shorthands scatter3d
 
 """
+    mesh3d(x,y,z)
+    mesh3d(x,y,z;i,j,k)
+
+Plot a 3d mesh. On Plotly the triangles can be specified using the i,j,k arguments.
+
+# Example
+```Julia
+x=[0, 1, 2, 0]
+y=[0, 0, 1, 2]
+z=[2, 4, 2, 3]
+
+i=[0, 0, 0, 1]
+j=[1, 2, 3, 2]
+k=[2, 3, 1, 3]
+
+mesh3d(x,y,z;i,j,k)
+```
+"""
+@shorthands mesh3d
+
+"""
     boxplot(x, y)
     boxplot!(x, y)
 


### PR DESCRIPTION
This pull-request adds the possibility to plot arbitrary 3d meshes using the mesh3d plot type in Plotly. It can be seen as partial fix/implementation for #392. For backends other than Plotly there is a fallback recipe provided that however does not support specifying the triangles of the mesh. 

Example: 
```Julia
using Plots; plotly()

x=[0, 1, 2, 0]
y=[0, 0, 1, 2]
z=[2, 4, 2, 3]

i=[0, 0, 0, 1]
j=[1, 2, 3, 2]
k=[2, 3, 1, 3]

plot(x,y,z,seriestype=:mesh3d;i,j,k)
```
Output:
<img width="504" alt="image" src="https://user-images.githubusercontent.com/7027000/90148757-00610000-dd84-11ea-979a-f792bbbeeb7f.png">