### PR TITLE
Benchmark CI tweaks

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,5 +6,5 @@ julia_cmd = split(get(ENV, "TESTCMD", Base.JLOptions().julia_bin))
 
 SUITE["load_plot_display"] = @benchmarkable run(`$julia_cmd --startup-file=no --project -e 'using Plots; display(plot(1:0.1:10, sin.(1:0.1:10)))'`)
 SUITE["load"] = @benchmarkable run(`$julia_cmd --startup-file=no --project -e 'using Plots'`)
-SUITE["plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10))
-SUITE["display"] = @benchmarkable display(p) setup=(p = plot(1:0.1:10, sin.(1:0.1:10)))
+SUITE["plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10)) samples=1 evals=1
+SUITE["display"] = @benchmarkable display(p) setup=(p = plot(1:0.1:10, sin.(1:0.1:10))) samples=1 evals=1


### PR DESCRIPTION
- limit `plot` and `display` tests to one run given we only really care about first run

I am also trying to figure out how to fix the report comment not being posted