### PR TITLE
Add new gnuplot capabilities (surface, contour, contour3d, scatter3d, wireframe, heatmap, ...)

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -623,44 +623,55 @@ const _gaston_attr = merge_with_base_supported([
     # :camera,
     # :contour_labels,
   ])
-const _gaston_seriestype = [:path,
-                            # :path3d,
-                            :scatter,
-                            :steppre,
-                            # :stepmid,
-                            :steppost,
-                            # :histogram2d,
-                            # :ysticks, :xsticks,
-                            # :contour,
-                            :shape,
-                            # :straightline,
-                            ]
 
-const _gaston_style = [:auto,
-                       :solid,
-                       :dash,
-                       :dot,
-                       :dashdot,
-                       :dashdotdot
-                       ]
+const _gaston_seriestype = [
+    :path,
+    :path3d,
+    :scatter,
+    :steppre,
+    :stepmid,
+    :steppost,
+    :histogram2d,
+    :ysticks, :xsticks,
+    :contour,
+    :shape,
+    :straightline,
+    :scatter3d,
+    :contour3d,
+    :wireframe,
+    :heatmap,
+    :surface,
+    :mesh3d,
+]
 
-const _gaston_marker = [:none,
-                        # :auto,
-                        :circle,
-                        :rect,
-                        :diamond,
-                        :utriangle,
-                        :dtriangle,
-                        :pentagon,
-                        :x,
-                        :+
-                        ] #vcat(_allMarkers, Shape)
+const _gaston_style = [
+    :auto,
+   :solid,
+   :dash,
+   :dot,
+   :dashdot,
+   :dashdotdot
+]
 
-const _gaston_scale = [:identity,
-                       # :ln,
-                       # :log2,
-                       :log10,
-                       ]
+const _gaston_marker = [
+    :none,
+    # :auto,
+    :circle,
+    :rect,
+    :diamond,
+    :utriangle,
+    :dtriangle,
+    :pentagon,
+    :x,
+    :+
+] #vcat(_allMarkers, Shape)
+
+const _gaston_scale = [
+    :identity,
+    # :ln,
+    # :log2,
+    :log10,
+]
 
 # ------------------------------------------------------------------------------
 # unicodeplots

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1243,12 +1243,19 @@ _backend_skips = Dict(
     :inspectdr => [4, 6, 10, 22, 24, 28, 30, 38, 43, 45, 47, 48, 49, 50, 51, 55],
     :unicodeplots => [6, 10, 22, 24, 28, 38, 43, 45, 47, 49, 50, 51, 55],
     :gaston => [
-        2, 4, 6,
+        2,  # animations
+        4,  # colors/palette issues
+        6,  # TODO: support embedded images
         16,  # TODO: support nested layouts
         27,  # TODO: support polar
-        30, 31, 47, 48,
+        30,  # uses StatsPlots, deprecated ?
+        31,  # animations
+        47,  # TODO: support mesh3d
+        48,  # TODO: vector of shapes, ...
         49,  # TODO: support polar
-        50, 51, 55
+        50,  # TODO: 1D data not supported for pm3d
+        51,  # TODO: support embedded images
+        55,  # TODO: scaling is ugly
     ],
 )
 

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1242,7 +1242,14 @@ _backend_skips = Dict(
     ],
     :inspectdr => [4, 6, 10, 22, 24, 28, 30, 38, 43, 45, 47, 48, 49, 50, 51, 55],
     :unicodeplots => [6, 10, 22, 24, 28, 38, 43, 45, 47, 49, 50, 51, 55],
-    :gaston => [2, 4, 5, 6, 10, 22, 24, 28, 31, 32, 35, 38, 43, 45, 47, 48, 49, 50, 51, 55],
+    :gaston => [
+        2, 4, 6,
+        16,  # TODO: support nested layouts
+        27,  # TODO: support polar
+        30, 31, 47, 48,
+        49,  # TODO: support polar
+        50, 51, 55
+    ],
 )
 
 


### PR DESCRIPTION
Add new gnuplot capabilities:

```julia
using Plots; gaston()

wframe() = begin
  x = [0, 1, 2, 3]
  y = [0, 1, 2]
  z = [10 10 10 10; 10 5 1 0; 10 10 10 10]
  wireframe(x, y, z, title="3D: Valley of the Gnu from gnuplot manual", legend=:none)
  png("wframe")
end

scatter3() = begin
  x = 0:.1:6π
  scatter3d(x, cos.(x), sin.(x))
  png("scatter3")
end

sombrero() = begin
  x = y = -15:.4:15
  surface(x, y, (x, y) -> @.(sin(sqrt(x^2 + y^2)) / sqrt(x^2 + y^2)), legend=:none, color=:viridis)
  png("sombrero")
end

hmap() = begin
  x = y = -5:.1:5
  heatmap(x, y, (x, y) ->cos.(x / 2) .* sin.(y / 2), legend=:none)
  png("hmap")
end

cnt() = begin
  x = y = -5:.1:5
  contour(x, y, (x, y) -> 5cos.(x / 2) .* sin.(y / 2), legend=:none, aspect_ratio=:equal)
  png("cnt")
end

cnt3d() = begin
  x = y = -5:.1:5
  contour3d(x, y, (x, y) -> 5cos.(x / 2) .* sin.(y / 2), legend=:none)
  png("cnt")
end

wframe()
scatter3()
sombrero()
hmap()
cnt()
cnt3d()
```

![wframe](https://user-images.githubusercontent.com/13423344/126900625-20032a3f-6025-474c-a284-13ec8cd72f25.png)
![scatter3](https://user-images.githubusercontent.com/13423344/126900627-c9e45938-dcdb-40ae-b87e-3b99cc9bdb00.png)
![sombrero](https://user-images.githubusercontent.com/13423344/126900629-d13ef9a9-8586-44ea-8ade-0810d9711fad.png)
![hmap](https://user-images.githubusercontent.com/13423344/126901576-8fbc24a4-2dd4-4471-aadb-9699bcce4f76.png)
![cnt](https://user-images.githubusercontent.com/13423344/126904069-b8853c38-4e83-40f6-ad75-08790a831657.png)
![cnt3d](https://user-images.githubusercontent.com/13423344/126903795-7cacbaaa-47aa-4cb1-8a2e-04996b979f3f.png)


