### PR TITLE
fix heatmap with x and y specifying edges in gr

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1537,7 +1537,7 @@ function gr_add_series(sp, series)
         dmin, dmax = GR.gr3.volume(y.v, 0)
     elseif st in (:heatmap, :image)
         if !ispolar(series)
-            x, y = heatmap_edges(x, xscale, y, yscale, size(z))
+            x, y = heatmap_edges(x, xscale, y, yscale, reverse(size(z)))
         end
         if st === :heatmap
             gr_draw_heatmap(series, x, y, z, clims)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1537,6 +1537,7 @@ function gr_add_series(sp, series)
         dmin, dmax = GR.gr3.volume(y.v, 0)
     elseif st in (:heatmap, :image)
         if !ispolar(series)
+            # `z` is already transposed, so we need to reverse before passing its size.
             x, y = heatmap_edges(x, xscale, y, yscale, reverse(size(z)))
         end
         if st === :heatmap


### PR DESCRIPTION
fix #3028 

```julia
using Plots; gr()

img = rand(6,8)

rows, cols = size(img)

xs = (0:cols) .- cols / 2 
ys = (0:rows) .- rows / 2

plot(xs, ys, img; st = :heatmap, color = :grays, ratio = 1)
```
![heatmapedges](https://user-images.githubusercontent.com/16589944/95016386-fb695000-0652-11eb-81e7-3e377fe80600.png)
