### PR TITLE
show extrakwargs on `show`

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -23,7 +23,38 @@ current(plot::AbstractPlot) = (CURRENT_PLOT.nullableplot = plot)
 
 Base.string(plt::Plot) = "Plot{$(plt.backend) n=$(plt.n)}"
 Base.print(io::IO, plt::Plot) = print(io, string(plt))
-Base.show(io::IO, plt::Plot) = print(io, string(plt))
+function Base.show(io::IO, plt::Plot)
+    print(io, string(plt))
+    sp_ekwargs = getindex.(plt.subplots, :extra_kwargs)
+    s_ekwargs = getindex.(plt.series_list, :extra_kwargs)
+    if isempty(plt[:extra_plot_kwargs]) && all(isempty, sp_ekwargs) && all(isempty, s_ekwargs)
+        return
+    end
+    print(io,"\nCaptured extra kwargs:\n")
+    do_show = true
+    for (key, value) in plt[:extra_plot_kwargs]
+        do_show && println(io, "  Plot:")
+        println(io, " "^4, key, ": ", value)
+        do_show = false
+    end
+    do_show = true
+    for (i, ekwargs) in enumerate(sp_ekwargs)
+        for (key, value) in ekwargs
+            do_show && println(io, "  SubplotPlot{$i}:")
+            println(io, " "^4, key, ": ", value)
+            do_show = false
+        end
+        do_show = true
+    end
+    for (i, ekwargs) in enumerate(s_ekwargs)
+        for (key, value) in ekwargs
+            do_show && println(io, "  Series{$i}:")
+            println(io, " "^4, key, ": ", value)
+            do_show = false
+        end
+        do_show = true
+    end
+end
 
 getplot(plt::Plot) = plt
 getattr(plt::Plot, idx::Int = 1) = plt.attr


### PR DESCRIPTION
Sometimes accidently mistyped variables get interpreted as extra_kwargs.

This PR would allow to discover that by using `show` on the Plot object.

```julia
julia> plot(1:5, margines = 2Plots.cm) |> show
Plot{Plots.GRBackend() n=1}
Captured extra kwargs:
  Series{1}:
    margines: 20.0mm
```