### PR TITLE
More strict on tolerance - drop tol for obsolete version

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,12 +70,7 @@ include("imgcomp.jl")
 Random.seed!(PLOTS_SEED)
 default(show=false, reuse=true)
 is_ci() = get(ENV, "CI", "false") == "true"
-const PLOTS_IMG_TOL = parse(
-    Float64, get(
-        ENV, "PLOTS_IMG_TOL",
-        VERSION < v"1.4" && Sys.iswindows() ? "1e-1" : is_ci() ? "1e-2" : "1e-3"
-    )
-)
+const PLOTS_IMG_TOL = parse(Float64, get(ENV, "PLOTS_IMG_TOL", is_ci() ? "1e-4" : "1e-5"))
 
 ## Uncomment the following lines to update reference images for different backends
 


### PR DESCRIPTION
We should be more strict on tolerance for images comparisons. If reference images are to be changed, then be it, but we should be able to detect minor changes in the CI.