### PR TITLE
Respect :widen when passing :lims

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -688,6 +688,10 @@
             "name": "@t-bltg",
             "type": "Other"
         }
+        {
+            "name": "Fred Callaway",
+            "type": "Other"
+        }
     ],
     "upload_type": "software"
 }

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -178,6 +178,9 @@ const _arg_desc = KW(
 :minorgridlinewidth          => "Number. Width of the minor grid lines (in pixels)",
 :tick_direction              => "Symbol.  Direction of the ticks. `:in`, `:out` or `:none`",
 :showaxis                    => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`",
-:widen                       => "Bool. Widen the axis limits by a small factor to avoid cut-off markers and lines at the borders. Defaults to `true`.",
+:widen                       => """
+                                Bool or :auto. Widen the axis limits by a small factor to avoid cut-off markers and lines at the borders.
+                                Defaults to `:auto`, which widens unless limits were manually set.
+                                """,
 :draw_arrow                  => "Bool. Draw arrow at the end of the axis.",
 )

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -141,7 +141,7 @@ const _arg_desc = KW(
                                 NTuple{2,Number} or Symbol. Force axis limits. Only finite values are used (you can set only the right limit with `xlims = (-Inf, 2)` for example).
                                 `:round` widens the limit to the nearest round number ie. [0.1,3.6]=>[0.0,4.0]
                                 `:symmetric` sets the limits to be symmetric around zero.
-                                Additionally pass `widen=false` to use the specified limits exactly. 
+                                Set widen=true to widen the specified limits (as occurs when lims are not specified).
                                 """,
 :ticks                       => "Vector of numbers (set the tick values), Tuple of (tickvalues, ticklabels), or `:auto`",
 :scale                       => "Symbol. Scale of the axis: `:none`, `:ln`, `:log2`, `:log10`",

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -141,6 +141,7 @@ const _arg_desc = KW(
                                 NTuple{2,Number} or Symbol. Force axis limits. Only finite values are used (you can set only the right limit with `xlims = (-Inf, 2)` for example).
                                 `:round` widens the limit to the nearest round number ie. [0.1,3.6]=>[0.0,4.0]
                                 `:symmetric` sets the limits to be symmetric around zero.
+                                Additionally pass `widen=false` to use the specified limits exactly. 
                                 """,
 :ticks                       => "Vector of numbers (set the tick values), Tuple of (tickvalues, ticklabels), or `:auto`",
 :scale                       => "Symbol. Scale of the axis: `:none`, `:ln`, `:log2`, `:log10`",

--- a/src/args.jl
+++ b/src/args.jl
@@ -476,7 +476,7 @@ const _axis_defaults = KW(
     :minorticks                  => false,
     :minorgrid                   => false,
     :showaxis                    => true,
-    :widen                       => true,
+    :widen                       => :auto,
     :draw_arrow                  => false,
 )
 

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -504,6 +504,11 @@ end
 const _widen_seriestypes = (:line, :path, :steppre, :stepmid, :steppost, :sticks, :scatter, :barbins, :barhist, :histogram, :scatterbins, :scatterhist, :stepbins, :stephist, :bins2d, :histogram2d, :bar, :shape, :path3d, :scatter3d)
 
 function default_should_widen(axis::Axis)
+    if axis[:widen] isa Bool
+        return axis[:widen]
+    end
+    # automatic behavior: widen if limits aren't specified and series type is appropriate
+    (is_2tuple(axis[:lims]) || axis[:lims] == :round) && return false
     for sp in axis.sps
         for series in series_list(sp)
             if series.plotattributes[:seriestype] in _widen_seriestypes
@@ -559,7 +564,7 @@ function axis_limits(sp, letter, should_widen = default_should_widen(sp[Symbol(l
         else
             amin, amax
         end
-    elseif should_widen && axis[:widen]
+    elseif should_widen
         widen(amin, amax, axis[:scale])
     elseif lims == :round
         round_limits(amin,amax)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -504,17 +504,14 @@ end
 const _widen_seriestypes = (:line, :path, :steppre, :stepmid, :steppost, :sticks, :scatter, :barbins, :barhist, :histogram, :scatterbins, :scatterhist, :stepbins, :stephist, :bins2d, :histogram2d, :bar, :shape, :path3d, :scatter3d)
 
 function default_should_widen(axis::Axis)
-    should_widen = false
-    if !(is_2tuple(axis[:lims]) || axis[:lims] == :round)
-        for sp in axis.sps
-            for series in series_list(sp)
-                if series.plotattributes[:seriestype] in _widen_seriestypes
-                    should_widen = true
-                end
+    for sp in axis.sps
+        for series in series_list(sp)
+            if series.plotattributes[:seriestype] in _widen_seriestypes
+                return true
             end
         end
     end
-    should_widen
+    false
 end
 
 function round_limits(amin,amax)

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -35,6 +35,18 @@ end
 @testset "Axis limits" begin
     pl = plot(1:5, xlims=:symmetric, widen = false)
     @test Plots.xlims(pl) == (-5, 5)
+    
+    pl = plot(1:3)
+    @test Plots.xlims(pl) == Plots.widen(1,3)
+    
+    pl = plot(1:3, xlims=:round)
+    @test Plots.xlims(pl) == (1, 3)
+    
+    pl = plot(1:3, xlims=(1,5))
+    @test Plots.xlims(pl) == (1, 5)
+
+    pl = plot(1:3, xlims=(1,5), widen=true)
+    @test Plots.xlims(pl) == Plots.widen(1, 5)
 end
 
 @testset "3D Axis" begin

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -39,7 +39,7 @@ end
     pl = plot(1:3)
     @test Plots.xlims(pl) == Plots.widen(1,3)
     
-    pl = plot(1:3, xlims=:round)
+    pl = plot(0.5:0.5:2.5, xlims=:round)
     @test Plots.xlims(pl) == (1, 3)
     
     pl = plot(1:3, xlims=(1,5))


### PR DESCRIPTION
Previously, the limits were not widened when passing a tuple or
:round to lims (ignoring the widen argument). Fixes #3339