### PR TITLE
Fix #1531, allows Date and DateTime objects to be xlims

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -426,6 +426,11 @@ end
 
 # -------------------------------------------------------------------------
 
+# handle widen in the case that xlims are of type Date or DateTime
+function widen(dmin::Union{Date,DateTime}, dmax::Union{Date,DateTime}, scale = :identity)
+    widen(Dates.value(dmin), Dates.value(dmax), scale)
+end
+
 # push the limits out slightly
 function widen(lmin, lmax, scale = :identity)
     f, invf = RecipesPipeline.scale_func(scale), RecipesPipeline.inverse_scale_func(scale)
@@ -674,7 +679,7 @@ function axis_drawing_info(sp, letter)
                             reverse_if((tick, tick_stop), isy),
                         )
                     end
-                    if ax[:minorgrid] 
+                    if ax[:minorgrid]
                         push!(
                             minorgrid_segments,
                             reverse_if((tick, oamin), isy),
@@ -728,7 +733,7 @@ function axis_drawing_info_3d(sp, letter)
     minorgrid_segments = Segments(3)
     border_segments = Segments(3)
 
-    
+
     if sp[:framestyle] != :none# && letter === :x
         na0, na1 = if sp[:framestyle] in (:origin, :zerolines)
             0, 0

--- a/test/integration_dates.jl
+++ b/test/integration_dates.jl
@@ -14,3 +14,29 @@ using Plots, Test, Dates
     @test Plots.ylims(p) == ref_ylims
     @test Plots.xlims(p) == ref_xlims
 end # testset
+
+@testset "Date xlims" begin
+    y=[1.0*i*i for i in 1:10]
+    x=[Date(2019,11,i) for i in 1:10]
+    span = (Date(2019,10,31), Date(2019,11,11))
+
+    p = plot(x,y, xlims=span, widen = false)
+
+    ref_ylims = (y[1], y[end])
+    ref_xlims = span
+    @test Plots.ylims(p) == ref_ylims
+    @test Plots.xlims(p) == ref_xlims
+end # testset
+
+@testset "DateTime xlims" begin
+    y=[1.0*i*i for i in 1:10]
+    x=[Date(2019,11,i) for i in 1:10]
+    span = (DateTime(2019,10,31,11,59,59), DateTime(2019,11,11,12,01,15))
+
+    p = plot(x,y, xlims=span, widen = false)
+
+    ref_ylims = (y[1], y[end])
+    ref_xlims = span
+    @test Plots.ylims(p) == ref_ylims
+    @test Plots.xlims(p) == ref_xlims
+end # testset


### PR DESCRIPTION
Resolves https://github.com/JuliaPlots/Plots.jl/issues/1531, allowing `xlims` to be set to Date or DateTime values. Also adds two unit tests that show xlims working with both Date and DateTime.