### PR TITLE
Increase the margins between axes and guides on GR

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1437,7 +1437,7 @@ function gr_label_axis(sp, letter, viewport_plotarea)
         gr_set_font(guidefont(axis), sp)
         guide_position = axis[:guide_position]
         if isy
-            w = 0.02 + gr_axis_width(sp, axis)
+            w = 0.03 + gr_axis_width(sp, axis)
             GR.setcharup(-1, 0)
             if guide_position == :right || (guide_position == :auto && axis[:mirror])
                 GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_BOTTOM)
@@ -1447,7 +1447,7 @@ function gr_label_axis(sp, letter, viewport_plotarea)
                 gr_text(viewport_plotarea[1] - w, gr_view_ycenter(viewport_plotarea), axis[:guide])
             end
         else
-            h = 0.01 + gr_axis_height(sp, axis)
+            h = 0.015 + gr_axis_height(sp, axis)
             if guide_position == :top || (guide_position == :auto && axis[:mirror])
                 GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_TOP)
                 gr_text(gr_view_xcenter(viewport_plotarea), viewport_plotarea[4] + h, axis[:guide])
@@ -1492,7 +1492,7 @@ function gr_label_axis_3d(sp, letter)
             x_offset = letter === :x ? -h : h
             y_offset = -h
         else
-            x_offset = -gr_axis_width(sp, ax)
+            x_offset = -0.03 - gr_axis_width(sp, ax)
             y_offset = 0
         end
         letter === :z && GR.setcharup(-1, 0)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1432,11 +1432,10 @@ function gr_label_axis(sp, letter, viewport_plotarea)
     axis = sp[Symbol(letter, :axis)]
     # guide
     if axis[:guide] != ""
-        isy = letter === :y
         GR.savestate()
         gr_set_font(guidefont(axis), sp)
         guide_position = axis[:guide_position]
-        if isy
+        if letter === :y
             w = 0.03 + gr_axis_width(sp, axis)
             GR.setcharup(-1, 0)
             if guide_position == :right || (guide_position == :auto && axis[:mirror])


### PR DESCRIPTION
fix #1988

```julia
plot(rand(10), xguide="x guide", yguide="y guide")
```

before:
![2d_old](https://user-images.githubusercontent.com/16589944/104108548-daee0900-52c5-11eb-87a3-43c3a8383ec9.png)

now:
![2d_new](https://user-images.githubusercontent.com/16589944/104108553-e80af800-52c5-11eb-93d9-dc007d91c59c.png)

```julia
surface(rand(10, 10), xguide="x guide", yguide="y guide", zguide="z guide")
```

before:
![3d_old](https://user-images.githubusercontent.com/16589944/104108564-0c66d480-52c6-11eb-9c25-61eb8be1d7ee.png)

now:
![3d_new](https://user-images.githubusercontent.com/16589944/104108568-17216980-52c6-11eb-9767-84a902d5b8f9.png)


Requires https://github.com/JuliaPlots/PlotReferenceImages.jl/pull/90 for tests to pass.