### PR TITLE
Fix #1531, Let xlims be set to Dates or DateTimes

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -94,6 +94,8 @@ function attr!(axis::Axis, args...; kw...)
                 for vi in v
                     discrete_value!(axis, vi)
                 end
+            #could perhaps use TimeType here, as Date and DateTime are both subtypes of TimeType
+            # or could perhaps check if dateformatter or datetimeformatter is in use
             elseif k == :lims && isa(v, Tuple{Date,Date})
                 plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
             elseif k == :lims && isa(v, Tuple{DateTime,DateTime})

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -94,6 +94,11 @@ function attr!(axis::Axis, args...; kw...)
                 for vi in v
                     discrete_value!(axis, vi)
                 end
+            elseif k == :lims && isa(v, Tuple{Date,Date})
+                plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
+            elseif k == :lims && isa(v, Tuple{DateTime,DateTime})
+                println("Converting datetime")
+                plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
             else
                 plotattributes[k] = v
             end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -97,7 +97,6 @@ function attr!(axis::Axis, args...; kw...)
             elseif k == :lims && isa(v, Tuple{Date,Date})
                 plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
             elseif k == :lims && isa(v, Tuple{DateTime,DateTime})
-                println("Converting datetime")
                 plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
             else
                 plotattributes[k] = v

--- a/test/integration_dates.jl
+++ b/test/integration_dates.jl
@@ -18,6 +18,7 @@ using Plots, Test, Dates
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true
+        closeall()
     end
 end # testset
 
@@ -36,6 +37,7 @@ end # testset
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true
+        closeall()
     end
 end # testset
 
@@ -53,5 +55,6 @@ end # testset
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true
+        closeall()
     end
 end # testset

--- a/test/integration_dates.jl
+++ b/test/integration_dates.jl
@@ -13,6 +13,7 @@ using Plots, Test, Dates
     ref_xlims = (x[1].instant.periods.value, x[end].instant.periods.value)
     @test Plots.ylims(p) == ref_ylims
     @test Plots.xlims(p) == ref_xlims
+    @test isa(display(p), Nothing) == true
 end # testset
 
 @testset "Date xlims" begin
@@ -21,6 +22,7 @@ end # testset
     span = (Date(2019,10,31), Date(2019,11,11))
 
     p = plot(x,y, xlims=span, widen = false)
+    @test isa(display(p), Nothing) == true
 end # testset
 
 @testset "DateTime xlims" begin
@@ -29,4 +31,5 @@ end # testset
     span = (DateTime(2019,10,31,11,59,59), DateTime(2019,11,11,12,01,15))
 
     p = plot(x,y, xlims=span, widen = false)
+    @test isa(display(p), Nothing) == true
 end # testset

--- a/test/integration_dates.jl
+++ b/test/integration_dates.jl
@@ -14,3 +14,19 @@ using Plots, Test, Dates
     @test Plots.ylims(p) == ref_ylims
     @test Plots.xlims(p) == ref_xlims
 end # testset
+
+@testset "Date xlims" begin
+    y=[1.0*i*i for i in 1:10]
+    x=[Date(2019,11,i) for i in 1:10]
+    span = (Date(2019,10,31), Date(2019,11,11))
+
+    p = plot(x,y, xlims=span, widen = false)
+end # testset
+
+@testset "DateTime xlims" begin
+    y=[1.0*i*i for i in 1:10]
+    x=[DateTime(2019,11,i,11) for i in 1:10]
+    span = (DateTime(2019,10,31,11,59,59), DateTime(2019,11,11,12,01,15))
+
+    p = plot(x,y, xlims=span, widen = false)
+end # testset

--- a/test/integration_dates.jl
+++ b/test/integration_dates.jl
@@ -13,7 +13,8 @@ using Plots, Test, Dates
     ref_xlims = (x[1].instant.periods.value, x[end].instant.periods.value)
     @test Plots.ylims(p) == ref_ylims
     @test Plots.xlims(p) == ref_xlims
-    @static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
+    #@static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
+    @static if haskey(ENV, "APPVEYOR")
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true
@@ -30,7 +31,8 @@ end # testset
     p = plot(x,y, xlims=span, widen = false)
 
     @test Plots.xlims(p) == ref_xlims
-    @static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
+    #@static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
+    @static if haskey(ENV, "APPVEYOR")
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true
@@ -46,7 +48,8 @@ end # testset
 
     p = plot(x,y, xlims=span, widen = false)
     @test Plots.xlims(p) == ref_xlims
-    @static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
+    #@static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
+    @static if haskey(ENV, "APPVEYOR")
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true

--- a/test/integration_dates.jl
+++ b/test/integration_dates.jl
@@ -13,7 +13,11 @@ using Plots, Test, Dates
     ref_xlims = (x[1].instant.periods.value, x[end].instant.periods.value)
     @test Plots.ylims(p) == ref_ylims
     @test Plots.xlims(p) == ref_xlims
-    @test isa(display(p), Nothing) == true
+    @static if haskey(ENV, "APPVEYOR")
+        @info "Skipping display tests on AppVeyor"
+    else
+        @test isa(display(p), Nothing) == true
+    end
 end # testset
 
 @testset "Date xlims" begin
@@ -21,8 +25,16 @@ end # testset
     x=[Date(2019,11,i) for i in 1:10]
     span = (Date(2019,10,31), Date(2019,11,11))
 
+    ref_xlims = map(date->date.instant.periods.value, span)
+
     p = plot(x,y, xlims=span, widen = false)
-    @test isa(display(p), Nothing) == true
+    
+    @test Plots.xlims(p) == ref_xlims
+    @static if haskey(ENV, "APPVEYOR")
+        @info "Skipping display tests on AppVeyor"
+    else
+        @test isa(display(p), Nothing) == true
+    end
 end # testset
 
 @testset "DateTime xlims" begin
@@ -30,6 +42,13 @@ end # testset
     x=[DateTime(2019,11,i,11) for i in 1:10]
     span = (DateTime(2019,10,31,11,59,59), DateTime(2019,11,11,12,01,15))
 
+    ref_xlims = map(date->date.instant.periods.value, span)
+
     p = plot(x,y, xlims=span, widen = false)
-    @test isa(display(p), Nothing) == true
+    @test Plots.xlims(p) == ref_xlims
+    @static if haskey(ENV, "APPVEYOR")
+        @info "Skipping display tests on AppVeyor"
+    else
+        @test isa(display(p), Nothing) == true
+    end
 end # testset

--- a/test/integration_dates.jl
+++ b/test/integration_dates.jl
@@ -13,7 +13,7 @@ using Plots, Test, Dates
     ref_xlims = (x[1].instant.periods.value, x[end].instant.periods.value)
     @test Plots.ylims(p) == ref_ylims
     @test Plots.xlims(p) == ref_xlims
-    @static if haskey(ENV, "APPVEYOR")
+    @static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true
@@ -28,9 +28,9 @@ end # testset
     ref_xlims = map(date->date.instant.periods.value, span)
 
     p = plot(x,y, xlims=span, widen = false)
-    
+
     @test Plots.xlims(p) == ref_xlims
-    @static if haskey(ENV, "APPVEYOR")
+    @static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true
@@ -46,7 +46,7 @@ end # testset
 
     p = plot(x,y, xlims=span, widen = false)
     @test Plots.xlims(p) == ref_xlims
-    @static if haskey(ENV, "APPVEYOR")
+    @static if (haskey(ENV, "APPVEYOR") || haskey(ENV, "CI"))
         @info "Skipping display tests on AppVeyor"
     else
         @test isa(display(p), Nothing) == true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ end # testset
 include("test_defaults.jl")
 include("test_axes.jl")
 include("test_axis_letter.jl")
+include("test_components.jl")
 include("test_recipes.jl")
 include("test_hdf5plots.jl")
 include("test_pgfplotsx.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,10 +32,10 @@ include("test_defaults.jl")
 include("test_axes.jl")
 include("test_axis_letter.jl")
 include("test_components.jl")
+include("integration_dates.jl")
 include("test_recipes.jl")
 include("test_hdf5plots.jl")
 include("test_pgfplotsx.jl")
-include("integration_dates.jl")
 
 reference_dir(args...) = joinpath(homedir(), ".julia", "dev", "PlotReferenceImages", args...)
 

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -1,0 +1,46 @@
+using Plots, Test
+
+@testset "Shape Copy" begin
+    square = Shape([(0,0),(1,0),(1,1),(0,1)])
+    square2 = Shape(square)
+    @test square2.x == square.x
+    @test square2.y == square.y
+end
+
+@testset "Shape Center" begin
+    square = Shape([(0,0),(1,0),(1,1),(0,1)])
+    @test Plots.center(square) == (0.5,0.5)
+end
+
+@testset "Shape Translate" begin
+    square = Shape([(0,0),(1,0),(1,1),(0,1)])
+    squareUp = Shape([(0,1),(1,1),(1,2),(0,2)])
+    squareUpRight = Shape([(1,1),(2,1),(2,2),(1,2)])
+
+    @test Plots.translate(square,0,1).x == squareUp.x
+    @test Plots.translate(square,0,1).y == squareUp.y
+
+    @test Plots.center(translate!(square,1)) == (1.5,1.5)
+end
+
+@testset "Brush" begin
+    @testset "Colors" begin
+        baseline = brush(1, RGB(0,0,0))
+        @test brush(:black) == baseline
+        @test brush("black") == baseline
+    end
+    @testset "Weight" begin
+        @test brush(10).size == 10
+        @test brush(0.1).size == 1
+    end
+    @testset "Alpha" begin
+        @test brush(0.4).alpha == 0.4
+        @test brush(20).alpha == nothing
+    end
+    @testset "Bad Argument" begin
+        # using test_logs because test_warn seems to not work anymore
+        @test_logs (:warn,"Unused brush arg: nothing (Nothing)") begin
+            brush(nothing)
+        end
+    end
+end


### PR DESCRIPTION
Resolves #1531, allowing xlims to be set to Date or DateTime values. Also adds two unit tests that show xlims working with both Date and DateTime.