### PR TITLE
Implement non-uniform polar heatmaps with the GR backend

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1579,7 +1579,7 @@ function gr_add_series(sp, series)
         dmin, dmax = GR.gr3.volume(y.v, 0)
     elseif st === :heatmap
         # `z` is already transposed, so we need to reverse before passing its size.
-        x, y = heatmap_edges(x, xscale, y, yscale, reverse(size(z)))
+        x, y = heatmap_edges(x, xscale, y, yscale, reverse(size(z)), ispolar(series))
         gr_draw_heatmap(series, x, y, z, clims)
     elseif st === :image
         gr_draw_image(series, x, y, z, clims)

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1044,7 +1044,7 @@ const _examples = PlotExample[
         "Polar heatmaps",
         "",
         [quote
-        x = range(0, 2π, length=0)
+        x = range(0, 2π, length=9)
         y = 0:4
         z = (1:4) .+ (1:8)'
         heatmap(x, y, z, projection = :polar)

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1044,8 +1044,10 @@ const _examples = PlotExample[
         "Polar heatmaps",
         "",
         [quote
-            z = (1:4) .+ (1:8)'
-            heatmap(z, projection = :polar)
+        x = range(0, 2π, length=0)
+        y = 0:4
+        z = (1:4) .+ (1:8)'
+        heatmap(x, y, z, projection = :polar)
         end]
     ),
     PlotExample( # 50

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -212,24 +212,24 @@ createSegments(z) = collect(repeat(reshape(z,1,:),2,1))[2:end]
 
 sortedkeys(plotattributes::Dict) = sort(collect(keys(plotattributes)))
 
-function _heatmap_edges(v::AVec, isedges::Bool = false)
-    length(v) == 1 && return v[1] .+ [-0.5, 0.5]
+function _heatmap_edges(v::AVec, isedges::Bool = false, ispolar::Bool = false)
+    length(v) == 1 && return v[1] .+ [ispolar ? max(-v[1], -0.5) : -0.5, 0.5]
     if isedges return v end
     # `isedges = true` means that v is a vector which already describes edges
     # and does not need to be extended.
     vmin, vmax = ignorenan_extrema(v)
-    extra_min = (v[2] - v[1]) / 2
+    extra_min = ispolar ? min(v[1], (v[2] - v[1]) / 2) : (v[2] - v[1]) / 2
     extra_max = (v[end] - v[end - 1]) / 2
     vcat(vmin-extra_min, 0.5 * (v[1:end-1] + v[2:end]), vmax+extra_max)
 end
 
 "create an (n+1) list of the outsides of heatmap rectangles"
-function heatmap_edges(v::AVec, scale::Symbol = :identity, isedges::Bool = false)
+function heatmap_edges(v::AVec, scale::Symbol = :identity, isedges::Bool = false, ispolar::Bool = false)
     f, invf = RecipesPipeline.scale_func(scale), RecipesPipeline.inverse_scale_func(scale)
-    map(invf, _heatmap_edges(map(f,v), isedges))
+    map(invf, _heatmap_edges(map(f,v), isedges, ispolar))
 end
 
-function heatmap_edges(x::AVec, xscale::Symbol, y::AVec, yscale::Symbol, z_size::Tuple{Int, Int})
+function heatmap_edges(x::AVec, xscale::Symbol, y::AVec, yscale::Symbol, z_size::Tuple{Int, Int}, ispolar::Bool = false)
     nx, ny = length(x), length(y)
     # ismidpoints = z_size == (ny, nx) # This fails some tests, but would actually be
     # the correct check, since (4, 3) != (3, 4) and a missleading plot is produced.
@@ -241,7 +241,7 @@ function heatmap_edges(x::AVec, xscale::Symbol, y::AVec, yscale::Symbol, z_size:
                 or `size(z) == (length(y)+1, length(x)+1))` (x & y define edges).""")
     end
     x, y = heatmap_edges(x, xscale, isedges),
-           heatmap_edges(y, yscale, isedges)
+           heatmap_edges(y, yscale, isedges, ispolar) # special handle for `r` in polar plots 
     return x, y
 end
 


### PR DESCRIPTION
Thanks to @danielkaiser (sciapp/gr@fcb2949ebde37db0d0833f16f8670cdfa9a85123) and @jheinen (jheinen/GR.jl@9b1dd41252bdf188539bebc5262765b024d73bd4) for implementing non-uniform polar cell arrays in the GR framework!

I tried to implement it in Plots.jl to fix #3149, but as a newbie would be very thankful for some feedback/reviews from the professionals here!

## Short summary of the changes in the code

- **Calling `GR.nonuniformpolarheatmap` for non-uniform polar heatmaps**
Polar heatmaps with GR will always be processed as `GR.nonuniformpolarheatmap`, just like non-uniform normal heatmaps are always processed as `GR.nonuniformheatmap`. The syntax between the two is very similar, just that GR.jl expects the angle array in units of degree rather than radians (hence the `rad2deg`).

- **Update warning to avoid displaying negative radii**
 Polar heatmaps will not be displayed if the first radius is smaller than 0. If the first value of the radius array is negative, one warning is implemented in Plots.jl (`@warn "'y[1] < 0' (rmin) is not yet supported."`) and another warning is given by GR itself (`Invalid radii specified`).

- **Update `heatmap_edges` to avoid negative radii**
In order to allow both, midpoints or edges, to be passed to the polar heatmap, the function `heatmap_edges` was expanded by an additional argument: `ispolar`. If the midpoints are passed and the first entry of the radius array is 0, `heatmap_edges` would return values smaller than 0, resulting in the heatmap not being displayed. `ispolar` will ensure that the edges are only expanded to smaller values than the minimum radius if the resulting value is still positive. This is probably not the most elegant way, so I would be very happy for some feedback!

## Example output

### Initial issue (#3149)

To get back to the example of the initial issue
```julia
using Plots
θ = π .+ 2*asin.(vcat(-(1:-0.001:0).^4,(0.001:0.001:1).^4))
r = sqrt.(0:1:100)
heatmap(θ,r,r.*cos.(2θ'), projection = :polar)
```

used to be this before:

![gr_old_nonuniform_polar_heatmap](https://user-images.githubusercontent.com/30291312/107856974-04053a80-6e2c-11eb-9a3f-66862a3aa595.png)


and would now be this:

![gr_new_nonuniform_polar_heatmap](https://user-images.githubusercontent.com/30291312/107857010-17b0a100-6e2c-11eb-82d0-30c3e6deb10b.png)

### Possibility to plot non-2π polar heatmaps

A very nice side effect of this update is that it also allows plotting polar heatmaps that do not range over the whole 2π range.
These were previously stretched to the full 2π range, causing misleading plots.

Minimum example (similar to the one before but `θ` only ranging from `0` to `π` instead of `2π`) :
```julia
using Plots
θ = 0:π/100:π # notice that this is not full 2π
r = sqrt.(0:1:100)
heatmap(θ,r,r.*cos.(2θ'), projection = :polar)
```
used to give this:

![gr_old_half_nonuniform_polar_heatmap](https://user-images.githubusercontent.com/30291312/107857148-dff62900-6e2c-11eb-84e8-7ad2b913074f.png)


and now gives this:

![gr_new_half_nonuniform_polar_heatmap](https://user-images.githubusercontent.com/30291312/107857243-91955a00-6e2d-11eb-8ab9-d1b2891d651a.png)




## Remarks

```julia
xmin, xmax, ymin, ymax = gr_xy_axislims(series[:subplot])
GR.setwindow(-ymax, ymax, -ymax, ymax)
```
I am not quite sure what these lines exactly do, as this PR also seems to add some white space around the polar heatmap which did not seem to be the case before:


Feel free to edit and push to this repository or comment!


Edit (daschw): fix #3156
