### PR TITLE
fix horizontal range of hspan()

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -133,7 +133,7 @@ end
 
 @recipe function f(::Type{Val{:hspan}}, x, y, z)
     n = div(length(y), 2)
-    newx = repeat([1, 2, 2, 1, NaN], outer = n)
+    newx = repeat([-Inf, Inf, Inf, -Inf, NaN], outer = n)
     newy = vcat([[y[2i - 1], y[2i - 1], y[2i], y[2i], NaN] for i = 1:n]...)
     linewidth --> 0
     x := newx


### PR DESCRIPTION
hspan!() has an odd behaviour in Plots v1.6.6, instead of plotting from -Inf to +Inf over x it plots from 1 to 2. Minimum example

```julia
julia> plot(0:9)
julia> hspan!([2,3])
```
The horizontal rectangle is drawn between 1 and 2 instead of between the minimum and maximum x range of the plot.

This small patch will draw the rectangle with the correct horizontal span, similarly to what vspan!() does.

Cheers,
\--
Alberto