### PR TITLE
Fix computing marker coordinates with log scales

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -326,13 +326,15 @@ end
 # draw ONE Shape
 function gr_draw_marker(series, xi, yi, clims, i, msize, strokewidth, shape::Shape)
     sx, sy = coords(shape)
-    # convert to ndc coords (percentages of window)
-    GR.selntran(0)
+    # convert to ndc coords (percentages of window) ...
     w, h = get_size(series)
     f = msize / (w + h)
+
     xi, yi = GR.wctondc(xi, yi)
-    xs = xi .+ sx .* f
-    ys = yi .+ sy .* f
+
+    # ... convert back to world coordinates
+    xs_ys = GR.ndctowc.(xi .+ sx .* f, yi .+ sy .* f)
+    xs, ys = getindex.(xs_ys, 1), getindex.(xs_ys, 2)
 
     # draw the interior
     mc = get_markercolor(series, clims, i)
@@ -345,7 +347,6 @@ function gr_draw_marker(series, xi, yi, clims, i, msize, strokewidth, shape::Sha
     gr_set_line(strokewidth, :solid, msc, series)
     gr_set_transparency(msc, get_markerstrokealpha(series, i))
     GR.polyline(xs, ys)
-    GR.selntran(1)
 end
 
 function gr_nominal_size(s)


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/3640

Output:
![test](https://user-images.githubusercontent.com/13423344/125771051-39518c2e-a1c2-4569-bb1b-0d48d578a48c.png)
