### PR TITLE
WIP add GR hexbin

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -355,6 +355,7 @@ const _gr_seriestype = [
     :wireframe,
     :volume,
     :shape,
+    :hexbin,
 ]
 const _gr_style = [:auto, :solid, :dash, :dot, :dashdot, :dashdotdot]
 const _gr_marker = _allMarkers

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1545,6 +1545,8 @@ function gr_add_series(sp, series)
         else
             gr_draw_image(series, x, y, z, clims)
         end
+    elseif st == :hexbin
+        gr_draw_hexbin(series, x, y)
     end
 
     # this is all we need to add the series_annotations text
@@ -1760,6 +1762,9 @@ function gr_draw_image(series, x, y, z, clims)
     GR.drawimage(xmin, xmax, ymax, ymin, w, h, rgba)
 end
 
+function gr_draw_hexbin(series, x, y)
+    GR.hexbin(x, y)
+end
 
 # ----------------------------------------------------------------
 


### PR DESCRIPTION
fix #3031

![image](https://user-images.githubusercontent.com/5306213/95542356-8df74f80-09c3-11eb-9109-f31c89958460.png)

clearly it doesn't work properly at the moment. I tried to do something similar to what we do for `heatmap` but realized we actually use `GR.drawimage` for heatmaps.

The issue is `GR.hexbin` doesn't take any `color, min, max` info. But I thought we were able to "correct" it after we draw the main `hexbin`.

Can you mentor me on this a bit? @BeastyBlacksmith 