### PR TITLE
don't stringify argument to `warn_on_recipe_aliases!` early

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -5,13 +5,24 @@
 function RecipesPipeline.warn_on_recipe_aliases!(
     plt::Plot,
     plotattributes::AKW,
-    recipe_type,
-    signature_string
+    recipe_type::Symbol,
+    args
 )
     for k in keys(plotattributes)
         if !is_default_attribute(k)
             dk = get(_keyAliases, k, k)
             if k !== dk
+                if recipe_type == :user
+                    signature_string = RecipesPipeline.userrecipe_signature_string(args)
+                elseif recipe_type == :type
+                    signature_string = RecipesPipeline.typerecipe_signature_string(args)
+                elseif recipe_type == :plot
+                    signature_string = RecipesPipeline.plotrecipe_signature_string(args)
+                elseif recipe_type == :series
+                    signature_string = RecipesPipeline.seriesrecipe_signature_string(args)
+                else
+                    throw(ArgumentError("Invalid recipe type `$recipe_type`"))
+                end
                 @warn "Attribute alias `$k` detected in the $recipe_type recipe defined for the signature $signature_string. To ensure expected behavior it is recommended to use the default attribute `$dk`."
             end
             plotattributes[dk] = RecipesPipeline.pop_kw!(plotattributes, k)


### PR DESCRIPTION
needs matching RecipesPipeline changes
fixes #3276 