### PR TITLE
GR: 3D, warn on invalid rotation or tilt

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1326,7 +1326,13 @@ function gr_draw_axes(sp, viewport_plotarea)
         # set space
         xmin, xmax, ymin, ymax = gr_xy_axislims(sp)
         zmin, zmax = gr_z_axislims(sp)
-        GR.setspace(zmin, zmax, round.(Int, sp[:camera])...)
+
+        camera = round.(Int, sp[:camera])
+
+        warn_invalid(val) = if val < 0 || val > 90 @warn "camera: $(val)° ∉ [0°, 90°]" end
+        warn_invalid.(camera)
+
+        GR.setspace(zmin, zmax, camera...)
 
         # fill the plot area
         gr_set_fill(plot_color(sp[:background_color_inside]))


### PR DESCRIPTION
Invalid rotation or tilt are currently silently ignored in GR, I believe the user should be warned.

This is a wontfix from `Plots.jl`'s side, users should open an issue or PR in https://github.com/sciapp/gr for supporting `θ < 0` or `θ > 90`.

See https://gr-framework.org/julia-gr.html#GR.setspace-0880646251e9db0f5d16f4369795d314:
> Angles of rotation and viewing angle must be specified between 0° and 90°.


Linked https://github.com/JuliaPlots/Plots.jl/issues/3541.
Fixes https://github.com/JuliaPlots/Plots.jl/issues/3445.
Fixes https://github.com/JuliaPlots/Plots.jl/issues/1911.
