### PR TITLE
Enable `dpi`  option for `pgfplotsx()` PNGs.

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -1363,7 +1363,7 @@ function _update_plot_object(plt::Plot{PGFPlotsXBackend})
     plt.o(plt)
 end
 
-for mime in ("application/pdf", "image/png", "image/svg+xml")
+for mime in ("application/pdf", "image/svg+xml")
     @eval function _show(
         io::IO,
         mime::MIME{Symbol($mime)},
@@ -1373,6 +1373,18 @@ for mime in ("application/pdf", "image/png", "image/svg+xml")
         show(io, mime, plt.o.the_plot)
     end
 end
+
+    function _show(
+        io::IO,
+        mime::MIME{Symbol("image/png")},
+        plt::Plot{PGFPlotsXBackend},
+    )
+        plt.o.was_shown = true
+        plt_file = tempname() * ".png"
+        PGFPlotsX.pgfsave(plt_file, plt.o.the_plot; dpi=plt[:dpi])
+        write(io, read(plt_file))
+        rm(plt_file; force = true)
+    end
 
 function _show(
     io::IO,


### PR DESCRIPTION
Enable `dpi` specification for PGFPlotsX png file generation. 

This bypasses the `Base.show` that PGFPlotsX implements in favour of just creating a file using `pgfsave` and reading that file into IO. It seems to work fine for me and the tests pass but it would be good for someone who knows the plumbing of Plots.jl to weigh in on whether this is fine.

 