### PR TITLE
fix missing z for 3d markerplots in PyPlot

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -480,9 +480,17 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     )
         for (i, rng) in enumerate(iter_segments(series, :scatter))
             xyargs = if st == :bar && !isvertical(series)
-                y[rng], x[rng]
+                if RecipesPipeline.is3d(sp)
+                    y[rng], x[rng], z[rng]
+                else
+                    y[rng], x[rng]
+                end        
             else
-                x[rng], y[rng]
+                if RecipesPipeline.is3d(sp)
+                    x[rng], y[rng], z[rng]
+                else 
+                    x[rng], y[rng]
+                end
             end
 
             handle = ax."scatter"(xyargs...;


### PR DESCRIPTION
This is an attempt to fix #3036.

For 3D plots, it seems like the `z` array is not passed, such that the markers are plotted at z = 0.

```julia
using Plots; pyplot()
plot([1,2,3],[1,3,2],[3,1,2], label = "Line")
scatter!([1,2,3],[1,3,2],[3,1,2], label = "Scatter", camera = (0,0), zlims = (0,3))
```

Old code:
![before_fix](https://user-images.githubusercontent.com/30291312/96926962-a0d74d00-14b6-11eb-9cc2-21e0b83f966e.png)

New code:
![after_fix](https://user-images.githubusercontent.com/30291312/96927037-bfd5df00-14b6-11eb-80f0-5b7b4f87fdee.png)


I am quite new to the Plots.jl code, so I cannot judge whether this pull request completely fixes the issue.

Feedback is very welcome!
