### PR TITLE
Added colorbar font settings for GR

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -559,11 +559,16 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, clims, viewport_plotare
     gr_set_line(1, :solid, plot_color(:black), sp)
     GR.axes(0, ztick, xmax, zmin, 0, 1, 0.005)
 
-    gr_set_font(guidefont(sp[:yaxis]), sp)
+    if isa(sp[:colorbar_title],PlotText)
+        title = sp[:colorbar_title]
+    else
+        title = text(sp[:colorbar_title], colorbartitlefont(sp))
+    end
+    gr_set_font(title.font, sp)
     GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_TOP)
     GR.setcharup(-1, 0)
     gr_text(
-        viewport_plotarea[2] + 0.1, gr_view_ycenter(viewport_plotarea), sp[:colorbar_title]
+        viewport_plotarea[2] + 0.1, gr_view_ycenter(viewport_plotarea), title.str
     )
 
     GR.restorestate()
@@ -1902,7 +1907,7 @@ function gr_draw_surface(series, x, y, z, clims)
         gr_set_line(get_linewidth(series), get_linestyle(series), get_linecolor(series), series)
         GR.polyline3d(X, Y, Z)
     else
-        throw(ArgumentError("Not handled !"))    
+        throw(ArgumentError("Not handled !"))
     end
 end
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -559,10 +559,10 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, clims, viewport_plotare
     gr_set_line(1, :solid, plot_color(:black), sp)
     GR.axes(0, ztick, xmax, zmin, 0, 1, 0.005)
 
-    if isa(sp[:colorbar_title],PlotText)
-        title = sp[:colorbar_title]
+    title = if isa(sp[:colorbar_title], PlotText)
+        sp[:colorbar_title]
     else
-        title = text(sp[:colorbar_title], colorbartitlefont(sp))
+        text(sp[:colorbar_title], colorbartitlefont(sp))
     end
     gr_set_font(title.font, sp)
     GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_TOP)


### PR DESCRIPTION
I guess the title says it all.
Without this PR `colorbar_font*`-properties are completely ignored. 
Now one can either set the `colorbar_font*`-properties directly in the plotting functions or pass a `Plots.PlotText` object created with `text(string, args...; kw...)` to the `colorbar_title` keyword.