### PR TITLE
fix pyplot polar heatmap size

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -911,7 +911,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 
             fig = plt.o
 
-            if RecipesPipeline.is3d(sp)
+            if RecipesPipeline.is3d(sp) || ispolar(sp)
                 cbax = fig."add_axes"([0.9, 0.1, 0.03, 0.8])
                 cb = fig."colorbar"(handle; cax=cbax, kw...)
             else


### PR DESCRIPTION
fix #3081 

```julia
using Plots
pyplot()
θ = deg2rad.(0:1:360)
r = 0:100
heatmap(θ, r, rand(length(θ), length(r))', projection = :polar)
```
![pyplot-polar](https://user-images.githubusercontent.com/16589944/96788734-3cec5000-13f4-11eb-9d62-8090d069e745.png)

Thanks a lot to @fhagemann for finding out when the regression happened!