### PR TITLE
Make tickmarks the same length for both axes in GR 2D plots

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -731,10 +731,6 @@ function axis_drawing_info(sp, letter)
             f = RecipesPipeline.scale_func(oax[:scale])
             invf = RecipesPipeline.inverse_scale_func(oax[:scale])
 
-            w = width(sp.plotarea).value
-            h = height(sp.plotarea).value
-            tick_factor = (letter === :x ? w : h) / min(w, h)
-
             add_major_or_minor_segments(ticks, grid, segments, factor, cond) = begin
                 ticks === nothing && return
                 if cond
@@ -766,12 +762,14 @@ function axis_drawing_info(sp, letter)
                 end
             end
 
+            ax_length = letter === :x ? height(sp.plotarea).value : width(sp.plotarea).value
+
             # add major grid segments
-            add_major_or_minor_segments(ticks[1], ax[:grid], grid_segments, 0.012 * tick_factor, ax[:tick_direction] !== :none)
+            add_major_or_minor_segments(ticks[1], ax[:grid], grid_segments, 1.6 / ax_length, ax[:tick_direction] !== :none)
 
             # add minor grid segments
             if ax[:minorticks] ∉ (:none, nothing, false) || ax[:minorgrid]
-                add_major_or_minor_segments(minor_ticks, ax[:minorgrid], minorgrid_segments, 0.006 * tick_factor, true)
+                add_major_or_minor_segments(minor_ticks, ax[:minorgrid], minorgrid_segments, 1 / ax_length, true)
             end
         end
     end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -731,6 +731,10 @@ function axis_drawing_info(sp, letter)
             f = RecipesPipeline.scale_func(oax[:scale])
             invf = RecipesPipeline.inverse_scale_func(oax[:scale])
 
+            w = width(sp.plotarea).value
+            h = height(sp.plotarea).value
+            tick_factor = (letter === :x ? w : h) / min(w, h)
+
             add_major_or_minor_segments(ticks, grid, segments, factor, cond) = begin
                 ticks === nothing && return
                 if cond
@@ -763,11 +767,11 @@ function axis_drawing_info(sp, letter)
             end
 
             # add major grid segments
-            add_major_or_minor_segments(ticks[1], ax[:grid], grid_segments, 0.012, ax[:tick_direction] !== :none)
+            add_major_or_minor_segments(ticks[1], ax[:grid], grid_segments, 0.012 * tick_factor, ax[:tick_direction] !== :none)
 
             # add minor grid segments
             if ax[:minorticks] ∉ (:none, nothing, false) || ax[:minorgrid]
-                add_major_or_minor_segments(minor_ticks, ax[:minorgrid], minorgrid_segments, 0.006, true)
+                add_major_or_minor_segments(minor_ticks, ax[:minorgrid], minorgrid_segments, 0.06 * tick_factor, true)
             end
         end
     end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -771,7 +771,7 @@ function axis_drawing_info(sp, letter)
 
             # add minor grid segments
             if ax[:minorticks] ∉ (:none, nothing, false) || ax[:minorgrid]
-                add_major_or_minor_segments(minor_ticks, ax[:minorgrid], minorgrid_segments, 0.06 * tick_factor, true)
+                add_major_or_minor_segments(minor_ticks, ax[:minorgrid], minorgrid_segments, 0.006 * tick_factor, true)
             end
         end
     end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -765,11 +765,11 @@ function axis_drawing_info(sp, letter)
             ax_length = letter === :x ? height(sp.plotarea).value : width(sp.plotarea).value
 
             # add major grid segments
-            add_major_or_minor_segments(ticks[1], ax[:grid], grid_segments, 1.6 / ax_length, ax[:tick_direction] !== :none)
+            add_major_or_minor_segments(ticks[1], ax[:grid], grid_segments, 1.2 / ax_length, ax[:tick_direction] !== :none)
 
             # add minor grid segments
             if ax[:minorticks] ∉ (:none, nothing, false) || ax[:minorgrid]
-                add_major_or_minor_segments(minor_ticks, ax[:minorgrid], minorgrid_segments, 1 / ax_length, true)
+                add_major_or_minor_segments(minor_ticks, ax[:minorgrid], minorgrid_segments, 0.6 / ax_length, true)
             end
         end
     end


### PR DESCRIPTION
Avoid too short ticks for one axis in very wide or narrow plots. This changes
```
plot(rand(10), size=(200, 400))
```
from
![portrait_old](https://user-images.githubusercontent.com/16589944/126556722-b03fcd40-943e-443c-87b7-8395a0c3a50c.png)

to
![portrait_new](https://user-images.githubusercontent.com/16589944/126556752-06249baa-6ac5-4f28-b7fd-3edd01de7575.png)

and
```julia
plot(rand(10), size=(600, 100))
```
from
![wide_old](https://user-images.githubusercontent.com/16589944/126556840-da48190e-da82-4e1e-aa93-92cb80a529df.png)

to
![wide_new](https://user-images.githubusercontent.com/16589944/126556863-86569b0d-a149-4856-af9f-48c7bcd0a7fe.png)
