### PR TITLE
add 3dquiver to pgfplotsx

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -587,12 +587,13 @@ function pgfx_add_series!(::Val{:quiver}, axis, series_opt, series, series_func,
         )
         x = opt[:x]
         y = opt[:y]
-        if is3d(series)
+        z = opt[:z]
+        if z !== nothing
             push!(series_opt["quiver"], "w" => "\\thisrow{w}")
             table = PGFPlotsX.Table([
                 :x => x,
                 :y => y,
-                :z => opt[:z],
+                :z => z,
                 :u => opt[:quiver][1],
                 :v => opt[:quiver][2],
                 :w => opt[:quiver][3],

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -282,7 +282,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 )
                 extra_series, extra_series_opt = pgfx_split_extra_opts(series[:extra_kwargs])
                 series_opt = merge(series_opt, PGFPlotsX.Options(extra_series_opt...))
-                if RecipesPipeline.is3d(series) || st in (:heatmap, :contour)
+                if RecipesPipeline.is3d(series) || st in (:heatmap, :contour) || (st == :quiver && opt[:z] !== nothing)
                     series_func = PGFPlotsX.Plot3
                 else
                     series_func = PGFPlotsX.Plot
@@ -587,12 +587,24 @@ function pgfx_add_series!(::Val{:quiver}, axis, series_opt, series, series_func,
         )
         x = opt[:x]
         y = opt[:y]
-        table = PGFPlotsX.Table([
-            :x => x,
-            :y => y,
-            :u => opt[:quiver][1],
-            :v => opt[:quiver][2],
-        ])
+        if is3d(series)
+            push!(series_opt["quiver"], "w" => "\\thisrow{w}")
+            table = PGFPlotsX.Table([
+                :x => x,
+                :y => y,
+                :z => opt[:z],
+                :u => opt[:quiver][1],
+                :v => opt[:quiver][2],
+                :w => opt[:quiver][3],
+            ])
+        else
+            table = PGFPlotsX.Table([
+                :x => x,
+                :y => y,
+                :u => opt[:quiver][1],
+                :v => opt[:quiver][2],
+            ])
+        end
     end
     series_plot = series_func(series_opt, table)
     push!(axis, series_plot)

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1055,10 +1055,10 @@ const _examples = PlotExample[
         f(x,a) = 1/x + a*x^2
         xs = collect(0.1:0.05:2.0);
         as = collect(0.2:0.1:2.0);
-        
+
         x_grid = [x for x in xs for y in as];
         a_grid = [y for x in xs for y in as];
-        
+
         plot(x_grid, a_grid, f.(x_grid,a_grid),
             st = :surface,
             xlabel = "longer xlabel",
@@ -1074,7 +1074,7 @@ const _examples = PlotExample[
             using Plots
             using TestImages
             img = testimage("lighthouse")
-            
+
             # plot the image reversing the first dimension and setting yflip = false
             plot([-π, π], [-1, 1], reverse(img, dims=1), yflip=false, aspect_ratio=:none)
             # plot other data
@@ -1090,15 +1090,15 @@ const _examples = PlotExample[
             ϕs = range(-π, π, length=50)
             θs = range(0, π, length=25)
             θqs = range(1, π-1, length=25)
-            
+
             x = vec([sin(θ) * cos(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θs)])
             y = vec([sin(θ) * sin(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θs)])
             z = vec([cos(θ) for (ϕ, θ) in Iterators.product(ϕs, θs)])
-            
+
             u = 0.1 * vec([sin(θ) * cos(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
             v = 0.1 * vec([sin(θ) * sin(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
             w = 0.1 * vec([cos(θ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
-            
+
             quiver(x,y,z, quiver=(u,v,w))
         end]
     ),
@@ -1120,7 +1120,6 @@ _backend_skips = Dict(
         32, # spy
         49, # polar heatmap
         51, # image with custom axes
-        52, # 3d quiver
     ],
 )
 

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -316,7 +316,7 @@ end
 
 function _override_seriestype_check(plotattributes::AKW, st::Symbol)
     # do we want to override the series type?
-    if !RecipesPipeline.is3d(st) && !(st in (:contour, :contour3d))
+    if !RecipesPipeline.is3d(st) && !(st in (:contour, :contour3d, :quiver))
         z = plotattributes[:z]
         if !isa(z, Nothing) &&
            (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z))


### PR DESCRIPTION
This is a native 3d quiver implementation for pgfplotsx.

However, I get different results for the example in https://github.com/JuliaPlots/Plots.jl/pull/3134
```julia
using Plots
pgfplotsx()
ϕs = range(-π, π, length=50)
θs = range(0, π, length=25)
θqs = range(1, π-1, length=25)

x = vec([sin(θ) * cos(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θs)])
y = vec([sin(θ) * sin(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θs)])
z = vec([cos(θ) for (ϕ, θ) in Iterators.product(ϕs, θs)])

u = 0.1 * vec([sin(θ) * cos(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
v = 0.1 * vec([sin(θ) * sin(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
w = 0.1 * vec([cos(θ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])

quiver(x,y,z, quiver=(u,v,w), arrow = true)
```
![3dquiver](https://user-images.githubusercontent.com/18145188/99060107-d647f580-259f-11eb-9717-232f529f86be.png)

Did I get something wrong? @daschw, @kellertuer

EDIT: nevermind, I found the mistake

![3dquiver](https://user-images.githubusercontent.com/18145188/99060553-7c93fb00-25a0-11eb-8e3f-ba918a0a27a8.png)
