### PR TITLE
change input to `optimize_ticks` for log scales

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -174,6 +174,11 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
             sf(amax);
             k_min = 4, # minimum number of ticks
             k_max = 8, # maximum number of ticks
+            Q = if scale in _logScales
+                [(1.0,1.0), (5.0, 0.9), (2.0, 0.7)]
+            else
+                [(1.0,1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)]
+            end,
         )[1]
     elseif typeof(ticks) <: Int
         scaled_ticks, viewmin, viewmax = optimize_ticks(
@@ -185,6 +190,11 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
             # `strict_span = false` rewards cases where the span of the
             # chosen  ticks is not too much bigger than amin - amax:
             strict_span = false,
+            Q = if scale in _logScales
+                [(1.0,1.0), (5.0, 0.9), (2.0, 0.7)]
+            else
+                [(1.0,1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)]
+            end,
         )
         # axis[:lims] = map(RecipesPipeline.inverse_scale_func(scale), (viewmin, viewmax))
     else

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -168,22 +168,27 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
     end
 
     # get a list of well-laid-out ticks
+    smin, smax = sf(amin), sf(amax)
     if ticks === nothing
         scaled_ticks = optimize_ticks(
-            sf(amin),
-            sf(amax);
+            smin,
+            smax;
             k_min = 4, # minimum number of ticks
             k_max = 8, # maximum number of ticks
             Q = if scale in _logScales
-                [(1.0,1.0), (5.0, 0.9), (2.0, 0.7)]
+                if scale === :log10 && smax - smin > 6
+                    [(1.0,1.0), (3.0, 0.9)]
+                else
+                    [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7)]
+                end
             else
                 [(1.0,1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)]
             end,
         )[1]
     elseif typeof(ticks) <: Int
         scaled_ticks, viewmin, viewmax = optimize_ticks(
-            sf(amin),
-            sf(amax);
+            smin,
+            smax;
             k_min = ticks, # minimum number of ticks
             k_max = ticks, # maximum number of ticks
             k_ideal = ticks,
@@ -191,7 +196,11 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
             # chosen  ticks is not too much bigger than amin - amax:
             strict_span = false,
             Q = if scale in _logScales
-                [(1.0,1.0), (5.0, 0.9), (2.0, 0.7)]
+                if scale === :log10 && smax - smin > 6
+                    [(1.0,1.0), (3.0, 0.9)]
+                else
+                    [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7)]
+                end
             else
                 [(1.0,1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)]
             end,


### PR DESCRIPTION
Alternative implementation to @t-bltg's awesome initiative in https://github.com/JuliaPlots/Plots.jl/pull/3547 based on @isentropic's suggestion in https://github.com/JuliaPlots/Plots.jl/pull/3547#issuecomment-857329723
```julia
using Plots; gr()
x = y = Float64[1]
for i ∈ range(-5, 6, step=1)
  append!(x, 2 * 10.0^i:10.0^i:10.0^(i + 1) |> collect)
end
plot(
  x, y, axis=:log10, minorgrid=true, legend=false,
  minorticks=true, shape=:cross, ms=2, lw=.5, dpi=300
)
```
![test](https://user-images.githubusercontent.com/16589944/121717046-109b5600-cae1-11eb-941c-28524a4323e3.png)
