### PR TITLE
Add :margins as an alias for :margin

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -577,7 +577,8 @@ end
 
 
 # margin
-add_aliases(:left_margin , :leftmargin )
+add_aliases(:margins)
+add_aliases(:left_margin , :leftmargin)
 add_aliases(:top_margin , :topmargin)
 add_aliases(:bottom_margin , :bottommargin)
 add_aliases(:right_margin ,:rightmargin)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -751,10 +751,10 @@ function _update_min_padding!(sp::Subplot{GRBackend})
         end
     end
     # Add margin given by the user
-    leftpad   = 2mm  + sp[:left_margin]
-    toppad    = 2mm  + sp[:top_margin]
-    rightpad  = 2mm  + sp[:right_margin]
-    bottompad = 2mm  + sp[:bottom_margin]
+    leftpad   = 2mm + sp[:left_margin]
+    toppad    = 2mm + sp[:top_margin]
+    rightpad  = 2mm + sp[:right_margin]
+    bottompad = 2mm + sp[:bottom_margin]
     # Add margin for title
     if sp[:title] != ""
         gr_set_font(titlefont(sp), sp)


### PR DESCRIPTION
I find (and it's subjective) that writing `margins=...` in a plot is more intuitive than `margin=...`, so an alias might be handy here.

What do you think ?