### PR TITLE
Fix CI + Use the triggering branch name in the SnoopCompile branch

### DIFF
--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -41,10 +41,10 @@ jobs:
 
       # TESTCMD
       - name: Default TESTCMD
-        run: echo ::set-env name=TESTCMD::"julia"
+        run: echo "TESTCMD=julia" >> $GITHUB_ENV
       - name: Ubuntu TESTCMD
         if: startsWith(matrix.os,'ubuntu')
-        run: echo ::set-env name=TESTCMD::"xvfb-run --auto-servernum julia"
+        run: echo "TESTCMD=xvfb-run --auto-servernum julia" >> $GITHUB_ENV
 
       # Generate precompile files
       - name: Generating precompile files

--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -78,7 +78,7 @@ jobs:
           commit-message: Update precompile_*.jl file
           title: "[AUTO] Update precompiles"
           labels: SnoopCompile
-          branch: "SnoopCompile_AutoPR"
+          branch: "Test_SnoopCompile_AutoPR_${{ github.ref }}"
 
 
   Skip:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,10 @@ jobs:
 
       # TESTCMD
       - name: Default TESTCMD
-        run: echo ::set-env name=TESTCMD::"julia"
+        run: echo "TESTCMD=julia" >> $GITHUB_ENV
       - name: Ubuntu TESTCMD
         if: startsWith(matrix.os,'ubuntu')
-        run: echo ::set-env name=TESTCMD::"xvfb-run --auto-servernum julia"
+        run: echo "TESTCMD=xvfb-run --auto-servernum julia" >> $GITHUB_ENV
 
       # Julia Dependencies
       - name: Install Julia dependencies


### PR DESCRIPTION
This will use separate SnoopCompile branches for separate triggering branches.

Fixes https://github.com/timholy/SnoopCompile.jl/issues/145#issuecomment-713086937

Running action: https://github.com/aminya/Plots.jl/actions/runs/386271477