### PR TITLE
pin upload action version

### DIFF
--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -59,7 +59,7 @@ jobs:
         run: $TESTCMD --project -e 'include("deps/SnoopCompile/snoop_bench.jl")' # NOTE: optional, if have benchmark file
 
       - name: Upload all
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.0.1
         with:
           path: ./
 


### PR DESCRIPTION
I am tracking this issue in the [respective repository](https://github.com/actions/upload-artifact/issues/115), but for now let's pin the version. 

Here is the sample of a PR that is created: https://github.com/aminya/Plots.jl/pull/16/files

Run: https://github.com/aminya/Plots.jl/actions/runs/212234152
