### PR TITLE
Ignore :blank plots

### DIFF
--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -406,7 +406,7 @@ end
 
 # ----------------------------------------------------------------------
 
-calc_num_subplots(layout::AbstractLayout) = 1
+calc_num_subplots(layout::AbstractLayout) = get(layout.attr, :blank, false) ? 0 : 1
 function calc_num_subplots(layout::GridLayout)
     tot = 0
     for l in layout.grid


### PR DESCRIPTION
When creating a layout, it makes sense not to count the `:blank` plots (using `_ character`, see https://github.com/JuliaPlots/Plots.jl/blob/master/src/layouts.jl#L686).

```julia
using Plots(); gr()
plot((plot() for i in 1:7)..., layout=(@layout [_ ° _; ° ° °; ° ° °]))
```

Required for https://github.com/JuliaPlots/Plots.jl/pull/3584.