### PR TITLE
GR: add support for mesh3d

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -352,6 +352,7 @@ const _gr_seriestype = [
     :scatter3d,
     :surface,
     :wireframe,
+    :mesh3d,
     :volume,
     :shape,
 ]

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -524,7 +524,7 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, clims, viewport_plotare
         levels = _cbar_unique(contour_levels.(series, Ref(clims)), "levels")
         # GR implicitly uses the maximal z value as the highest level
         if levels[end] < clims[2]
-            @warn("GR: highest contour level less than maximal z value is not supported.")
+            @warn "GR: highest contour level less than maximal z value is not supported."
             # replace levels, rather than assign to levels[end], to ensure type
             # promotion in case levels is an integer array
             levels = [levels[1:end-1]; clims[2]]
@@ -1832,7 +1832,7 @@ function gr_draw_contour(series, x, y, z, clims)
     h = gr_contour_levels(series, clims)
     if series[:fillrange] !== nothing
         if series[:fillcolor] != series[:linecolor] && !is_lc_black
-            @warn("GR: filled contour only supported with black contour lines")
+            @warn "GR: filled contour only supported with black contour lines"
         end
         GR.contourf(x, y, h, z, series[:contour_labels] == true ? 1 : 0)
     else
@@ -1863,6 +1863,7 @@ function gr_draw_surface(series, x, y, z, clims)
         GR.setfillcolorind(0)
         GR.surface(x, y, z, get(e_kwargs, :display_option, GR.OPTION_FILLED_MESH))
     elseif st === :mesh3d
+        @warn "GR: mesh3d is experimental (no face colors)"
         conn = series[:connections]
         if typeof(conn) <: Tuple{Array, Array, Array}
             ci, cj, ck = conn
@@ -1872,25 +1873,25 @@ function gr_draw_surface(series, x, y, z, clims)
         else
             throw(ArgumentError("Argument connections has to be a tuple of three arrays."))
         end
-        xx = zeros(eltype(x), 4length(ci))
-        yy = zeros(eltype(y), 4length(cj))
-        zz = zeros(eltype(z), 4length(ck))
+        X = zeros(eltype(x), 4length(ci))
+        Y = zeros(eltype(y), 4length(cj))
+        Z = zeros(eltype(z), 4length(ck))
         @inbounds for I ∈ 1:length(ci)
             i = ci[I] + 1  # connections are 0-based
             j = cj[I] + 1
             k = ck[I] + 1
             m = 4(I - 1) + 1; n = m + 1; o = m + 2; p = m + 3
-            xx[m] = xx[p] = x[i]
-            yy[m] = yy[p] = y[i]
-            zz[m] = zz[p] = z[i]
-            xx[n] = x[j]
-            yy[n] = y[j]
-            zz[n] = z[j]
-            xx[o] = x[k]
-            yy[o] = y[k]
-            zz[o] = z[k]
+            X[m] = X[p] = x[i]
+            Y[m] = Y[p] = y[i]
+            Z[m] = Z[p] = z[i]
+            X[n] = x[j]
+            Y[n] = y[j]
+            Z[n] = z[j]
+            X[o] = x[k]
+            Y[o] = y[k]
+            Z[o] = z[k]
         end
-        GR.polyline3d(xx, yy, zz)
+        GR.polyline3d(X, Y, Z)
     else
         throw(ArgumentError("Not handled !"))    
     end

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1214,7 +1214,7 @@ const _examples = PlotExample[
 # Some constants for PlotDocs and PlotReferenceImages
 _animation_examples = [2, 31]
 _backend_skips = Dict(
-    :gr => [25, 30, 47],
+    :gr => [25, 30],
     :pyplot => [2, 25, 30, 31, 47, 49, 55],
     :plotlyjs => [2, 21, 24, 25, 30, 31, 49, 51, 55],
     :plotly => [2, 21, 24, 25, 30, 31, 49, 50, 51, 55],

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -998,33 +998,37 @@ const _examples = PlotExample[
         end]
     ),
     PlotExample( # 47
-	"Mesh3d",
-	"""
-	Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically.
-	You can also specify the connections using the connections keyword.
-    The connections are specified using a tuple of vectors. Each vector contains the 0-based indices of one point of a triangle,
-	such that elements at the same position of these vectors form a triangle.
-	""",
-	[
-		:(
-		  begin
-			# specify the vertices
-			x=[0, 1, 2, 0]
-			y=[0, 0, 1, 2]
-			z=[0, 2, 0, 1]
+        "Mesh3d",
+        """
+        Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically.
+        You can also specify the connections using the connections keyword.
+        The connections are specified using a tuple of vectors. Each vector contains the 0-based indices of one point of a triangle,
+        such that elements at the same position of these vectors form a triangle.
+        """,
+        [
+            :(
+                begin
+                    # specify the vertices
+                    x=[0, 1, 2, 0]
+                    y=[0, 0, 1, 2]
+                    z=[0, 2, 0, 1]
 
-			# specify the triangles
-			# every column is one triangle,
-			# where the values denote the indices of the vertices of the triangle
-			i=[0, 0, 0, 1]
-			j=[1, 2, 3, 2]
-			k=[2, 3, 1, 3]
+                    # specify the triangles
+                    # every column is one triangle,
+                    # where the values denote the indices of the vertices of the triangle
+                    i=[0, 0, 0, 1]
+                    j=[1, 2, 3, 2]
+                    k=[2, 3, 1, 3]
 
-			# the four triangles gives above give a tetrahedron
-			mesh3d(x,y,z;connections=(i,j,k))
-		  end
-		),
-	],
+                    # the four triangles gives above give a tetrahedron
+                    mesh3d(
+                        x, y, z; connections=(i, j, k),
+                        title="triangles", xlabel="x", ylabel="y", zlabel="z",
+                        legend=:none, margin=2Plots.mm
+                    )
+                end
+            ),
+        ],
     ),
     PlotExample( # 48
         "Vectors of markershapes and segments",


### PR DESCRIPTION
Add GR support for mesh3d since, for now, [GR](https://github.com/sciapp/gr) does not support drawing arbitrary points using a triangle connectivity array.
The error check code was copied from the `pgfplotsx` backend: https://github.com/JuliaPlots/Plots.jl/blob/master/src/backends/pgfplotsx.jl 

The test for this case already exists [here](https://github.com/JuliaPlots/Plots.jl/blob/ef93aa87be11f30837c87089d9f8e5c1f73c1baf/src/examples.jl#L1001) as example `47`, and is run e.g. for `pgfplotsx`: https://docs.juliaplots.org/latest/generated/pgfplotsx/#pgfplotsx-ref47.

Needs https://github.com/JuliaPlots/RecipesPipeline.jl/pull/90 patch.

Output of example 47
----------------------------
![ref47](https://user-images.githubusercontent.com/13423344/124903770-94633800-dfe4-11eb-91eb-25f5123599f9.png)


- [x] generate `ref47.png` for GR 
https://github.com/JuliaPlots/PlotReferenceImages.jl/pull/101

Linked https://github.com/JuliaPlots/Plots.jl/issues/392