### PR TITLE
Revert fix for failing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run Graphical test
         run:  |
           $TESTCMD --project -e 'using Pkg; Pkg.test(coverage=true);'
-          # $TESTCMD -e 'using Pkg; Pkg.activate(tempdir()); Pkg.develop(path=abspath(".")); Pkg.add("StatsPlots"); Pkg.test("StatsPlots");'
+          $TESTCMD -e 'using Pkg; Pkg.activate(tempdir()); Pkg.develop(path=abspath(".")); Pkg.add("StatsPlots"); Pkg.test("StatsPlots");'
           $TESTCMD -e 'using Pkg; Pkg.activate(tempdir()); Pkg.develop(path=abspath(".")); Pkg.add("GraphRecipes"); Pkg.test("GraphRecipes");'
 
       - name: Codecov

--- a/Project.toml
+++ b/Project.toml
@@ -51,7 +51,6 @@ Requires = "1"
 Scratch = "1"
 Showoff = "0.3.1, 1.0"
 StatsBase = "0.32, 0.33"
-Distributions = "< 0.25.7, ≥ 0.25.9"
 julia = "1.5"
 
 [extras]


### PR DESCRIPTION
Merge this PR when:
- [x] https://github.com/JuliaPlots/StatsPlots.jl/pull/454 is merged;
- [x] New release of https://github.com/JuliaPlots/StatsPlots.jl;
- [x] CI is clear of errors.

EDIT: Those are in fact not needed:
1. https://github.com/JuliaStats/Distributions.jl/pull/1359 is merged;
2. New release of https://github.com/JuliaStats/Distributions.jl;

Fix https://github.com/JuliaStats/Distributions.jl/issues/1358.