### PR TITLE
Fix PyPlot spines iteration

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -839,10 +839,20 @@ function py_set_scale(ax, sp::Subplot, axis::Axis)
     py_set_scale(ax, sp, scale, letter)
 end
 
-function py_set_axis_colors(sp, ax, a::Axis)
-    for loc in ax.spines
-        ax.spines[loc]."set_color"(py_color(a[:foreground_color_border]))
+function py_set_spine_color(spines, color)
+    for loc in spines
+        spines[loc]."set_color"(color)
     end
+end
+
+function py_set_spine_color(spines::Dict, color)
+    for (loc, spine) in spines
+        spine."set_color"(color)
+    end
+end
+
+function py_set_axis_colors(sp, ax, a::Axis)
+    py_set_spine_color(ax.spines, py_color(a[:foreground_color_border]))
     axissym = Symbol(a[:letter], :axis)
     if PyPlot.PyCall.hasproperty(ax, axissym)
         tickcolor = sp[:framestyle] in (:zerolines, :grid) ? py_color(plot_color(a[:foreground_color_grid], a[:gridalpha])) : py_color(a[:foreground_color_axis])

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -840,8 +840,8 @@ function py_set_scale(ax, sp::Subplot, axis::Axis)
 end
 
 function py_set_axis_colors(sp, ax, a::Axis)
-    for (loc, spine) in ax.spines
-        spine."set_color"(py_color(a[:foreground_color_border]))
+    for loc in ax.spines
+        ax.spines[loc]."set_color"(py_color(a[:foreground_color_border]))
     end
     axissym = Symbol(a[:letter], :axis)
     if PyPlot.PyCall.hasproperty(ax, axissym)


### PR DESCRIPTION
```
$ pacman -Q julia python python-matplotlib
julia 2:1.6.0-5
python 3.9.2-1
python-matplotlib 3.4.0-2

pkg> status
  [91a5bcdd] Plots v1.11.0
  [438e738f] PyCall v1.92.2
  [d330b81b] PyPlot v2.9.0
```

With julia 1.6 and python 3.9, the pyplot backend is no longer working for me. I get the following error:

```
> using Plots, PyCall; pyplot()
> @pyimport numpy as np
> x = y = np.arange(10)
> plot(x, y)
Error showing value of type Plots.Plot{Plots.PyPlotBackend}:
ERROR: MethodError: no method matching getproperty(::Char, ::String)
[...]
Stacktrace:
 [1] py_set_axis_colors(sp::Plots.Subplot{Plots.PyPlotBackend}, ax::PyObject, a::Plots.Axis)
   @ Plots ~/.julia/packages/Plots/z5Msu/src/backends/pyplot.jl:838
 [2] _before_layout_calcs(plt::Plots.Plot{Plots.PyPlotBackend})
   @ Plots ~/.julia/packages/Plots/z5Msu/src/backends/pyplot.jl:1176
 [3] prepare_output(plt::Plots.Plot{Plots.PyPlotBackend})
   @ Plots ~/.julia/packages/Plots/z5Msu/src/plot.jl:182
 [4] display(#unused#::Plots.PlotsDisplay, plt::Plots.Plot{Plots.PyPlotBackend})
   @ Plots ~/.julia/packages/Plots/z5Msu/src/output.jl:149
 [5] (::REPL.var"#do_respond#61"{Bool, Bool, REPL.var"#72#82"{REPL.LineEditREPL, REPL.REPLHistoryProvider}, REPL.LineEditREPL, REPL.LineEdit.Prompt})(s::REPL.LineEdit.MIState, buf::Any, ok::Bool)
   @ REPL /build/julia/src/julia-1.6.0/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:798
```


The suggested change fixes it for me, however I don't know enough about matplotlib/pyplot to say whether the real issue is with PyPlot.jl, PyCall.jl, or Plots.jl.