### PR TITLE
GR: rework automatic major/minor ticks for log scales

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -115,7 +115,7 @@ const _examples = PlotExample[
                     )
                     vline!([5, 10])
                     title!("TITLE")
-                    yaxis!("YLABEL", :log10)
+                    yaxis!("YLABEL", :log10, minorgrid = true)
                 end
             ),
         ],


### PR DESCRIPTION
Superseding https://github.com/JuliaPlots/Plots.jl/pull/3547, required patch: https://github.com/JuliaPlots/PlotUtils.jl/pull/115.

Test cases:
```julia
using Plots; gr()

for (i, (start, stop)) ∈ enumerate([(-1, 2), (-6, 5)])
    x = y = Float64[1]
    for j ∈ start:stop
      append!(x, 2 * 10.0^j:10.0^j:10.0^(j + 1) |> collect)
    end
    plot(
      x, y, axis=:log10, minorgrid=true, legend=:none,
      shape=:cross, ms=2, lw=.5, dpi=200
    )
    png("loglog-$i")
end
```

Output:
![loglog-1](https://user-images.githubusercontent.com/13423344/124640530-d4fc6d80-de8d-11eb-88c1-70b7985d94ae.png)
![loglog-2](https://user-images.githubusercontent.com/13423344/124640534-d5950400-de8d-11eb-9413-0bf5e101d253.png)

Fix https://github.com/JuliaPlots/Plots.jl/issues/3318
Fix https://github.com/JuliaPlots/Plots.jl/issues/696
Fix https://github.com/JuliaPlots/Plots.jl/issues/458