### PR TITLE
Allow `while`-block in at-animate macro

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -137,8 +137,8 @@ end
 # -----------------------------------------------
 
 function _animate(forloop::Expr, args...; callgif = false)
-  if forloop.head != :for
-    error("@animate macro expects a for-block. got: $(forloop.head)")
+  if forloop.head ∉ (:for, :while)
+    error("@animate macro expects a for- or while-block. got: $(forloop.head)")
   end
 
   # add the call to frame to the end of each iteration


### PR DESCRIPTION
The `@animate` example in [documentation](https://docs.juliaplots.org/dev/animations/#Convenience-macros) just works for me on this branch with
```julia
anim = @animate while i ≤ n
    circleplot(x, y, i)
    i += 1
end
```

For reference: https://discourse.julialang.org/t/animate-with-while-loop-in-julia/61069