### PR TITLE
Fix typo preventing minor ticks from working in 3D plots

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -815,7 +815,7 @@ function axis_drawing_info_3d(sp, letter)
                     t = invf(f(na0) + 0.006 * (f(na1) - f(na0)) * ticks_in)
                     (na0, t)
                 end
-                for tick in minorticks
+                for tick in minor_ticks
                     if ax[:showaxis]
                         push!(
                             tick_segments,


### PR DESCRIPTION
Currently, minor ticks do not seem to work in plots with 3D axes. I noticed this bug while trying to use `Plots.showtheme(:ggplot2)` which was failing due to an undefined variable error.

This PR simply adds a missing underscore to fix the issue.