### PR TITLE
Add basic CI Benchmarking via BenchmarkCI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   Benchmark:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    env:
+      GKS_ENCODING: "utf8"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,10 +14,7 @@ jobs:
           version: 1
 
       ## Setup
-      - name: Default TESTCMD
-        run: echo "TESTCMD=julia" >> $GITHUB_ENV
       - name: Ubuntu TESTCMD
-        if: startsWith(matrix.os,'ubuntu')
         run: echo "TESTCMD=xvfb-run --auto-servernum julia" >> $GITHUB_ENV
       - name: Install Plots dependencies
         uses: julia-actions/julia-buildpkg@latest

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,32 @@
+name: Run benchmarks
+
+on:
+  pull_request:
+
+jobs:
+  Benchmark:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1
+
+      ## Setup
+      - name: Default TESTCMD
+        run: echo "TESTCMD=julia" >> $GITHUB_ENV
+      - name: Ubuntu TESTCMD
+        if: startsWith(matrix.os,'ubuntu')
+        run: echo "TESTCMD=xvfb-run --auto-servernum julia" >> $GITHUB_ENV
+      - name: Install Plots dependencies
+        uses: julia-actions/julia-buildpkg@latest
+      - name: Install Benchmarking dependencies
+        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
+
+      - name: Run benchmarks
+        run: $TESTCMD -e 'using BenchmarkCI; BenchmarkCI.judge()'
+      - name: Post results
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ deps/deps.jl
 Manifest.toml
 dev/
 test/tmpplotsave.hdf5
+/.benchmarkci
+/benchmark/*.json

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 BenchmarkCI = "20533458-34a3-403d-a444-e18f38190b5b"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+BenchmarkCI = "20533458-34a3-403d-a444-e18f38190b5b"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,8 @@
+using BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# numbered to enforce sequence
+SUITE["1_load"] = @benchmarkable @eval(using Plots)
+SUITE["2_plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10))
+SUITE["3_display"] = @benchmarkable display(p) setup=(p = plot(1:0.1:10, sin.(1:0.1:10)))

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,8 +1,11 @@
 using BenchmarkTools
 
 const SUITE = BenchmarkGroup()
+julia_cmd = get(ENV, "TESTCMD", Base.JLOptions().julia_bin)
 
 # numbered to enforce sequence
+SUITE["0_load_plot_display"] = @benchmarkable run(`$(julia_cmd) -e "using Plots; display(plot(1:0.1:10, sin.(1:0.1:10))))"`)
+
 SUITE["1_load"] = @benchmarkable @eval(using Plots)
 SUITE["2_plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10))
 SUITE["3_display"] = @benchmarkable display(p) setup=(p = plot(1:0.1:10, sin.(1:0.1:10)))

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -5,7 +5,6 @@ julia_cmd = get(ENV, "TESTCMD", Base.JLOptions().julia_bin)
 
 # numbered to enforce sequence
 SUITE["1_load_plot_display"] = @benchmarkable run(`sh -c $("$julia_cmd --startup-file=no -e 'using Plots; display(plot(1:0.1:10, sin.(1:0.1:10))))'")`)
-
-SUITE["2_load"] = @benchmarkable @eval(using Plots)
-SUITE["3_plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10))
-SUITE["4_display"] = @benchmarkable display(p) setup=(p = plot(1:0.1:10, sin.(1:0.1:10)))
+SUITE["2_load"] = @benchmarkable run(`sh -c $("$julia_cmd --startup-file=no -e 'using Plots'")`)
+SUITE["3_plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10)) setup(@eval(using Plots))
+SUITE["4_display"] = @benchmarkable display(p) setup=(@eval(using Plots); p = plot(1:0.1:10, sin.(1:0.1:10)))

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -4,8 +4,8 @@ const SUITE = BenchmarkGroup()
 julia_cmd = get(ENV, "TESTCMD", Base.JLOptions().julia_bin)
 
 # numbered to enforce sequence
-SUITE["0_load_plot_display"] = @benchmarkable run(`$(julia_cmd) -e "using Plots; display(plot(1:0.1:10, sin.(1:0.1:10))))"`)
+SUITE["1_load_plot_display"] = @benchmarkable run(`sh -c $("$julia_cmd --startup-file=no -e 'using Plots; display(plot(1:0.1:10, sin.(1:0.1:10))))'")`)
 
-SUITE["1_load"] = @benchmarkable @eval(using Plots)
-SUITE["2_plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10))
-SUITE["3_display"] = @benchmarkable display(p) setup=(p = plot(1:0.1:10, sin.(1:0.1:10)))
+SUITE["2_load"] = @benchmarkable @eval(using Plots)
+SUITE["3_plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10))
+SUITE["4_display"] = @benchmarkable display(p) setup=(p = plot(1:0.1:10, sin.(1:0.1:10)))


### PR DESCRIPTION
A suggestion, based on a slack discussion about trying to help avoid performance regressions like https://github.com/JuliaPlots/Plots.jl/issues/3238

This setup will post a comment with the result after every push to a PR, which might be a bit noisy. 
That can be changed to a less visible print in the action as per https://github.com/tkf/BenchmarkCI.jl#printing-benchmark-result-optional

cc. @brenhinkeller