### PR TITLE
Proposed fix for Latex sub/super-scripts in legends

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1162,25 +1162,25 @@ function gr_legend_pos(theta::Real, leg, viewport_plotarea; axisclearance=nothin
 end
 
 function gr_get_legend_geometry(viewport_plotarea, sp)
-    legendn = 0
-    legendw = 0
+    legendn = legendw = 0; dy = 0.
     if sp[:legend] != :none
         GR.savestate()
         GR.selntran(0)
         GR.setscale(0)
         if sp[:legendtitle] !== nothing
             gr_set_font(legendtitlefont(sp), sp)
+            legendn += 1
             tbx, tby = gr_inqtext(0, 0, string(sp[:legendtitle]))
             legendw = tbx[3] - tbx[1]
-            legendn += 1
+            dy = tby[3] - tby[1]
         end
         gr_set_font(legendfont(sp), sp)
         for series in series_list(sp)
             should_add_to_legend(series) || continue
             legendn += 1
-            lab = series[:label]
-            tbx, tby = gr_inqtext(0, 0, string(lab))
+            tbx, tby = gr_inqtext(0, 0, string(series[:label]))
             legendw = max(legendw, tbx[3] - tbx[1]) # Holds text width right now
+            dy = max(dy, tby[3] - tby[1])
         end
 
         GR.setscale(1)
@@ -1197,7 +1197,6 @@ function gr_get_legend_geometry(viewport_plotarea, sp)
     x_legend_offset = (viewport_plotarea[2] - viewport_plotarea[1]) / 30
     y_legend_offset = (viewport_plotarea[4] - viewport_plotarea[3]) / 30
 
-    dy = gr_point_mult(sp) * sp[:legendfontsize] * 1.75
     legendh = dy * legendn
 
     return (


### PR DESCRIPTION
Fixes https://github.com/JuliaPlots/Plots.jl/issues/3558.

Retain the maximum legend height, for each serie.

EDIT: breaks, ref13, ref18, I will re-generate them asap.

MWE
-------
```julia
using LaTeXStrings
using Plots; gr()

main() = begin
  y1, y2 = rand(100), rand(100)
  histogram(y1, ylims = (0,50), label = L"\left\Vert\beta_{1}^{2}-\beta_{2}^{2}\right\Vert")
  histogram!(y2, label = L"\left\Vert\beta_{2}^{2}-\beta_{3}^{2}\right\Vert", legendfontsize=10)
  png("foo")
end

main()
```

With PR
-----------
![pr3](https://user-images.githubusercontent.com/13423344/124314923-6bb9e900-db73-11eb-9946-d8d51a8e7589.png)

Without PR
---------------
![pr3_ex-without](https://user-images.githubusercontent.com/13423344/124288620-b0348d00-db51-11eb-9de5-7436cacd7879.png)