### PR TITLE
Set extra mime only when HTML format

### DIFF
--- a/src/ijulia.jl
+++ b/src/ijulia.jl
@@ -54,9 +54,9 @@ function _ijulia_display_dict(plt::Plot)
     elseif output_type == :html
         mime = "text/html"
         out[mime] = sprint(show, MIME(mime), plt)
+        _ijulia__extra_mime_info!(plt, out)
     else
         error("Unsupported output type $output_type")
     end
-    _ijulia__extra_mime_info!(plt, out)
     out
 end


### PR DESCRIPTION
Extra mine is not used by other format.

For example

```julia
using Plots
plotlyjs()
plot(rand(1000000), x->x, fmt=:png)
```

Above codes make jupyter file be about 60 MiB.
After changing, jupyter file is only 40 KiB.