### PR TITLE
GR: allow explicit guidefontrotation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -683,6 +683,10 @@
             "affiliation": "University of Cambridge",
             "name": "Will Tebbutt",
             "type": "Other"
+        },
+        {
+            "name": "@t-bltg",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1510,8 +1510,10 @@ function gr_label_axis(sp, letter, viewport_plotarea)
         GR.savestate()
         gr_set_font(guidefont(axis), sp)
         guide_position = axis[:guide_position]
+        angle = float(axis[:guidefontrotation])  # github.com/JuliaPlots/Plots.jl/issues/3089
         if letter === :y
-            GR.setcharup(-1, 0)
+            angle += 180.  # default angle = 0. should yield GR.setcharup(-1, 0) i.e. 180°
+            GR.setcharup(cosd(angle), sind(angle))
             ypos = gr_view_yposition(viewport_plotarea, position(axis[:guidefontvalign]))
             yalign = alignment(axis[:guidefontvalign])
             if guide_position === :right || (guide_position == :auto && mirror)
@@ -1522,6 +1524,8 @@ function gr_label_axis(sp, letter, viewport_plotarea)
                 xpos = viewport_plotarea[1] - 0.03 - !mirror * gr_axis_width(sp, axis)
             end
         else
+            angle += 90.  # default angle = 0. should yield GR.setcharup(0, 1) i.e. 90°
+            GR.setcharup(cosd(angle), sind(angle))
             xpos = gr_view_xposition(viewport_plotarea, position(axis[:guidefonthalign]))
             xalign = alignment(axis[:guidefonthalign])
             if guide_position === :top || (guide_position == :auto && mirror)


### PR DESCRIPTION
This patch allows using `guidefontrotation` (x or y label rotation) with the GR backend :

**mwe.jl**

```julia
using Plots; gr()

plot(1:2, 1:2, xlabel="Δx", ylabel="ε", yguidefontrotation=-90.)
savefig("foo.png")
```
**output:**
![foo](https://user-images.githubusercontent.com/13423344/120406968-6be48000-c34c-11eb-93b7-54da8dbba0f0.png)

**related:**
https://github.com/JuliaPlots/Plots.jl/issues/3089
https://discourse.julialang.org/t/rotating-the-axes-labels-in-gr/52379
