### PR TITLE
add mesh3d support

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -818,6 +818,7 @@ const _pgfplotsx_seriestype = [
     :surface,
     :wireframe,
     :heatmap,
+    :mesh3d,
     :contour,
     :contour3d,
     :quiver,

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -527,6 +527,17 @@ function pgfx_add_series!(::Val{:heatmap}, axis, series_opt, series, series_func
     pgfx_add_legend!(axis, series, opt)
 end
 
+function pgfx_add_series!(::Val{:mesh3d}, axis, series_opt, series, series_func, opt)
+    ptable = join([ string(i, " ", j, " ", k, "\\\\") for (i, j, k) in zip(opt[:connections]...) ], "\n        ")
+    push!(
+        series_opt,
+        "patch" => nothing,
+        "table/row sep" => "\\\\",
+        "patch table" => ptable
+    )
+    pgfx_add_series!(axis, series_opt, series, series_func, opt)
+end
+
 function pgfx_add_series!(::Val{:contour}, axis, series_opt, series, series_func, opt)
     push!(axis.options, "view" => "{0}{90}")
     if isfilledcontour(series)

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1057,16 +1057,13 @@ _backend_skips = Dict(
     :pyplot => [2, 25, 30, 31, 47, 49],
     :plotlyjs => [2, 21, 24, 25, 30, 31, 49],
     :plotly => [2, 21, 24, 25, 30, 31, 49],
-    :pgfplots => [2, 5, 6, 10, 16, 20, 22, 23, 25, 28, 30, 31, 34, 37, 38, 39, 47],
     :pgfplotsx => [
         2, # animation
         6, # images
         16, # pgfplots thinks the upper panel is too small
-        25, # @df
         30, # @df
         31, # animation
         32, # spy
-        47, # mesh3
         49, # polar heatmap
     ],
 )

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1000,8 +1000,8 @@ const _examples = PlotExample[
 	"Mesh3d",
 	"""
 	Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically.
-	You can also specify the connections using the connections keyword. This is only supported on the Plotly backend.
-	The connections are specified using a tuple of vectors. Each vector contains the 0-based indices of one point of a triangle,
+	You can also specify the connections using the connections keyword.
+    The connections are specified using a tuple of vectors. Each vector contains the 0-based indices of one point of a triangle,
 	such that elements at the same position of these vectors form a triangle.
 	""",
 	[


### PR DESCRIPTION
```julia
x = [0, 1, 2, 0]
y = [0, 0, 1, 2]
z = [0, 2, 0, 1]
i = [0, 0, 0, 1]
j = [1, 2, 3, 2]
k = [2, 3, 1, 3]
mesh3d(x, y, z; connections = (i, j, k))
```
![mesh3d](https://user-images.githubusercontent.com/18145188/96346798-059d3c80-109e-11eb-976d-446d908c2b71.png)
