### PR TITLE
add "no changelog" label for SnoopCompile CI

### DIFF
--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -77,7 +77,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update precompile_*.jl file [skip ci]
           title: "[AUTO] Update precompiles [skip ci]"
-          labels: SnoopCompile
+          labels: |
+            SnoopCompile
+            no changelog
           branch: "Test_SnoopCompile_AutoPR_${{ github.ref }}"
 
 


### PR DESCRIPTION
This excludes PRs created by SnoopCompile CI from the release notes, more specifically, the "[AUTO] Update precompiles *" items in release page https://github.com/JuliaPlots/Plots.jl/releases

FWIW, there are some special labels that tagbot handles for exact the same purpose, the full list is shown in https://github.com/JuliaRegistries/TagBot#changelogs