### PR TITLE
Take series alpha into account when drawing contours

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1832,6 +1832,7 @@ end
 function gr_draw_contour(series, x, y, z, clims)
     GR.setspace(clims[1], clims[2], 0, 90)
     gr_set_line(get_linewidth(series), get_linestyle(series), get_linecolor(series), series)
+    gr_set_transparency(get_fillalpha(series))
     is_lc_black = let black=plot_color(:black)
         plot_color(series[:linecolor]) in (black,[black])
     end


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/3589:

![ct](https://user-images.githubusercontent.com/13423344/126157141-9cc9bdd0-a0ac-4717-be0a-fe1e1c63848f.png)
