### PR TITLE
Proposed fix for Latex sub/super-scripts in legends

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1162,25 +1162,25 @@ function gr_legend_pos(theta::Real, leg, viewport_plotarea; axisclearance=nothin
 end
 
 function gr_get_legend_geometry(viewport_plotarea, sp)
-    legendn = 0
-    legendw = 0
+    legendn = legendw = 0; dy = 0.
     if sp[:legend] != :none
         GR.savestate()
         GR.selntran(0)
         GR.setscale(0)
         if sp[:legendtitle] !== nothing
             gr_set_font(legendtitlefont(sp), sp)
+            legendn += 1
             tbx, tby = gr_inqtext(0, 0, string(sp[:legendtitle]))
             legendw = tbx[3] - tbx[1]
-            legendn += 1
+            dy = tby[3] - tby[1]
         end
         gr_set_font(legendfont(sp), sp)
         for series in series_list(sp)
             should_add_to_legend(series) || continue
             legendn += 1
-            lab = series[:label]
-            tbx, tby = gr_inqtext(0, 0, string(lab))
+            tbx, tby = gr_inqtext(0, 0, string(series[:label]))
             legendw = max(legendw, tbx[3] - tbx[1]) # Holds text width right now
+            dy = max(dy, tby[3] - tby[1])
         end
 
         GR.setscale(1)
@@ -1197,7 +1197,6 @@ function gr_get_legend_geometry(viewport_plotarea, sp)
     x_legend_offset = (viewport_plotarea[2] - viewport_plotarea[1]) / 30
     y_legend_offset = (viewport_plotarea[4] - viewport_plotarea[3]) / 30
 
-    dy = gr_point_mult(sp) * sp[:legendfontsize] * 1.75
     legendh = dy * legendn
 
     return (

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1162,7 +1162,7 @@ function gr_legend_pos(theta::Real, leg, viewport_plotarea; axisclearance=nothin
 end
 
 function gr_get_legend_geometry(viewport_plotarea, sp)
-    legendn = legendw = 0; dy = 0.
+    legendn = legendw = dy = 0
     if sp[:legend] != :none
         GR.savestate()
         GR.selntran(0)
@@ -1196,6 +1196,8 @@ function gr_get_legend_geometry(viewport_plotarea, sp)
 
     x_legend_offset = (viewport_plotarea[2] - viewport_plotarea[1]) / 30
     y_legend_offset = (viewport_plotarea[4] - viewport_plotarea[3]) / 30
+
+    dy *= get(sp[:extra_kwargs], :legend_hfactor, 1)
 
     legendh = dy * legendn
 


### PR DESCRIPTION
Fixes https://github.com/JuliaPlots/Plots.jl/issues/3558:
1. Fix height computation by retaining the maximum legend height, for each serie;
2. Allow changing the height factor via the `extra_kwargs` mecanism.

Discussion:
Change [1.] does modify some reference images, but I think the fix is justified. Only applying [2.] allows fixing the OP issue, without changing the default legend sizes.

MWE
-------
```julia
using LaTeXStrings
using Random; Random.seed!(1234)
using Plots; gr()

main() = begin
  y1, y2 = rand(100), rand(100)
  histogram(y1, ylims=(0, 50), label=L"\left\Vert\beta_{1}^{2}-\beta_{2}^{2}\right\Vert", extra_kwargs=Dict(:subplot=>Dict(:legend_hfactor=>1.25)))
  histogram!(y2, label=L"\left\Vert\beta_{2}^{2}-\beta_{3}^{2}\right\Vert", legendfontsize=10)
  png("foo")
end

main()
```

With PR
-----------
Without using `extra_kwargs`:
![pr3](https://user-images.githubusercontent.com/13423344/124314923-6bb9e900-db73-11eb-9946-d8d51a8e7589.png)

Using `:legend_hfactor=>1.25`:
![pr3](https://user-images.githubusercontent.com/13423344/124320388-1d5d1800-db7c-11eb-8fc1-512d7d5fe1c4.png)

Without PR
---------------
![pr3](https://user-images.githubusercontent.com/13423344/124320599-76c54700-db7c-11eb-873d-ecf3ac7e5b0c.png)

Default behavior modification (example # 23)
==================================

With PR
-----------
![ref23](https://user-images.githubusercontent.com/13423344/124324552-71b7c600-db83-11eb-92e3-d232b34cf221.png)

Without PR
---------------
![ref23_old](https://user-images.githubusercontent.com/13423344/124326206-60bc8400-db86-11eb-8e1c-0d06e4944b8d.png)
