### PR TITLE
Fixed plotly_colorbar_hack() to avoid additional marker

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -584,9 +584,9 @@ function plotly_series(plt::Plot, series::Series)
     elseif st == :mesh3d
 	plotattributes_out[:type] = "mesh3d"
         plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
-       
+
 	if series[:connections] != nothing
-		if typeof(series[:connections]) <: Tuple{Array,Array,Array} 
+		if typeof(series[:connections]) <: Tuple{Array,Array,Array}
 			i,j,k = series[:connections]
 			if !(length(i) == length(j) == length(k))
 				throw(ArgumentError("Argument connections must consist of equally sized arrays."))
@@ -604,7 +604,7 @@ function plotly_series(plt::Plot, series::Series)
         if series[:fill_z] !== nothing
             plotattributes_out[:surfacecolor] = plotly_surface_data(series, series[:fill_z])
         end
-        plotattributes_out[:showscale] = hascolorbar(sp) 
+        plotattributes_out[:showscale] = hascolorbar(sp)
     else
         @warn("Plotly: seriestype $st isn't supported.")
         return KW()
@@ -824,8 +824,8 @@ function plotly_colorbar_hack(series::Series, plotattributes_base::KW, sym::Symb
     end
     # zrange = zmax == zmin ? 1 : zmax - zmin # if all marker_z values are the same, plot all markers same color (avoids division by zero in next line)
     plotattributes_out[:marker] = KW(
-        :size => 0,
-        :opacity => 0,
+        :size => 1e-10,
+        :opacity => 1e-10,
         :color => [0.5],
         :cmin => cmin,
         :cmax => cmax,


### PR DESCRIPTION
After recently adding "support for 3d-plots of seriestype sticks" (https://github.com/JuliaPlots/Plots.jl/pull/3002) I recognized in my scatter-plots additional points which should not be there when using the `plotly()` backend.

The following code produced the following figure:
```julia
plotly();
x,y,z,c = rand(10),rand(10),rand(10),rand(10);
scatter(x,y,z,marker_z=c,marker=(:circle),st=:sticks);
```
![markersticks_old](https://user-images.githubusercontent.com/20151553/94667851-9be80900-030f-11eb-8fe8-3cd049860c8d.png)

It seems that the main problem is that `plotly` uses a hack for creating the colorbar by adding one additional marker at the start of a new series. Therefore these two pinkish dots are added, one for the fill segments of the sticks and one for the general scatter plot. However, this behavior is unexpected because in `plotly_colorbar_hack()` the opacity and the size of this marker is set to 0.

In the end it turned out that a value of 0 (and also 0.0) is not working as markersize and/or markeropacity. Thus as an intermediate fix I set these values to a very small number and now it produces the following plot.
![markerssticks_fixed](https://user-images.githubusercontent.com/20151553/94668404-48c28600-0310-11eb-80c0-8904d4e247db.png)

As a final side remark this also happens without `st=:sticks`:
```julia
scatter(x,y,z,marker_z=c,marker=(:circle),st=:sticks);
```
old: 
![marker_old](https://user-images.githubusercontent.com/20151553/94668557-7ad3e800-0310-11eb-8f22-6bcc286e0bab.png)

fixed:
![marker_fixed](https://user-images.githubusercontent.com/20151553/94668545-77406100-0310-11eb-97e1-7ef0f09a9fc3.png)



