### PR TITLE
First attempt at histogram3d/legoplot

### DIFF
--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -108,6 +108,25 @@ julia> histogram2d(randn(10_000),randn(10_000))
 @shorthands histogram2d
 
 """
+    histogram3d(x,y)
+    histogram3d!(x,y)
+
+Plot a three-dimensional histogram.
+
+# Arguments
+
+- `bins`: Number of bins (if an `Integer`) or bin edges (if an `AbtractVector`)
+- `weights`: Vector of weights for the values in `x`. Each entry of x contributes
+             its weight to the height of its bin.
+
+# Example
+```julia-repl
+julia> histogram3d(randn(10_000),randn(10_000))
+```
+"""
+@shorthands histogram3d
+
+"""
     density(x)
     density!(x)
 


### PR DESCRIPTION
As already mentioned in #3379 I wanted to add a `histogram3d()` function for plotting. 
Therefore I took over the ides from the issue and translated it in a recipe, however now I am a bit stuck.

The main problems + possible solutions are:
  1. `wireframe` is not reliable across the different backends (very different behaviours) so I switched to `surface`
  2. `surface` does not provide a mesh option (like `surface` + `wireframe`) and so one does not get a lot of information from the plots. 
     - solution 1: adding all the lines manually? may be very resource intensive
     - solution 2: Adding a wireframe? does not provide the correct overlay properties depending on the backend
  3. color: Should it be one color like it is done for usual histograms or would it be nicer to have colored bars depending on their height (like a heatmap not seen from above)?
  4. Additionally I wanted to add the same possibility as in 2d-histograms to use the attribute `show_empty_bins` which turned out to be really hard. Especially the `plotly()` backend seems to have a lot of trouble with a mixture of `NaN` and numeric-values at the same x-y position.
     - Additionally this needs the `_allneighbours` function which checks if all neighbours in a matrix are the same value, which I need to set the `NaN`-values for the plot. I really dislike this function a lot but I couldn't wrap my head around another idea to resolve this


# Figures

All plots are created by
```julia
x=rand(100)
y=rand(100)
histogram3d(x,y,bins=(10,10),camera=(20,60),xlabel="x")
```

## GR
### One-coloured surface plot
- Good: Shows bins as expected
- Bad: Not very useful without lines at the edges (Problem 2 from above)
![hist3d_blue_gr](https://user-images.githubusercontent.com/20151553/118518244-375faa00-b738-11eb-86a0-71c72204e305.png)

### Multi-coloured surface plot
- Good: Shows bins as expected, able to separate different bins by color
- Bad: Color gradient messes here with the plot, would be better to have one fixed color for each bar instead of a gradient (How to resolve this?)
![hist3d_colored_gr](https://user-images.githubusercontent.com/20151553/118518251-39296d80-b738-11eb-9758-3c8e08b36598.png)

### Single-coloured surface + wireframe plot
Not possible with the current solution, wince `wireframe` in GR needs x and y values in ascending (i.e. repeated values are forbidden). Therefore one would need again the workaround with `repeateps()` in #3379 which I have discarded for now.

## Plotly
### One-coloured surface plot
- Good: Bins separable by eye due to automatic shadows in plotly
- Bad: lines at the edges would still be helpful (Problem 2 from above), `NaN`-values are not completely correct rendered as can be seen at for instance `x=0.2` and `y = 0.0 to 0.1` by a missing part of the wall.
![hist3d_blue_plotly](https://user-images.githubusercontent.com/20151553/118518249-3890d700-b738-11eb-96c2-6f8c7bfc1e69.png)

### Multi-coloured surface plot
- Good: Shows bins as expected, able to separate different bins by color
- Bad: Color gradient messes here with the plot, would be better to have one fixed color for each bar instead of a gradient (How to resolve this?), also here problem with `NaN`-values e.g. at `x=0.4`
![hist3d_colored_plotly_2](https://user-images.githubusercontent.com/20151553/118518254-39c20400-b738-11eb-9023-c05131fab63b.png)
![hist3d_colored_plotly](https://user-images.githubusercontent.com/20151553/118518255-3a5a9a80-b738-11eb-9fe7-6beaf469ad53.png)

### Single-coloured surface + wireframe plot
- Good: Bins separable by eye due to automatic shadows in plotly
- Bad: Wireframe lines are definitely not displayed as expected
![hist3d_colored_wf_plotly](https://user-images.githubusercontent.com/20151553/118519265-409d4680-b739-11eb-827b-852ab5811830.png)

## Pyplot

Already worked yesterday, but somehow is not compiling at the moment on my PC. I'll try to add figures as soon as possible.

# Further info

I am totally willing to expand this myself but I also definitely need some help (and also style-decisions) here. So let me know if you have any idea. Also @dorn-gerhard it would be really nice if your colleagues could add their solutions as proposed in #3379

Thanks already and Cheers.