### PR TITLE
[WIP] Add hatched fill for GR and PyPlot

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -13,6 +13,7 @@ const _arg_desc = KW(
 :fillrange         	=> "Number or AbstractVector.  Fills area between fillrange and y for line-types, sets the base for bar/stick types, and similar for other types.",
 :fillcolor         	=> "Color Type. Color of the filled area of path or bar types.  `:match` will take the value from `:seriescolor`.",
 :fillalpha         	=> "Number in [0,1]. The alpha/opacity override for the fill area.  `nothing` (the default) means it will take the alpha value of fillcolor.",
+:fillstyle          => "Symbol. Style of the fill area. `nothing` (the default) means solid fill. Choose from :/, :\\, :|, :-, :+, :x",
 :markershape       	=> "Symbol, Shape, or AbstractVector. Choose from $(_allMarkers).",
 :markercolor       	=> "Color Type. Color of the interior of the marker or shape. `:match` will take the value from `:seriescolor`.",
 :markeralpha       	=> "Number in [0,1]. The alpha/opacity override for the marker interior.  `nothing` (the default) means it will take the alpha value of markercolor.",

--- a/src/args.jl
+++ b/src/args.jl
@@ -285,6 +285,7 @@ const _series_defaults = KW(
     :fillrange         => nothing,   # ribbons, areas, etc
     :fillcolor         => :match,
     :fillalpha         => nothing,
+    :fillstyle         => nothing,
     :markershape       => :none,
     :markercolor       => :match,
     :markeralpha       => nothing,
@@ -805,6 +806,7 @@ function processLineArg(plotattributes::AKW, arg)
         arg.size  === nothing || (plotattributes[:fillrange] = arg.size)
         arg.color === nothing || (plotattributes[:fillcolor] = arg.color == :auto ? :auto : plot_color(arg.color))
         arg.alpha === nothing || (plotattributes[:fillalpha] = arg.alpha)
+        arg.style === nothing || (plotattributes[:fillstyle] = arg.style)
 
     elseif typeof(arg) <: Arrow || arg in (:arrow, :arrows)
         plotattributes[:arrow] = arg
@@ -871,6 +873,7 @@ function processFillArg(plotattributes::AKW, arg)
         arg.size  === nothing || (plotattributes[:fillrange] = arg.size)
         arg.color === nothing || (plotattributes[:fillcolor] = arg.color == :auto ? :auto : plot_color(arg.color))
         arg.alpha === nothing || (plotattributes[:fillalpha] = arg.alpha)
+        arg.style === nothing || (plotattributes[:fillstyle] = arg.style)
 
     elseif typeof(arg) <: Bool
         plotattributes[:fillrange] = arg ? 0 : nothing

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -110,6 +110,7 @@ end
 
 gr_set_linecolor(c)   = GR.setlinecolorind(gr_getcolorind(_cycle(c,1)))
 gr_set_fillcolor(c)   = GR.setfillcolorind(gr_getcolorind(_cycle(c,1)))
+
 gr_set_markercolor(c) = GR.setmarkercolorind(gr_getcolorind(_cycle(c,1)))
 gr_set_bordercolor(c) = GR.setbordercolorind(gr_getcolorind(_cycle(c,1)))
 gr_set_textcolor(c)   = GR.settextcolorind(gr_getcolorind(_cycle(c,1)))
@@ -132,6 +133,24 @@ gr_set_arrowstyle(s::Symbol) = GR.setarrowstyle(get(
     s,
     1,
 ))
+
+gr_set_fillstyle(::Nothing) = GR.setfillintstyle(GR.INTSTYLE_SOLID)
+function gr_set_fillstyle(s::Symbol)
+    GR.setfillintstyle(GR.INTSTYLE_HATCH)
+    GR.setfillstyle(get(
+        (
+            / = 9,
+            \ = 10,
+            | = 7,
+            - = 8,
+            + = 11,
+            x = 6,
+        ),
+        s,
+        9),
+    )
+end
+
 
 # --------------------------------------------------------------------------------------
 
@@ -914,7 +933,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     gr_update_viewport_ratio!(viewport_plotarea, sp)
     leg = gr_get_legend_geometry(viewport_plotarea, sp)
     gr_update_viewport_legend!(viewport_plotarea, sp, leg)
-    
+
     # fill in the plot area background
     gr_fill_plotarea(sp, viewport_plotarea)
 
@@ -998,6 +1017,8 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                 if (st == :shape || series[:fillrange] !== nothing) && series[:ribbon] === nothing
                     fc = get_fillcolor(series, clims)
                     gr_set_fill(fc) #, series[:fillalpha])
+                    fs = get_fillstyle(series, i)
+                    gr_set_fillstyle(fs)
                     l, r = xpos - leg.width_factor * 3.5, xpos - leg.width_factor / 2
                     b, t = ypos - 0.4 * leg.dy, ypos + 0.4 * leg.dy
                     x = [l, r, r, l, l]
@@ -1468,10 +1489,10 @@ function gr_label_axis_3d(sp, letter)
     if ax[:guide] != ""
         near_letter = letter in (:x, :z) ? :y : :x
         far_letter = letter in (:x, :y) ? :z : :x
-    
+
         nax = sp[Symbol(near_letter, :axis)]
         fax = sp[Symbol(far_letter, :axis)]
-    
+
         amin, amax = axis_limits(sp, letter)
         namin, namax = axis_limits(sp, near_letter)
         famin, famax = axis_limits(sp, far_letter)
@@ -1629,6 +1650,8 @@ function gr_draw_segments(series, x, y, fillrange, clims)
             for (i, rng) in enumerate(segments)
                 fc = get_fillcolor(series, clims, i)
                 gr_set_fillcolor(fc)
+                fs = get_fillstyle(series, i)
+                gr_set_fillstyle(fs)
                 fx = _cycle(x, vcat(rng, reverse(rng)))
                 fy = vcat(_cycle(fr_from, rng), _cycle(fr_to, reverse(rng)))
                 gr_set_transparency(fc, get_fillalpha(series, i))
@@ -1709,6 +1732,8 @@ function gr_draw_shapes(series, x, y, clims)
             # draw the interior
             fc = get_fillcolor(series, clims, i)
             gr_set_fill(fc)
+            fs = get_fillstyle(series, i)
+            gr_set_fillstyle(fs)
             gr_set_transparency(fc, get_fillalpha(series, i))
             GR.fillarea(xseg, yseg)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -557,6 +557,10 @@ function get_linestyle(series, i::Int = 1)
     _cycle(series[:linestyle], i)
 end
 
+function get_fillstyle(series, i::Int = 1)
+    _cycle(series[:fillstyle], i)
+end
+
 function get_markerstrokecolor(series, i::Int = 1)
     msc = series[:markerstrokecolor]
     isa(msc, ColorGradient) ? msc : _cycle(msc, i)
@@ -592,6 +596,7 @@ function has_attribute_segments(series::Series)
             :linestyle,
             :fillcolor,
             :fillalpha,
+            :fillstyle,
             :markercolor,
             :markeralpha,
             :markersize,


### PR DESCRIPTION
I took a crack at adding a `fillstyle` argument which allows a few different hatching patterns, as suggested on [Discourse](https://discourse.julialang.org/t/hatched-fill-with-plots-and-gr/43640) and [Gitter](https://gitter.im/tbreloff/Plots.jl?at=5c5c16d5ceb5a2264fab8413). I (kind of arbitrarily) followed the PyPlot convention in letting the possible values of `fillstyle` be `:/`, `:\`, `:|`, `:-`, `:+`, `:x`, and `nothing` (the default, which keeps the solid fill).

In PyPlot:
```
using Plots, PyPlot
pyplot()
Y = rand(10)
plot(y .+ 1, fillrange = y, fillstyle = :/)
```

<img src="https://user-images.githubusercontent.com/6033297/97397902-854db700-18a7-11eb-8820-a4d63f810605.png" width="300"> <img src="https://user-images.githubusercontent.com/6033297/97397958-9dbdd180-18a7-11eb-8809-05ac977a3624.png" width="300">
<img src="https://user-images.githubusercontent.com/6033297/97397987-a8786680-18a7-11eb-9ad0-d11028017049.png" width="300"> <img src="https://user-images.githubusercontent.com/6033297/97397980-a4e4df80-18a7-11eb-8947-d09ba6b3274a.png" width="300">
<img src="https://user-images.githubusercontent.com/6033297/97397985-a7473980-18a7-11eb-9408-3e0799ab362d.png" width="300"> <img src="https://user-images.githubusercontent.com/6033297/97397972-a2828580-18a7-11eb-8b1c-2d65d4927863.png" width="300">

In GR, I unfortunately can't figure out how to change the color of the hatching from black:
```
using Plots
gr()
Y = rand(10)
plot(y .+ 1, fillrange = y, fillstyle = :/)
```
<img src="https://user-images.githubusercontent.com/6033297/97398241-158bfc00-18a8-11eb-94c6-f0cfe0401af6.png" width="450">

Would love to get your feedback and suggestions!