### PR TITLE
remove black lines from GR surface with equal-length x, y, and z input

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1736,13 +1736,12 @@ end
 function gr_draw_surface(series, x, y, z, clims)
     if series[:seriestype] === :surface
         if length(x) == length(y) == length(z)
-            GR.trisurface(x, y, z)
-        else
-            try
-                GR.gr3.surface(x, y, z, GR.OPTION_COLORED_MESH)
-            catch
-                GR.surface(x, y, z, GR.OPTION_COLORED_MESH)
-            end
+            x, y, z = GR.gridit(x, y, z, 200, 200)
+        end
+        try
+            GR.gr3.surface(x, y, z, GR.OPTION_COLORED_MESH)
+        catch
+            GR.surface(x, y, z, GR.OPTION_COLORED_MESH)
         end
     else # wireframe
         GR.setfillcolorind(0)


### PR DESCRIPTION
changes
```julia
using Plots

x_range = -10:0.5:10
p_range = -3:0.5:3

f(x, p) = sin(x) + cos(p)

xs = Float64[]
ps = Float64[]
ws = Float64[]

for x in x_range, p in p_range
    push!(xs, x)
    push!(ps, p)
    push!(ws, f(x, p))
end

surface(xs, ps, ws)
```
from
![gr_surf_old](https://user-images.githubusercontent.com/16589944/107549397-12efb100-6bd0-11eb-9224-972a9afba890.png)

to
![gr_surf_new](https://user-images.githubusercontent.com/16589944/107549419-197e2880-6bd0-11eb-9e5c-8f9afb1b76bc.png)

fix #3279 cc @foldfelis