### PR TITLE
GR: fix alignment of ticks labels when rotating

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -651,12 +651,17 @@ end
 
 function gr_set_tickfont(sp, letter)
     axis = sp[Symbol(letter, :axis)]
+
+    # invalidate alignment changes for small rotations (|θ| < 45°)
+    trigger(rot) = abs(sind(rot)) < abs(cosd(rot)) ? 0 : sign(rot)
+
+    rot = axis[:rotation]
     if letter === :x || (RecipesPipeline.is3d(sp) && letter === :y)
-        halign = (:left, :hcenter, :right)[sign(axis[:rotation]) + 2]
-        valign = (axis[:mirror] ? :bottom : :top)
+        halign = (:left, :hcenter, :right)[trigger(rot) + 2]
+        valign = (axis[:mirror] ? :bottom : :top, :vcenter)[trigger(abs(rot)) + 1]
     else
-        halign = (axis[:mirror] ? :left : :right)
-        valign = (:top, :vcenter, :bottom)[sign(axis[:rotation]) + 2]
+        halign = (axis[:mirror] ? :left : :right, :hcenter)[trigger(abs(rot)) + 1]
+        valign = (:top, :vcenter, :bottom)[trigger(rot) + 2]
     end
     gr_set_font(
         tickfont(axis),


### PR DESCRIPTION
Fixes https://github.com/JuliaPlots/Plots.jl/issues/3581.

Reproducer:
```julia
using Plots; gr()

for r in (0, 20, 70, 90)
    ttl = "bug-rot-xr=$r-yr=$r"
    @show ttl
    plot(xrotation=r, yrotation=r, dpi=100, minorticks=false, title=ttl)
    scatter!(rand(10), rand(10))
    png(ttl)
  end
```

Without PR
---------------
![out](https://user-images.githubusercontent.com/13423344/123655743-8f0d2d00-d82f-11eb-99a8-7edae7522f6c.png)

With PR
-----------
![out_PR](https://user-images.githubusercontent.com/13423344/123655726-89174c00-d82f-11eb-85e2-081e840cbe7d.png)


