### PR TITLE
Fix for plotting a vector of (at least two) NaNs 

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -178,6 +178,14 @@ makevec(v::T) where {T} = T[v]
 maketuple(x::Real)                     = (x,x)
 maketuple(x::Tuple{T,S}) where {T,S} = x
 
+for i in 2:4
+    @eval begin
+        RecipesPipeline.unzip(
+            v::Union{AVec{<:Tuple{Vararg{T,$i} where T}}, AVec{<:GeometryBasics.Point{$i}}},
+        ) = $(Expr(:tuple, (:([t[$j] for t in v]) for j=1:i)...))
+    end
+end
+
 RecipesPipeline.unzip(
     ::Union{AVec{<:GeometryBasics.Point{N}}, AVec{<:Tuple{Vararg{T,N} where T}}}
 ) where N = error("$N-dimensional unzip not implemented.")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,6 +172,8 @@ end
     @testset "Plot" begin
         plots = [histogram([1, 0, 0, 0, 0, 0]),
                  plot([missing]),
+                 plot([missing, missing]),
+                 plot(fill(missing, 10)),
                  plot([missing; 1:4]),
                  plot([fill(missing, 10); 1:4]),
                  plot([1 1; 1 missing]),


### PR DESCRIPTION
Fixes `plot([NaN,NaN])` on GR
The new test doesn't actually test on GR, because the "NoFail" testset runs on the unicode backend since #3387. Maybe this should be reverted? @olegshtch, can you comment on why you made this change?