### PR TITLE
GR: expose surface(...) display options, fix hardcoded constants

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1845,8 +1845,10 @@ function gr_draw_surface(series, x, y, z, clims)
     if series[:seriestype] === :surface
         fillalpha = get_fillalpha(series)
         fillcolor = get_fillcolor(series)
-        if length(x) == length(y) == length(z)
-            x, y, z = GR.gridit(x, y, z, 200, 200)
+        # NOTE: setting nx = 0 or ny = 0 disables GR.gridit interpolation
+        nx, ny = get(e_kwargs, :nx, 200), get(e_kwargs, :ny, 200)
+        if length(x) == length(y) == length(z) && nx > 0 && ny > 0
+            x, y, z = GR.gridit(x, y, z, nx, ny)
         end
         d_opt = get(e_kwargs, :display_option, GR.OPTION_COLORED_MESH)
         if (!isnothing(fillalpha) && fillalpha < 1) || alpha(first(fillcolor)) < 1

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1841,22 +1841,23 @@ function gr_draw_contour(series, x, y, z, clims)
 end
 
 function gr_draw_surface(series, x, y, z, clims)
-
+    e_kwargs = series[:extra_kwargs]
     if series[:seriestype] === :surface
         fillalpha = get_fillalpha(series)
         fillcolor = get_fillcolor(series)
         if length(x) == length(y) == length(z)
             x, y, z = GR.gridit(x, y, z, 200, 200)
         end
+        d_opt = get(e_kwargs, :display_option, GR.OPTION_COLORED_MESH)
         if (!isnothing(fillalpha) && fillalpha < 1) || alpha(first(fillcolor)) < 1
             gr_set_transparency(fillcolor, fillalpha)
-            GR.surface(x, y, z, GR.OPTION_COLORED_MESH)
+            GR.surface(x, y, z, d_opt)
         else
-            GR.gr3.surface(x, y, z, GR.OPTION_COLORED_MESH)
+            GR.gr3.surface(x, y, z, d_opt)
         end
-    else # wireframe
+    else  # wireframe
         GR.setfillcolorind(0)
-        GR.surface(x, y, z, GR.OPTION_FILLED_MESH)
+        GR.surface(x, y, z, get(e_kwargs, :display_option, GR.OPTION_FILLED_MESH))
     end
 end
 


### PR DESCRIPTION
This PR add:
1. Expose the options described in [GR surface's table](https://gr-framework.org/julia-gr.html#GR.surface-e3e6f234cc6cd4713b8727c874a5f331);
2. Add the possibility to override hardcoded `nx` and `ny` when re-griding.

NOTES:
- name used: `:display_option` is arbitrary, maybe there is a better naming ?
- using `series[:extra_kwargs]` seems appropriate since this is specific to the GR backend
- should we document this or not ?

mwe
------
```julia
using Plots; gr()
import GR

main() = begin
  meshgrid(x, y) = (ones(eltype(y), length(y)) * x', y * ones(eltype(x), length(x))')

  x, y = meshgrid(-2:.25:2, -2:.25:2)
  f = x .* exp.(-x.^2 - y.^2)

  surface(x[:], y[:], f[:], display_option=GR.OPTION_SHADED_MESH, nx=50, ny=50, legend=:none, c=:viridis)
  return
end

main()
```

without PR
--------------
![pr2_ex-WITHOUT](https://user-images.githubusercontent.com/13423344/124129966-9413eb80-da7e-11eb-876f-ed3fff65df3f.png)

with PR
----------
![pr2_ex-WITH](https://user-images.githubusercontent.com/13423344/124141913-15bd4680-da8a-11eb-99d7-cbbcc395f19a.png)


