### PR TITLE
GR: fix axis flip / mirror in 3D plots

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -853,15 +853,17 @@ function axis_drawing_info_3d(sp, letter)
                         )
                     end
                     if grid
+                        fa0_, fa1_ = reverse_if((fa0, fa1), ax[:mirror])
+                        ga0_, ga1_ = reverse_if((ga0, ga1), ax[:mirror])
                         push!(
                             segments,
-                            sort_3d_axes(tick, ga0, fa0, letter),
-                            sort_3d_axes(tick, ga1, fa0, letter),
+                            sort_3d_axes(tick, ga0_, fa0_, letter),
+                            sort_3d_axes(tick, ga1_, fa0_, letter),
                         )
                         push!(
                             segments,
-                            sort_3d_axes(tick, ga1, fa0, letter),
-                            sort_3d_axes(tick, ga1, fa1, letter),
+                            sort_3d_axes(tick, ga1_, fa0_, letter),
+                            sort_3d_axes(tick, ga1_, fa1_, letter),
                         )
                     end
                 end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1282,8 +1282,8 @@ function gr_set_window(sp, viewport_plotarea)
         gr_set_viewport_polar(viewport_plotarea)
     else
         xmin, xmax, ymin, ymax = gr_xy_axislims(sp)
-        is3d = RecipesPipeline.is3d(sp)
-        if is3d
+        needs_3d = needs_any_3d_axes(sp)
+        if needs_3d
             zmin, zmax = gr_z_axislims(sp)
             zok = zmax > zmin
         else
@@ -1292,12 +1292,12 @@ function gr_set_window(sp, viewport_plotarea)
 
         scaleop = 0
         if xmax > xmin && ymax > ymin && zok
-            sp[:xaxis][:scale] == :log10         && (scaleop |= GR.OPTION_X_LOG)
-            sp[:yaxis][:scale] == :log10         && (scaleop |= GR.OPTION_Y_LOG)
-            is3d && sp[:zaxis][:scale] == :log10 && (scaleop |= GR.OPTION_Z_LOG)
-            sp[:xaxis][:flip]                    && (scaleop |= GR.OPTION_FLIP_X)
-            sp[:yaxis][:flip]                    && (scaleop |= GR.OPTION_FLIP_Y)
-            is3d && sp[:zaxis][:flip]            && (scaleop |= GR.OPTION_FLIP_Z)
+            sp[:xaxis][:scale] == :log10             && (scaleop |= GR.OPTION_X_LOG)
+            sp[:yaxis][:scale] == :log10             && (scaleop |= GR.OPTION_Y_LOG)
+            needs_3d && sp[:zaxis][:scale] == :log10 && (scaleop |= GR.OPTION_Z_LOG)
+            sp[:xaxis][:flip]                        && (scaleop |= GR.OPTION_FLIP_X)
+            sp[:yaxis][:flip]                        && (scaleop |= GR.OPTION_FLIP_Y)
+            needs_3d && sp[:zaxis][:flip]            && (scaleop |= GR.OPTION_FLIP_Z)
             # NOTE: setwindow sets the "data coordinate" limits of the current "viewport"
             GR.setwindow(xmin, xmax, ymin, ymax)
             GR.setscale(scaleop)

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1163,6 +1163,56 @@ const _examples = PlotExample[
             ),
         ],
     ),
+    PlotExample( # 55
+        "3D axis flip / mirror",
+        "",
+        [
+            :(
+              begin
+                meshgrid(x, y) = (ones(eltype(y), length(y)) * x', y * ones(eltype(x), length(x))')
+                scalefontsizes(.5)
+
+                x, y = meshgrid(-6:0.5:10, -8:0.5:8)
+                r = sqrt.(x .^ 2 + y .^ 2) .+ eps()
+                z = sin.(r) ./ r
+
+                args = x[1, :], y[:, 1], z[:]
+                kwargs = Dict(
+                    :xlabel => "x", :ylabel => "y", :zlabel => "z",
+                    :grid => true, :minorgrid => true, :dpi => 200
+                )
+
+                plots = [wireframe(args..., title = "wire"; kwargs...)]
+
+                for ax ∈ (:x, :y, :z)
+                    push!(plots, wireframe(
+                        args...,
+                        title = "wire-flip-$ax",
+                        xflip = ax == :x,
+                        yflip = ax == :y,
+                        zflip = ax == :z;
+                        kwargs...,
+                    ))
+                end
+
+                for ax ∈ (:x, :y, :z)
+                    push!(plots, wireframe(
+                        args...,
+                        title = "wire-mirror-$ax",
+                        xmirror = ax == :x,
+                        ymirror = ax == :y,
+                        zmirror = ax == :z;
+                        kwargs...,
+                    ))
+                end
+
+                plot(plots..., layout=(@layout [_ ° _; ° ° °; ° ° °]), margin=2Plots.mm)
+
+                scalefontsizes()
+              end
+            ),
+        ],
+    ),
 ]
 
 # Some constants for PlotDocs and PlotReferenceImages

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -338,6 +338,14 @@ function _override_seriestype_check(plotattributes::AKW, st::Symbol)
     st
 end
 
+function needs_any_3d_axes(sp::Subplot)
+    any(
+        RecipesPipeline.needs_3d_axes(
+            _override_seriestype_check(s.plotattributes, s.plotattributes[:seriestype])
+        ) for s in series_list(sp)
+    )
+end
+
 function _expand_subplot_extrema(sp::Subplot, plotattributes::AKW, st::Symbol)
     # adjust extrema and discrete info
     if st == :image


### PR DESCRIPTION
Here is a test case and PR fixing several issues with 3D plots.

This PR fixes the following:
- wrong ticks / axis label position when flipping axes
- data not flipped on z axis
- axis label outside box when using mirror
- grid lines when mirroring

```julia
using Plots; gr()

main() = begin
  meshgrid(x, y) = (ones(eltype(y), length(y)) * x', y * ones(eltype(x), length(x))')

  x, y = meshgrid(-6:.5:10, -8:.5:8)
  r = sqrt.(x.^2 + y.^2) .+ eps()
  z = sin.(r) ./ r

  args = x[1, :], y[:, 1], z[:]
  kwargs = Dict(:xlabel=>"x", :ylabel=>"y", :zlabel=>"z", :dpi=>200, :grid=>true, :minorgrid=>true)

  ttl = "wire"
  wireframe(args..., title=ttl; kwargs...)
  png(ttl)

  for ax ∈ (:x, :y, :z)
    ttl = "wire-flip-$ax"
    wireframe(
      args..., title=ttl, xflip=ax == :x, yflip=ax == :y, zflip=ax == :z; kwargs...
    )
    png(ttl)
  end

  for ax ∈ (:x, :y, :z)
    ttl = "wire-mirror-$ax"
    wireframe(
      args..., title=ttl, xmirror=ax == :x, ymirror=ax == :y, zmirror=ax == :z; kwargs...
    )
    png(ttl)
  end

  return
end

main()
```

without PR
--------------
![out](https://user-images.githubusercontent.com/13423344/123346521-cee6c280-d558-11eb-8fa9-4f22c543ac7d.png)

with PR
----------
![out-PR](https://user-images.githubusercontent.com/13423344/123346529-d312e000-d558-11eb-8aad-28302df5d97d.png)

