### PR TITLE
Don't propagate widening axis limits for pipeline recipes

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -141,7 +141,7 @@ function _add_smooth_kw(kw_list::Vector{KW}, kw::AKW)
 end
 
 
-RecipesPipeline.get_axis_limits(plt::Plot, letter) = axis_limits(plt[1], letter)
+RecipesPipeline.get_axis_limits(plt::Plot, letter) = axis_limits(plt[1], letter, false)
 
 
 ## Plot recipes

--- a/test/test_pipeline.jl
+++ b/test/test_pipeline.jl
@@ -8,3 +8,11 @@ using Plots, Test
     plot!(pl, tex_output_standalone = true)
     @test pl[:tex_output_standalone] == true
 end
+
+@testset "get_axis_limits" begin
+    x = [.1, 5]
+    p1 = plot(x, [5, .1], yscale=:log10)
+    p2 = plot!(identity)
+    @test all(RecipesPipeline.get_axis_limits(p1, :x) .== x)
+    @test all(RecipesPipeline.get_axis_limits(p2, :x) .== x)
+end

--- a/test/test_pipeline.jl
+++ b/test/test_pipeline.jl
@@ -1,4 +1,5 @@
 using Plots, Test
+using RecipesPipeline
 
 @testset "plot" begin
     pl = plot(1:5)


### PR DESCRIPTION
The bug described in #3451 is triggered by https://github.com/JuliaPlots/RecipesPipeline.jl/blob/d11dcb642340c4bbe4068130d09597b54c079bcd/src/user_recipe.jl#L249.

Applying a function without `x` values should only be applied on the initial `x` data, not on the widened axis data (causing log to fails with `NaNs` on negative values).

Fix #3451.

Mwe
------
```julia
using Plots; gr()

main() = begin
  plot([.1, 5], [5, .1], yscale=:log10)
  plot!(identity)
  png("bug")
end

main()
```

Output
---------
![grault](https://user-images.githubusercontent.com/13423344/124515554-0ae31880-dde0-11eb-8a71-8ef4d3d79bc5.png)

