### PR TITLE
Fixing xfvb issues

### DIFF
--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo ::set-env name=TESTCMD::"julia"
       - name: Ubuntu TESTCMD
         if: startsWith(matrix.os,'ubuntu')
-        run: echo ::set-env name=TESTCMD::"xvfb-run julia"
+        run: echo ::set-env name=TESTCMD::"xvfb-run --auto-servernum julia"
 
       # Generate precompile files
       - name: Generating precompile files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: echo ::set-env name=TESTCMD::"julia"
       - name: Ubuntu TESTCMD
         if: startsWith(matrix.os,'ubuntu')
-        run: echo ::set-env name=TESTCMD::"xvfb-run julia"
+        run: echo ::set-env name=TESTCMD::"xvfb-run --auto-servernum julia"
 
       # Julia Dependencies
       - name: Install Julia dependencies


### PR DESCRIPTION
Trying to fix the xfvb issues in the CI

Based on the documentation: https://manpages.ubuntu.com/manpages/trusty/man1/xvfb-run.1.html
Some times the xfvb server might be busy, so this command finds a free server.

Running SnoopCompile action, the Ubuntu jobs now run without any issues.
https://github.com/aminya/Plots.jl/runs/993198724?check_suite_focus=true