### PR TITLE
Gnuplot (GASTON) backend testing

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -256,6 +256,7 @@ end
 @init_backend PGFPlotsX
 @init_backend InspectDR
 @init_backend HDF5
+@init_backend Gaston
 
 # ---------------------------------------------------------
 
@@ -568,6 +569,34 @@ const _pyplot_seriestype = [
 const _pyplot_style = [:auto, :solid, :dash, :dot, :dashdot]
 const _pyplot_marker = vcat(_allMarkers, :pixel)
 const _pyplot_scale = [:identity, :ln, :log2, :log10]
+
+# ------------------------------------------------------------------------------
+# Gaston
+
+function _initialize_backend(::GastonBackend)
+    @eval Main begin
+        import Gaston
+        export Gaston
+    end
+end
+
+const _gaston_attr = merge_with_base_supported([
+    :label,
+    :legend,
+    :seriescolor,
+    :seriesalpha,
+    :linestyle,
+    :markershape,
+    :bins,
+    :title,
+    :guide, :lims,
+  ])
+const _gaston_seriestype = [
+    :path, :scatter, :shape, :straightline,
+]
+const _gaston_style = [:auto, :solid]
+const _gaston_marker = [:none, :auto, :circle]
+const _gaston_scale = [:identity]
 
 # ------------------------------------------------------------------------------
 # unicodeplots

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -598,8 +598,11 @@ const _gaston_attr = merge_with_base_supported([
     # :bar_width, :bar_edges,
     # :title,
     # :window_title,
-    # :guide, :guide_position, :lims, :ticks, :scale, :flip, :rotation,
-    # :tickfont, :guidefont, :legendfont,
+    :guide,
+    # :guide_position,
+    :lims, :ticks, :scale, # :flip, :rotation,
+    :tickfont, :guidefont,
+    # :legendfont,
     # :grid, :legend,
     # :colorbar, :colorbar_title,
     # :fill_z, :line_z, :marker_z, :levels,
@@ -623,7 +626,7 @@ const _gaston_seriestype = [:path,
                             # :histogram2d,
                             # :ysticks, :xsticks,
                             # :contour,
-                            # :shape,
+                            :shape,
                             # :straightline,
                             ]
 
@@ -650,7 +653,7 @@ const _gaston_marker = [:none,
 const _gaston_scale = [:identity,
                        # :ln,
                        # :log2,
-                       # :log10,
+                       :log10,
                        ]
 
 # ------------------------------------------------------------------------------

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -581,22 +581,77 @@ function _initialize_backend(::GastonBackend)
 end
 
 const _gaston_attr = merge_with_base_supported([
+    # :annotations,
+    # :background_color_legend,
+    # :background_color_inside,
+    # :background_color_outside,
+    # :foreground_color_legend,
+    # :foreground_color_grid, :foreground_color_axis,
+    # :foreground_color_text, :foreground_color_border,
     :label,
-    :legend,
-    :seriescolor,
-    :seriesalpha,
-    :linestyle,
-    :markershape,
-    :bins,
-    :title,
-    :guide, :lims,
+    # :seriescolor, :seriesalpha,
+    :linecolor, :linestyle, :linewidth, :linealpha,
+    :markershape, :markercolor, :markersize, :markeralpha,
+    # :markerstrokewidth, :markerstrokecolor, :markerstrokealpha, :markerstrokestyle,
+    # :fillrange, :fillcolor, :fillalpha,
+    # :bins,
+    # :bar_width, :bar_edges,
+    # :title,
+    # :window_title,
+    # :guide, :guide_position, :lims, :ticks, :scale, :flip, :rotation,
+    # :tickfont, :guidefont, :legendfont,
+    # :grid, :legend,
+    # :colorbar, :colorbar_title,
+    # :fill_z, :line_z, :marker_z, :levels,
+    # :ribbon, :quiver, :arrow,
+    # :orientation,
+    # :overwrite_figure,
+    # :polar,
+    # :normalize, :weights, :contours,
+    # :aspect_ratio,
+    :tick_direction,
+    # :framestyle,
+    # :camera,
+    # :contour_labels,
   ])
-const _gaston_seriestype = [
-    :path, :scatter, :shape, :straightline,
-]
-const _gaston_style = [:auto, :solid]
-const _gaston_marker = [:none, :auto, :circle]
-const _gaston_scale = [:identity]
+const _gaston_seriestype = [:path,
+                            # :path3d,
+                            :scatter,
+                            :steppre,
+                            # :stepmid,
+                            :steppost,
+                            # :histogram2d,
+                            # :ysticks, :xsticks,
+                            # :contour,
+                            # :shape,
+                            # :straightline,
+                            ]
+
+const _gaston_style = [:auto,
+                       :solid,
+                       :dash,
+                       :dot,
+                       :dashdot,
+                       :dashdotdot
+                       ]
+
+const _gaston_marker = [:none,
+                        # :auto,
+                        :circle,
+                        :rect,
+                        :diamond,
+                        :utriangle,
+                        :dtriangle,
+                        :pentagon,
+                        :x,
+                        :+
+                        ] #vcat(_allMarkers, Shape)
+
+const _gaston_scale = [:identity,
+                       # :ln,
+                       # :log2,
+                       # :log10,
+                       ]
 
 # ------------------------------------------------------------------------------
 # unicodeplots

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -1,40 +1,67 @@
 # https://github.com/mbaz/Gaston.
 const G = Gaston
-
+const GastonSubplot = G.Plot
+# --------------------------------------------
+# These functions are called by Plots
+# --------------------------------------------
 # Create the window/figure for this backend.
 function _create_backend_figure(plt::Plot{GastonBackend})
-    plt.o = G.newfigure(G.gnuplot_state.current)
+    state_handle = G.nexthandle() # for now all the figures will be kept
+    plt.o = G.newfigure(state_handle)
 end
 
-# # this is called early in the pipeline, use it to make the plot current or something
-# function _prepare_plot_object(plt::Plot{GastonBackend})
-# end
-
-# Set up the subplot within the backend object.
-function gaston_init_subplot(plt::Plot{GastonBackend}, sp::Subplot{GastonBackend})
-    sp.o = plt.o.subplots[1]
-    empty!(sp.o.curves)
-
-end
 
 function _before_layout_calcs(plt::Plot{GastonBackend})
+    # Initialize all the subplots first
+    plt.o.subplots = G.SubPlot[]
+
+    grid = size(plt.layout)
+    plt.o.layout = grid
+
     for sp in plt.subplots
         gaston_init_subplot(plt, sp)
     end
 
-    # add the series
+    # Then add the series (curves in gaston)
     for series in plt.series_list
         gaston_add_series(plt, series)
     end
 end
 
-function gaston_add_series(plt::Plot{GastonBackend}, series::Series)
-    st = series[:seriestype]
-    sp = series[:subplot]
-    g_sp = sp.o
+function _update_min_padding!(sp::Subplot{GastonBackend})
+    sp.minpad = (20mm, 5mm, 2mm, 10mm)
+end
 
-    gnuplot_args = gaston_parse_series_args(series)
-    c = G.Curve(series[:x], series[:y], nothing, nothing, gnuplot_args)
+function _update_plot_object(plt::Plot{GastonBackend})
+end
+
+function _show(io::IO, ::MIME"image/png", plt::Plot{GastonBackend})
+end
+
+function _display(plt::Plot{GastonBackend})
+    display(plt.o)
+end
+
+# --------------------------------------------
+# These functions are called gaston specific
+# --------------------------------------------
+
+function gaston_init_subplot(plt::Plot{GastonBackend}, sp::Subplot{GastonBackend})
+    dims = RecipesPipeline.is3d(sp) ? 3 : 2
+
+    axesconf = gaston_parse_axes_args(plt, sp)  # Gnuplot string
+    sp.o = GastonSubplot(dims=dims, axesconf = axesconf, curves = [])
+    push!(plt.o.subplots,  sp.o)
+
+end
+
+function gaston_add_series(plt::Plot{GastonBackend}, series::Series)
+    # Gaston.Curve = Plots.Series
+    sp = series[:subplot]
+    g_sp = sp.o  # Gaston subplot object
+
+    seriesconf = gaston_parse_series_args(series)  # Gnuplot string
+    c = G.Curve(series[:x], series[:y], nothing, nothing, seriesconf )
 
     isfirst = length(g_sp.curves) == 0 ? true : false
     push!(g_sp.curves, c)
@@ -50,7 +77,7 @@ function gaston_parse_series_args(series::Series)
     elseif st == :steppre
         push!(curveconf, """with steps""")
     elseif st == :steppost
-        push!(curveconf, """with fsteps""")  # Not sure if not 'steps'
+        push!(curveconf, """with fsteps""")  # Not sure if not the other way
     end
 
     # line color
@@ -62,18 +89,32 @@ function gaston_parse_series_args(series::Series)
     return join(curveconf, " ")
 end
 
-# Set the (left, top, right, bottom) minimum padding around the plot area
-# to fit ticks, tick labels, guides, colorbars, etc.
-function _update_min_padding!(sp::Subplot{GastonBackend})
-    sp.minpad = (20mm, 5mm, 2mm, 10mm)
-end
+function gaston_parse_axes_args(plt::Plot{GastonBackend}, sp::Subplot{GastonBackend})
+    axesconf = String[]
+    # Standard 2d axis
+    if !ispolar(sp) && !RecipesPipeline.is3d(sp)
+        # TODO
+        # configure grid, axis spines, thickness
+    end
 
-function _update_plot_object(plt::Plot{GastonBackend})
-end
+    for letter in (:x, :y, :z)
+        axis_attr = sp.attr[Symbol(letter, :axis)]
+        # label names
+        push!(axesconf, """set $(letter)label "$(axis_attr[:guide])"  """)
+        push!(axesconf, """set $(letter)label font "$(axis_attr[:guidefontfamily]), $(axis_attr[:guidefontsize])"  """)
 
-function _show(io::IO, ::MIME"image/png", plt::Plot{GastonBackend})
-end
+        # tick font
+        push!(axesconf, """set $(letter)tics font "$(axis_attr[:tickfontfamily]), $(axis_attr[:tickfontsize])"  """)
 
-function _display(plt::Plot{GastonBackend})
-    display(plt.o)
+        push!(axesconf, """set $(letter)tics textcolor rgb "#$(hex(axis_attr[:tickfontcolor], :rrggbb))" """)
+
+        push!(axesconf, """set $(letter)tics  $(axis_attr[:tick_direction])""")
+
+        mirror = axis_attr[:mirror] ? "nomirror" : "mirror"
+        push!(axesconf, """set $(letter)tics  $(mirror) """)
+
+        # set xtics (1,2,5,10,20,50)
+        # TODO logscale, explicit tick location, range,
+    end
+    return join(axesconf, "\n")
 end

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -1,0 +1,79 @@
+# https://github.com/mbaz/Gaston.
+const G = Gaston
+
+# Create the window/figure for this backend.
+function _create_backend_figure(plt::Plot{GastonBackend})
+    plt.o = G.newfigure(G.gnuplot_state.current)
+end
+
+# # this is called early in the pipeline, use it to make the plot current or something
+# function _prepare_plot_object(plt::Plot{GastonBackend})
+# end
+
+# Set up the subplot within the backend object.
+function gaston_init_subplot(plt::Plot{GastonBackend}, sp::Subplot{GastonBackend})
+    sp.o = plt.o.subplots[1]
+    empty!(sp.o.curves)
+
+end
+
+function _before_layout_calcs(plt::Plot{GastonBackend})
+    for sp in plt.subplots
+        gaston_init_subplot(plt, sp)
+    end
+
+    # add the series
+    for series in plt.series_list
+        gaston_add_series(plt, series)
+    end
+end
+
+function gaston_add_series(plt::Plot{GastonBackend}, series::Series)
+    st = series[:seriestype]
+    sp = series[:subplot]
+    g_sp = sp.o
+
+    gnuplot_args = gaston_parse_series_args(series)
+    c = G.Curve(series[:x], series[:y], nothing, nothing, gnuplot_args)
+
+    isfirst = length(g_sp.curves) == 0 ? true : false
+    push!(g_sp.curves, c)
+    G.write_data(c, g_sp.dims, g_sp.datafile, append = isfirst ? false : true)  # TODO add appended series
+end
+
+function gaston_parse_series_args(series::Series)
+    curveconf = String[]
+    st = series[:seriestype]
+
+    if st == :path
+        push!(curveconf, """with lines """)
+    elseif st == :steppre
+        push!(curveconf, """with steps""")
+    elseif st == :steppost
+        push!(curveconf, """with fsteps""")  # Not sure if not 'steps'
+    end
+
+    # line color
+    push!(curveconf, """lc rgb "#$(hex(series[:linecolor], :rrggbb))" """)
+
+    # label
+    push!(curveconf, """title "$(series[:label])" """)
+
+    return join(curveconf, " ")
+end
+
+# Set the (left, top, right, bottom) minimum padding around the plot area
+# to fit ticks, tick labels, guides, colorbars, etc.
+function _update_min_padding!(sp::Subplot{GastonBackend})
+    sp.minpad = (20mm, 5mm, 2mm, 10mm)
+end
+
+function _update_plot_object(plt::Plot{GastonBackend})
+end
+
+function _show(io::IO, ::MIME"image/png", plt::Plot{GastonBackend})
+end
+
+function _display(plt::Plot{GastonBackend})
+    display(plt.o)
+end

--- a/src/init.jl
+++ b/src/init.jl
@@ -70,6 +70,11 @@ function __init__()
         include(fn)
     end
 
+    @require Gaston = "4b11ee91-296f-5714-9832-002c20994614" begin
+        fn = joinpath(@__DIR__, "backends", "gaston.jl")
+        include(fn)
+    end
+
     @require IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a" begin
         if IJulia.inited
             _init_ijulia_plotting()


### PR DESCRIPTION
Dear all, 
here is the first attempt at making gnuplot (gaston) plots backend. Still very early stage, still testing, too many things remain, but it feels like gnuplot can be a good backend as there have been no hacks implementing it so far.

Please test it like  (naturally need to have gaston and gnuplot working beforehand)

```
using Plots; gaston()
plot(1:10, xlab="gnuplot is not bad at all", xguidefontsize=15, ylab="notbad", yguidefontsize=5, tick_direction=:out, guidefontfamily="Serif")
```
![image](https://user-images.githubusercontent.com/24591123/100970330-03247280-3578-11eb-8c76-22d8f3de3661.png)

```
plot(
       plot(1:10, xlab="gnuplot is not bad at all", xguidefontsize=15, ylab="notbad", yguidefontsize=5, tick_direction=:out, guidefontfamily="Serif"), plot(sin.(1:100))
       )
```
![image](https://user-images.githubusercontent.com/24591123/100970399-2fd88a00-3578-11eb-8993-5d1933ec55a6.png)

Not many things work, in fact, most don't. But I think there is potential to this as it behaved very nice so far. Only tested in repl, but jupyter has to work too. Waiting for reviews from @mbaz 
q
```