### PR TITLE
Warn on invalid value for log scale based series

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -355,9 +355,9 @@ end
 
 # draw ONE symbol marker
 function gr_draw_marker(series, xi, yi, clims, i, msize, strokewidth, shape::Symbol)
-    GR.setborderwidth(strokewidth);
-    gr_set_bordercolor(get_markerstrokecolor(series, i));
-    gr_set_markercolor(get_markercolor(series, clims, i));
+    GR.setborderwidth(strokewidth)
+    gr_set_bordercolor(get_markerstrokecolor(series, i))
+    gr_set_markercolor(get_markercolor(series, clims, i))
     gr_set_transparency(get_markeralpha(series, i))
     GR.setmarkertype(gr_markertype(shape))
     GR.setmarkersize(0.3msize / gr_nominal_size(series))
@@ -1717,7 +1717,7 @@ end
 function gr_draw_segments(series, x, y, fillrange, clims)
     st = series[:seriestype]
     if x !== nothing && length(x) > 1
-        segments = series_segments(series, st)
+        segments = series_segments(series, st; check=true)
         # do area fill
         if fillrange !== nothing
             GR.setfillintstyle(GR.INTSTYLE_SOLID)
@@ -1754,7 +1754,7 @@ end
 function gr_draw_segments_3d(series, x, y, z, clims)
     if series[:seriestype] === :path3d && length(x) > 1
         lz = series[:line_z]
-        segments = series_segments(series, :path3d)
+        segments = series_segments(series, :path3d; check=true)
         for segment in segments
             i, rng = segment.attr_index, segment.range
             lc = get_linecolor(series, clims, i)

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -327,7 +327,7 @@ end
 
 function pgfx_add_series!(::Val{:path}, axis, series_opt, series, series_func, opt)
     # treat segments
-    segments = collect(series_segments(series, series[:seriestype]))
+    segments = collect(series_segments(series, series[:seriestype]; check=true))
     sf = opt[:fillrange]
     for (k, segment) in enumerate(segments)
         i, rng = segment.attr_index, segment.range

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -663,7 +663,7 @@ function plotly_series(plt::Plot, series::Series)
 end
 
 function plotly_series_shapes(plt::Plot, series::Series, clims)
-    segments = series_segments(series)
+    segments = series_segments(series; check=true)
     plotattributes_outs = Vector{KW}(undef, length(segments))
 
     # TODO: create a plotattributes_out for each polygon

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -442,7 +442,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             #     end
             #     push!(handles, handle)
             # else
-            for (k, segment) in enumerate(series_segments(series, st))
+            for (k, segment) in enumerate(series_segments(series, st; check=true))
                 i, rng = segment.attr_index, segment.range
                 handle = ax."plot"((arg[rng] for arg in xyargs)...;
                                    label = k == 1 ? series[:label] : "",

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -75,22 +75,23 @@ function iter_segments(args...)
     NaNSegmentsIterator(tup, n1, n2)
 end
 
-function series_segments(series::Series, seriestype::Symbol = :path)
+function series_segments(series::Series, seriestype::Symbol=:path; check=false)
     x, y, z = series[:x], series[:y], series[:z]
     (x === nothing || isempty(x)) && return UnitRange{Int}[]
 
     args = RecipesPipeline.is3d(series) ? (x, y, z) : (x, y)
     nan_segments = collect(iter_segments(args...))
 
-    scales = :xscale, :yscale, :zscale
-    for (n, s) ∈ enumerate(args)
-        scale = get(series, scales[n], :identity)
-        if scale ∈ _logScales
-            for (i, v) ∈ enumerate(s)
-                if v <= 0
-                    msg = "Invalid negative or zero value $v found at serie index $i for $(scale) based $(scales[n])"
-                    @warn msg
-                    @debug msg exception=(DomainError(v), stacktrace())
+    if check
+        scales = :xscale, :yscale, :zscale
+        for (n, s) ∈ enumerate(args)
+            scale = get(series, scales[n], :identity)
+            if scale ∈ _logScales
+                for (i, v) ∈ enumerate(s)
+                    if v <= 0
+                        @warn "Invalid negative or zero value $v found at series index $i for $(scale) based $(scales[n])"
+                        @debug "" exception=(DomainError(v), stacktrace())
+                    end
                 end
             end
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -82,6 +82,20 @@ function series_segments(series::Series, seriestype::Symbol = :path)
     args = RecipesPipeline.is3d(series) ? (x, y, z) : (x, y)
     nan_segments = collect(iter_segments(args...))
 
+    scales = :xscale, :yscale, :zscale
+    for (n, s) ∈ enumerate(args)
+        scale = get(series, scales[n], :identity)
+        if scale ∈ _logScales
+            for (i, v) ∈ enumerate(s)
+                if v <= 0
+                    msg = "Invalid negative or zero value $v found at serie index $i for $(scale) based $(scales[n])"
+                    @warn msg
+                    @debug msg exception=(DomainError(v), stacktrace())
+                end
+            end
+        end
+    end
+
     segments = if has_attribute_segments(series)
         Iterators.flatten(map(nan_segments) do r
             if seriestype in (:scatter, :scatter3d)


### PR DESCRIPTION
With this PR, the example in https://github.com/JuliaPlots/Plots.jl/issues/3594 now shows a warning or a full stacktrace controlled via the `JULIA_DEBUG` environment variable.

@mortenpi, is this what you expect ?

~~If someone has a tip for logging the messages only once, I'm all ears ...~~
==> now warning only once
~~Not sure about the potential performance penalty traversing series though.~~
==> now traversing only once

Fix https://github.com/JuliaPlots/Plots.jl/issues/3594.

```julia
$ julia bug.jl
┌ Warning: Invalid negative or zero value 0.0 found at series index 3 for log10 based yscale
└ @ Plots [...]/Plots/Bfn5f/src/utils.jl:92

$ JULIA_DEBUG=Plots julia bug.jl
┌ Warning: Invalid negative or zero value 0.0 found at series index 3 for log10 based yscale
└ @ Plots [...]/Bfn5f/src/utils.jl:92
┌ Debug: 
│   exception =
│    DomainError with 0.0:
│    
│    Stacktrace:
│      [1] macro expansion
│        @ ./logging.jl:341 [inlined]
│      [2] series_segments(series::Plots.Series, seriestype::Symbol; check::Bool)
│        @ Plots [...]/Bfn5f/src/utils.jl:93
│      [3] pgfx_add_series!(#unused#::Val{:path}, axis::PGFPlotsX.Axis, series_opt::PGFPlotsX.Options, series::Plots.Series, series_func::Type{PGFPlotsX.Plot}, opt::RecipesPipeline.DefaultsDict)
│        @ Plots [...]/Bfn5f/src/backends/pgfplotsx.jl:334
│      [4] (::Plots.PGFPlotsXPlot)(plt::Plots.Plot{Plots.PGFPlotsXBackend})
│        @ Plots [...]/Bfn5f/src/backends/pgfplotsx.jl:287
│      [5] _update_plot_object(plt::Plots.Plot{Plots.PGFPlotsXBackend})
│        @ Plots [...]/Bfn5f/src/backends/pgfplotsx.jl:1415
│      [6] prepare_output(plt::Plots.Plot{Plots.PGFPlotsXBackend})
│        @ Plots [...]/Bfn5f/src/plot.jl:245
│      [7] show
│        @ [...]/Bfn5f/src/output.jl:214 [inlined]
│      [8] png(plt::Plots.Plot{Plots.PGFPlotsXBackend}, fn::String)
│        @ Plots [...]/Bfn5f/src/output.jl:7
│      [9] png(fn::String)
│        @ Plots [...]/Bfn5f/src/output.jl:10
│     [10] main(i::Int64)
│        @ Main [...]/bug.jl:10
│     [11] top-level scope
│        @ [...]/bug.jl:16
│     [12] include(mod::Module, _path::String)
│        @ Base ./Base.jl:386
│     [13] exec_options(opts::Base.JLOptions)
│        @ Base ./client.jl:285
│     [14] _start()
│        @ Base ./client.jl:485
└ @ Plots [...]/Bfn5f/src/utils.jl:93
```