### PR TITLE
Fix plotting images with custom axes in GR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -68,8 +68,9 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 
 [targets]
-test = ["Distributions", "FileIO", "Gtk", "ImageMagick", "Images", "LibGit2", "OffsetArrays", "PGFPlotsX", "HDF5", "RDatasets", "StableRNGs", "StaticArrays", "StatsPlots", "Test", "UnicodePlots", "VisualRegressionTests"]
+test = ["Distributions", "FileIO", "Gtk", "ImageMagick", "Images", "LibGit2", "OffsetArrays", "PGFPlotsX", "HDF5", "RDatasets", "StableRNGs", "StaticArrays", "StatsPlots", "Test", "TestImages", "UnicodePlots", "VisualRegressionTests"]

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1578,16 +1578,14 @@ function gr_add_series(sp, series)
         sp[:legend] = :none
         GR.gr3.clear()
         dmin, dmax = GR.gr3.volume(y.v, 0)
-    elseif st in (:heatmap, :image)
+    elseif st === :heatmap
         if !ispolar(series)
             # `z` is already transposed, so we need to reverse before passing its size.
             x, y = heatmap_edges(x, xscale, y, yscale, reverse(size(z)))
         end
-        if st === :heatmap
-            gr_draw_heatmap(series, x, y, z, clims)
-        else
-            gr_draw_image(series, x, y, z, clims)
-        end
+        gr_draw_heatmap(series, x, y, z, clims)
+    elseif st === :image
+        gr_draw_image(series, x, y, z, clims)
     end
 
     # this is all we need to add the series_annotations text

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1067,6 +1067,20 @@ const _examples = PlotExample[
         )
         end]
     ),
+    PlotExample( # 51
+        "Images with custom axes",
+        "",
+        [quote
+            using Plots
+            using TestImages
+            img = testimage("lighthouse")
+            
+            # plot the image reversing the first dimension and setting yflip = false
+            plot([-π, π], [-1, 1], reverse(img, dims=1), yflip=false, aspect_ratio=:none)
+            # plot other data
+            plot!(sin, -π, π, lw=3, color=:red)
+        end]
+    ),
 ]
 
 # Some constants for PlotDocs and PlotReferenceImages
@@ -1074,8 +1088,8 @@ _animation_examples = [2, 31]
 _backend_skips = Dict(
     :gr => [25, 30, 47],
     :pyplot => [2, 25, 30, 31, 47, 49],
-    :plotlyjs => [2, 21, 24, 25, 30, 31, 49],
-    :plotly => [2, 21, 24, 25, 30, 31, 49],
+    :plotlyjs => [2, 21, 24, 25, 30, 31, 49, 51],
+    :plotly => [2, 21, 24, 25, 30, 31, 49, 51],
     :pgfplotsx => [
         2, # animation
         6, # images
@@ -1084,6 +1098,7 @@ _backend_skips = Dict(
         31, # animation
         32, # spy
         49, # polar heatmap
+        51, # image with custom axes
     ],
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Plots
 using Random
 using StableRNGs
 using Test
+using TestImages
 using FileIO
 using Gtk
 using LibGit2


### PR DESCRIPTION
fix #3136

I added a new test example:
```julia
using Plots
using TestImages
img = testimage("lighthouse")

# plot the image reversing the first dimension and setting yflip = false
plot([-π, π], [-1, 1], reverse(img, dims=1), yflip=false, aspect_ratio=:none)
# plot other data
plot!(sin, -π, π, lw=3, color=:red)
```
![testimage](https://user-images.githubusercontent.com/16589944/98946794-a2fc5c80-24f4-11eb-9630-b0a71c356d8a.png)
