### PR TITLE
Safeguard against nothing arg to isfile in standalone_html_window

### DIFF
--- a/src/backends/web.jl
+++ b/src/backends/web.jl
@@ -45,7 +45,7 @@ function standalone_html_window(plt::AbstractPlot)
     old = use_local_dependencies[] # save state to restore afterwards
     # if we open a browser ourself, we can host local files, so
     # when we have a local plotly downloaded this is the way to go!
-    use_local_dependencies[] = isfile(plotly_local_file_path[])
+    use_local_dependencies[] = plotly_local_file_path[] === nothing ? false : isfile(plotly_local_file_path[])
     filename = write_temp_html(plt)
     open_browser_window(filename)
     # restore for other backends


### PR DESCRIPTION
Fixes #3093
There might still be an issue left though, since I guess `plotly_local_file_path` shouldn't be `nothing`?