### PR TITLE
Support plotting `OffsetArray`s for `:sticks` series type

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -268,15 +268,15 @@ end
         end
     end
     newx, newy = zeros(3n), zeros(3n)
-    newz = z!== nothing ? zeros(3n) : nothing
-    for i = 1:n
+    newz = z !== nothing ? zeros(3n) : nothing
+    for (i, (xi, yi, zi)) = enumerate(zip(x, y, z !== nothing ? z : 1:n))
         rng = (3i - 2):(3i)
-        newx[rng] = [x[i], x[i], NaN]
+        newx[rng] = [xi, xi, NaN]
         if z !== nothing
-            newy[rng] = [y[i], y[i], NaN]
-            newz[rng] = [_cycle(fr, i), z[i], NaN]
+            newy[rng] = [yi, yi, NaN]
+            newz[rng] = [_cycle(fr, i), zi, NaN]
         else
-            newy[rng] = [_cycle(fr, i), y[i], NaN]
+            newy[rng] = [_cycle(fr, i), yi, NaN]
         end
     end
     x := newx

--- a/test/test_recipes.jl
+++ b/test/test_recipes.jl
@@ -1,4 +1,6 @@
 using Plots, Test
+using OffsetArrays
+
 @testset "lens!" begin
     pl = plot(1:5)
     lens!(pl, [1,2], [1,2], inset = (1, bbox(0.0,0.0,0.2,0.2)), colorbar = false)
@@ -23,3 +25,9 @@ end # testset
     vsp = vspan([1,3], ylims=(-2,5), widen = false)
     @test Plots.ylims(vsp) == (-2,5)
 end # testset
+
+@testset "offset axes" begin
+    tri = OffsetVector(vcat(1:5, 4:-1:1), 11:19)
+    sticks = plot(tri, seriestype = :sticks)
+    @test length(sticks) == 1
+end


### PR DESCRIPTION
This is my attempt at fixing #3166 which appears to be due to just assuming the inputs have standard 1-based indexing.

I'm not sure what the best test for this actually is within the testing framework (I'm a pretty casual user of `Plots`), but it appears `OffsetArrays` is already a listed as a test dependency in `Project.toml` even though I didn't find it actually imported anywhere already.

Fixes #3166.