### PR TITLE
embeddable html show for performance in Pluto

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -986,7 +986,7 @@ end
 
 
 function _show(io::IO, ::MIME"text/html", plt::Plot{PlotlyBackend})
-    write(io, standalone_html(plt))
+    write(io, embeddable_html(plt))
 end
 
 

--- a/src/backends/plotlyjs.jl
+++ b/src/backends/plotlyjs.jl
@@ -34,7 +34,7 @@ _show(io::IO, mime::MIME"application/vnd.plotly.v1+json", plt::Plot{PlotlyJSBack
 html_head(plt::Plot{PlotlyJSBackend}) = plotly_html_head(plt)
 html_body(plt::Plot{PlotlyJSBackend}) = plotly_html_body(plt)
 
-_show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend}) = write(io, standalone_html(plt))
+_show(io::IO, ::MIME"text/html", plt::Plot{PlotlyJSBackend}) = write(io, embeddable_html(plt))
 
 _display(plt::Plot{PlotlyJSBackend}) = display(plotlyjs_syncplot(plt))
 

--- a/src/backends/web.jl
+++ b/src/backends/web.jl
@@ -19,6 +19,10 @@ function standalone_html(plt::AbstractPlot; title::AbstractString = get(plt.attr
     """
 end
 
+function embeddable_html(plt::AbstractPlot)
+    html_head(plt) * html_body(plt)
+end
+
 function open_browser_window(filename::AbstractString)
     @static if Sys.isapple()
         return run(`open $(filename)`)


### PR DESCRIPTION
# Standalone/embeddable html in `Base.show`

Currently, the `Base.show(io::IO, m::MIME"text/html", p::Plot{PlotlyBackend})` method outputs a standalone HTML document, i.e.
```html
<html>
<head>
...
</head>
<body>
...
</body>
</html>
```

which means that it cannot (correctly) be embedded _inside_ HTML output, without using an `<iframe>`.

This is why `text/html` show methods in Julia are generally not standalone pages, but HTML snippets. A good example is Plots.jl with the GR backend, where `Base.show(io::IO, m::MIME"text/html", p::Plot{PlotlyBackend})` outputs a bare `<img>` or `<svg>` tag, not wrapped inside `<html>`. 

Other examples are DataFrames.jl ([bare `<table>`](https://github.com/JuliaData/DataFrames.jl/blob/d5bb28daffb1471e93c185e99fcb68d2d26dfb8b/src/abstractdataframe/io.jl#L191)) and the Markdown stdlib ([bare `<div>`](https://github.com/JuliaLang/julia/blob/1910a7685a86d44041a98ff874f92e480fc44632/stdlib/Markdown/src/render/html.jl#L188)).

`<script>` tags do not need to be placed inside a `<head>` to load, which is why this PR replaces the show method with a simpler one.


# Before

Because every cell output is a standalone HTML document, Pluto needs to create a new `iframe` to render the subpage in, causing notable flickering.

https://user-images.githubusercontent.com/6933510/121240062-3edb2480-c89a-11eb-8053-ee3873f1d51a.mov



# After


https://user-images.githubusercontent.com/6933510/121240051-3b479d80-c89a-11eb-8755-401d1279b351.mov


# Other environments still work

### VS Code

![image](https://user-images.githubusercontent.com/6933510/121243797-6df39500-c89e-11eb-8f20-af97e0c2dd10.png)


### Jupyter

![Schermafbeelding 2021-06-08 om 20 42 17](https://user-images.githubusercontent.com/6933510/121240017-31259f00-c89a-11eb-8eba-7207d0e4dc2b.png)

### Static 

Environments that generate static HTML will be unaffected, including Franklin and Literate.


# Example code

(For Pluto and Jupyter)

```julia
begin
	import Pkg
	Pkg.activate(mktempdir())
	Pkg.add([
			Pkg.PackageSpec(url="https://github.com/fonsp/Plots.jl", rev="embeddable-plotly-html"),
			Pkg.PackageSpec(name="PlutoUI"),
		])
	using PlutoUI
	using Plots
	plotly()
end
```

```julia
plot(sin.(.01 .* (1:x)))
```
