### PR TITLE
Default fontsize for pgfplotsx backend

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -887,6 +887,13 @@ function pgfx_font(fontsize, thickness_scaling = 1, font = "\\selectfont")
     return string("{\\fontsize{", fs, " pt}{", 1.3fs, " pt}", font, "}")
 end
 
+# If a particular fontsize parameter is `nothing`, produce a figure that doesn't specify the
+# font size, and therefore uses whatever fontsize is utilised by the doc in which the
+# figure is located.
+function pgfx_font(fontsize::Nothing, thickness_scaling = 1, font = "\\selectfont")
+    return string("{", font, "}")
+end
+
 function pgfx_should_add_to_legend(series::Series)
     series.plotattributes[:primary] &&
     !(


### PR DESCRIPTION
@BeastyBlacksmith , this is as per our discussion on [this discourse thread](https://discourse.julialang.org/t/plots-jl-default-label-size/49454).

Is there any unit testing that you would like me to provide? Not sure how best to go about it.

edit: additionally, assuming this is an acceptable change, what's the Plots' policy regarding releases? Should I bump the minor / patch version, or do you generally wait to group new bits of code together?