### PR TITLE
fix plotly not showing the second marker

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -708,7 +708,7 @@ function plotly_series_segments(series::Series, plotattributes_base::KW, x, y, z
     segments = iter_segments(series, st)
     plotattributes_outs = fill(KW(), (hasfillrange ? 2 : 1 ) * length(segments))
 
-    needs_scatter_fix = !isscatter && hasmarker && !any(isnan,y)
+    needs_scatter_fix = !isscatter && hasmarker && !any(isnan,y) && length(segments) > 1
 
     for (i,rng) in enumerate(segments)
         plotattributes_out = deepcopy(plotattributes_base)


### PR DESCRIPTION
Reported on slack, changes
```julia
using Plots; plotly()
plot(1:5, markershape = :circle)
```
from
![plotly_marker_old](https://user-images.githubusercontent.com/16589944/95177917-11941f00-07bf-11eb-8214-123d638be927.png)
to
![plotly_marker_new](https://user-images.githubusercontent.com/16589944/95177928-178a0000-07bf-11eb-84f3-115005df1cde.png)
