### PR TITLE
Support extra_kwargs in hexbins for PyPlot

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -510,7 +510,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     end
 
     if st == :hexbin
-        handle = ax."hexbin"(x, y,
+        handle = ax."hexbin"(x, y;
             label = series[:label],
             C = series[:weights],
             gridsize = series[:bins]==:auto ? 100 : series[:bins],  # 100 is the default value

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -510,12 +510,12 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     end
 
     if st == :hexbin
+        extrakw[:edgecolors] = get(series[:extra_kwargs], :edgecolors, py_color(get_linecolor(series)))
         handle = ax."hexbin"(x, y;
             label = series[:label],
             C = series[:weights],
             gridsize = series[:bins]==:auto ? 100 : series[:bins],  # 100 is the default value
             linewidths = py_thickness_scale(plt, series[:linewidth]),
-            edgecolors = py_color(get_linecolor(series)),
             alpha = series[:fillalpha],
             cmap = py_fillcolormap(series),  # applies to the pcolorfast object
             zorder = series[:series_plotindex],

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -510,6 +510,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     end
 
     if st == :hexbin
+        extrakw[:mincnt] = get(series[:extra_kwargs], :mincnt, nothing)
         extrakw[:edgecolors] = get(series[:extra_kwargs], :edgecolors, py_color(get_linecolor(series)))
         handle = ax."hexbin"(x, y;
             label = series[:label],

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -372,8 +372,10 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     vmin, vmax = clims = get_clims(sp, series)
 
     # Dict to store extra kwargs
-    if st == :wireframe
-        extrakw = KW()          # vmin, vmax cause an error for wireframe plot
+    if st == :wireframe || st == :hexbin
+        # vmin, vmax cause an error for wireframe plot
+        # We are not supporting clims for hexbin as calculation of bins is not trivial
+        extrakw = KW()
     else
         extrakw = KW(:vmin => vmin, :vmax => vmax)
     end
@@ -517,7 +519,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             alpha = series[:fillalpha],
             cmap = py_fillcolormap(series),  # applies to the pcolorfast object
             zorder = series[:series_plotindex],
-            # extrakw...  # We are not supporting clims for hexbin as calculation of bins is not trivial
+            extrakw...
         )
         push!(handles, handle)
     end


### PR DESCRIPTION
Fixes #3301 by supporting `extra_kwargs` for `hexbin` with `pyplot` backend, in particular `:mincnt` and `:edgecolors` (which overrides `:linecolor`)

Example:
```julia
using Plots; pyplot()
x, y = randn(10_000), randn(10_000)
hexbin(x, y; bins=50, extra_kwargs=Dict(:series=>Dict(:mincnt=>1, :edgecolors=>:face)))
```
![tmp](https://user-images.githubusercontent.com/8673634/108000110-fe2f6680-6f9d-11eb-94d9-e36b8cfb5e05.png)

cc @BeastyBlacksmith 