### PR TITLE
more friendly error when x,y shape mis-match

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -147,7 +147,21 @@ end
 
 function Base.display(::PlotsDisplay, plt::Plot)
     prepare_output(plt)
-    _display(plt)
+
+    try
+        _display(plt)
+    catch err
+        # need to be careful not to supress other kinds of error
+        # could use a more general error 'teleporter'
+        # 1. handle when length(x) != size(y,1)
+        if err isa BoundsError && length(err.i)==1
+            ex_nrows = length(err.i[1])
+            actual_nrows = size(err.a)[1]
+            @warn "length(x) == $ex_nrows, but only sees $actual_nrows in the other inputs."
+        else
+            rethorw()
+        end
+    end
 end
 
 _do_plot_show(plt, showval::Bool) = showval && gui(plt)

--- a/src/output.jl
+++ b/src/output.jl
@@ -159,7 +159,7 @@ function Base.display(::PlotsDisplay, plt::Plot)
             actual_nrows = size(err.a)[1]
             @warn "length(x) == $ex_nrows, but only sees $actual_nrows in the other inputs."
         else
-            rethorw()
+            rethrow()
         end
     end
 end


### PR DESCRIPTION
fix #3048
```
julia> plot( rand(5), rand(1,5) )
┌ Warning: length(x) == 5, but only sees 1 in the other inputs.
└ @ Plots ~/.julia/dev/Plots/src/output.jl:160

julia> plotly()
[ Info: For saving to png with the Plotly backend PlotlyBase has to be installed.
Plots.PlotlyBackend()

julia> plot( rand(5,3), rand(4,5) )
┌ Warning: length(x) == 5, but only sees 4 in the other inputs.
└ @ Plots ~/.julia/dev/Plots/src/output.jl:160
```