### PR TITLE
add series_projections of contour plots

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -287,6 +287,7 @@ const _series_defaults = KW(
     :hover              => nothing,  # text to display when hovering over the data points
     :stride             => (1,1),    # array stride for wireframe/surface, the first element is the row stride and the second is the column stride.
     :connections	  => nothing,  # tuple of arrays to specifiy connectivity of a 3d mesh
+    :series_projection  => :none, # allows e.g. projection to planes in a 3D plot 
     :extra_kwargs       => Dict()
 )
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -531,7 +531,7 @@ function get_colorgradient(series::Series)
     st = series[:seriestype]
     if st in (:surface, :heatmap) || isfilledcontour(series)
         series[:fillcolor]
-    elseif st in (:contour, :wireframe)
+    elseif st in (:contour, :wireframe, :contour3d)
         series[:linecolor]
     elseif series[:marker_z] !== nothing
         series[:markercolor]


### PR DESCRIPTION
It doesn't work too well at the moment and the API is up for debate, but currently
```julia
julia> surface(range(-3,3, length=30), range(-3,3, length=30),
               (x, y)->exp(-x^2-y^2),
               label="",
               colormap_name = "viridis", # there is some bug with the default colormap
               extra_kwargs =:subplot)

julia> contour3d!(range(-3,3, length=30), range(-3,3, length=30),
               (x, y)->exp(-x^2-y^2), series_projection = :xz,
               label="",
               colormap_name = "viridis",
               extra_kwargs =:subplot)

julia> contour3d!(range(-3,3, length=30), range(-3,3, length=30),
               (x, y)->exp(-x^2-y^2), series_projection = :zx,
               label="",
               colormap_name = "viridis",
               extra_kwargs =:subplot)

julia> contour3d!(range(-3,3, length=30), range(-3,3, length=30),
               (x, y)->exp(-x^2-y^2), series_projection = :yz,
               label="",
               colormap_name = "viridis",
               extra_kwargs =:subplot)
```

gives 
![surfaceNcontour](https://user-images.githubusercontent.com/18145188/96426148-2334e800-11fd-11eb-83e8-1dae230f576d.png)

Which has these lines I don't know yet where they come from.
Would fix https://github.com/JuliaPlots/Plots.jl/issues/2778