### PR TITLE
Generalize Shape

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -9,9 +9,9 @@ compute_angle(v::P2) = (angle = atan(v[2], v[1]); angle < 0 ? 2π - angle : angl
 
 # -------------------------------------------------------------
 
-struct Shape
-    x::Vector{Float64}
-    y::Vector{Float64}
+struct Shape{X<:Number, Y<:Number}
+    x::Vector{X}
+    y::Vector{Y}
     # function Shape(x::AVec, y::AVec)
     #     # if x[1] != x[end] || y[1] != y[end]
     #     #     new(vcat(x, x[1]), vcat(y, y[1]))
@@ -52,7 +52,7 @@ end
 
 "get an array of tuples of points on a circle with radius `r`"
 function partialcircle(start_θ, end_θ, n = 20, r=1)
-    Tuple{Float64,Float64}[(r*cos(u),r*sin(u)) for u in range(start_θ, stop=end_θ, length=n)]
+    [(r*cos(u), r*sin(u)) for u in range(start_θ, stop=end_θ, length=n)]
 end
 
 "interleave 2 vectors into each other (like a zipper's teeth)"
@@ -205,9 +205,12 @@ function rotate!(shape::Shape, Θ::Real, c = center(shape))
 end
 
 "rotate an object in space"
-function rotate(shape::Shape, Θ::Real, c = center(shape))
-    shapecopy = deepcopy(shape)
-    rotate!(shapecopy, Θ, c)
+function rotate(shape::Shape, θ::Real, c = center(shape))
+    x, y = coords(shape)
+    cx, cy = c
+    x_new = rotate_x.(x, y, θ, cx, cy)
+    y_new = rotate_y.(x, y, θ, cx, cy)
+    Shape(x_new, y_new)
 end
 
 # -----------------------------------------------------------------------

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -1,6 +1,11 @@
 using Plots, Test
 
 @testset "Shapes" begin
+    @testset "Type" begin
+        square = Shape([(0,0.0),(1,0.0),(1,1.0),(0,1.0)])
+        @test isa(square, Shape{Int64, Float64})
+    end
+
     @testset "Copy" begin
         square = Shape([(0,0),(1,0),(1,1),(0,1)])
         square2 = Shape(square)


### PR DESCRIPTION
Allows `Shape` to hold other types than `Float64`, so that recipes can dispatch on the vertices.

With this change, for instance, `Shape([(0u"m", 1u"s"), (1u"m", 1u"s"), (1u"m", 2u"s")])` (with Unitful units `u"m"` and `u"s"`) is a valid `Shape`, and when plotted it will invoke the recipes for the respective axis types:

```julia
julia> using Unitful, Plots, UnitfulRecipes

julia> s = Shape([(0u"m", 1u"s"), (1u"m", 1u"s"), (1u"m", 2u"s")])
Shape{Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}}}(Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}[0 m, 1 m, 1 m], Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}}[1 s, 1 s, 2 s])

julia> plot(s)

```

![shape](https://user-images.githubusercontent.com/6677110/114673652-b3fd0400-9d06-11eb-8a28-ae31ab8b87e8.png)

