### PR TITLE
Changed labeling-behaviour of :sticks

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -280,7 +280,6 @@ end
     end
     fillrange := nothing
     seriestype := :path
-    println(plotattributes[:linecolor])
     if plotattributes[:linecolor] == :auto && plotattributes[:marker_z] !== nothing && plotattributes[:line_z] == nothing
         line_z := plotattributes[:marker_z]
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -280,7 +280,8 @@ end
     end
     fillrange := nothing
     seriestype := :path
-    if plotattributes[:marker_z] !== nothing && plotattributes[:line_z] == nothing
+    println(plotattributes[:linecolor])
+    if plotattributes[:linecolor] == :auto && plotattributes[:marker_z] !== nothing && plotattributes[:line_z] == nothing
         line_z := plotattributes[:marker_z]
     end
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -286,8 +286,6 @@ end
 
     # create a primary series for the markers
     if plotattributes[:markershape] != :none
-        tmplabel = deepcopy(plotattributes[:label])
-        label := ""
         primary := false
         @series begin
             seriestype := :scatter
@@ -296,7 +294,6 @@ end
             if z !== nothing
                 z := z
             end
-            label := tmplabel
             primary := true
             ()
         end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -280,11 +280,15 @@ end
     end
     fillrange := nothing
     seriestype := :path
+    if plotattributes[:marker_z] !== nothing && plotattributes[:line_z] == nothing
+        line_z := plotattributes[:marker_z]
+    end
 
-    # create a secondary series for the markers
+    # create a primary series for the markers
     if plotattributes[:markershape] != :none
         tmplabel = deepcopy(plotattributes[:label])
         label := ""
+        primary := false
         @series begin
             seriestype := :scatter
             x := x

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -283,6 +283,8 @@ end
 
     # create a secondary series for the markers
     if plotattributes[:markershape] != :none
+        tmplabel = deepcopy(plotattributes[:label])
+        label := ""
         @series begin
             seriestype := :scatter
             x := x
@@ -290,8 +292,8 @@ end
             if z !== nothing
                 z := z
             end
-            label := ""
-            primary := false
+            label := tmplabel
+            primary := true
             ()
         end
         markershape := :none


### PR DESCRIPTION
As mentioned in https://github.com/JuliaPlots/Plots.jl/pull/3002#issuecomment-701293633 the labeling behavior of sticks is (at least to me ) misleading.

So I changed the behavior to the following:

### Sticks alone; column 1x5 array
```julia
x,y,z = rand(1,5),rand(1,5),rand(1,5);
sticks(x,y,z,label = ["1" "2" "3" "4" "5"])
```
Expected: 
  - Labels for lines
  - Different colors (columns are separate series)
![stickslabel](https://user-images.githubusercontent.com/20151553/94689442-29872100-032f-11eb-84df-4f8470922bdd.png)

### Sticks+Marker; column 1x5 array
```julia
x,y,z = rand(1,5),rand(1,5),rand(1,5);
sticks(x,y,z,marker=(:circle),label = ["a" "b" "c" "d" "e"])
```
Expected: 
  - Labels for markers
  - Line and markers share a color (works also with color set by `marker_z`)
![sticksmarkerlabel](https://user-images.githubusercontent.com/20151553/94689650-6ce18f80-032f-11eb-83c8-8ec79a1afb50.png)

### Adjustments

It was necessary to set the markers (if they are added) as the primary series to achieve that. I am not sure if this introduces some other ambiguity elsewhere? However it didn't seem to make any problems by now.
