### PR TITLE
Bar chart series_annotations

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -416,7 +416,11 @@ end
     end
 
     if !isnothing(plotattributes[:series_annotations])
-        annotations := (x,y,plotattributes[:series_annotations].strs,:bottom)
+        if isvertical(plotattributes)
+            annotations := (x,y,plotattributes[:series_annotations].strs,:bottom)
+        else
+            annotations := (y,x,plotattributes[:series_annotations].strs,:left)
+        end
         series_annotations := nothing
     end
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -415,6 +415,11 @@ end
         fillto = map(x -> _is_positive(x) ? typeof(baseline)(x) : baseline, fillto)
     end
 
+    if !isnothing(plotattributes[:series_annotations])
+        annotations := (x,y,plotattributes[:series_annotations].strs,:bottom)
+        series_annotations := nothing
+    end
+
     # create the bar shapes by adding x/y segments
     xseg, yseg = Segments(), Segments()
     for i = 1:ny


### PR DESCRIPTION
Makes bar chart annotations work.

```julia
x=1:5
y=rand(5)
t=["a","b","c","d","e"]
plot(x,y,st=:bar,series_annotations=t)
```
![barchart](https://user-images.githubusercontent.com/6677110/109412126-89e5c180-79a6-11eb-9118-a2a46e0d4d65.png)

closes #761