### PR TITLE
more regular automatic categorical ticks

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -227,8 +227,9 @@ function get_ticks(sp::Subplot, axis::Axis; update = true)
                 if !isempty(dvals)
                     # discrete ticks...
                     n = length(dvals)
-                    rng = if ticks == :auto
-                        Int[round(Int,i) for i in range(1, stop=n, length=min(n,15))]
+                    rng = if ticks == :auto && n > 15
+                        Δ = ceil(Int, n / 10)
+                        Δ:Δ:n
                     else # if ticks == :all
                         1:n
                     end

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -12,3 +12,12 @@ end
     @test plot(1, axis=nothing)[1][:xaxis][:ticks] == []
     @test plot(1, axis=nothing)[1][:yaxis][:ticks] == []
 end # testset
+
+@testset "Categorical ticks" begin
+    p1 = plot('A':'M', 1:13)
+    p2 = plot('A':'Z', 1:26)
+    p3 = plot('A':'Z', 1:26, ticks = :all)
+    @test Plots.get_ticks(p1[1], p1[1][:xaxis])[2] == string.('A':'M')
+    @test Plots.get_ticks(p2[1], p2[1][:xaxis])[2] == string.('C':3:'Z')
+    @test Plots.get_ticks(p3[1], p3[1][:xaxis])[2] == string.('A':'Z')
+end


### PR DESCRIPTION
Changes
```julia
using Plots
x = [string(letter, num) for letter in 'a':'z' for num in 0:9]
plot([plot(x[1:n], 1:n) for n in (15, 18, 29, 52)]...)
```
from
![ticks_before](https://user-images.githubusercontent.com/16589944/97351082-94296f00-1891-11eb-96d4-cde9734bad78.png)
to
![ticks_regular](https://user-images.githubusercontent.com/16589944/97351107-9a1f5000-1891-11eb-84a9-4e0578723671.png)

@oheil would you consider this a fix for #3063?
