### PR TITLE
Rework adding legends

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1656,12 +1656,13 @@ function _slice_series_args!(plotattributes::AKW, plt::Plot, sp::Subplot, comman
     return plotattributes
 end
 
+label_auto(series_plotindex) = string("y", series_plotindex)
 label_to_string(label::Bool, series_plotindex) = label ? label_to_string(:auto, series_plotindex) : ""
 label_to_string(label::Nothing, series_plotindex) = ""
 label_to_string(label::Missing, series_plotindex) = ""
 function label_to_string(label::Symbol, series_plotindex)
     if label==:auto
-        return string("y", series_plotindex)
+        return label_auto(series_plotindex)
     elseif label==:none
         return ""
     else

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -396,7 +396,7 @@ function pgfx_add_series!(::Val{:path}, axis, series_opt, series, series_func, o
                 end
             end
             if k == 1 &&
-               series[:subplot][:legend] != :none && pgfx_should_add_to_legend(series)
+                series[:subplot][:legend] != :none && pgfx_should_add_to_legend(series)
                 pgfx_filllegend!(series_opt, opt)
             end
         end
@@ -948,8 +948,12 @@ function pgfx_font(fontsize::Nothing, thickness_scaling = 1, font = "\\selectfon
     return string("{", font, "}")
 end
 
-function pgfx_should_add_to_legend(series::Series)
+pgfx_should_add_to_legend(series::Series) = (
     series.plotattributes[:primary] &&
+    !(
+        length(series_list(series[:subplot])) == 1 &&
+        series.plotattributes[:label] == label_auto(series.plotattributes[:series_plotindex])
+    ) &&
     !(
         series.plotattributes[:seriestype] in (
             :hexbin,
@@ -964,7 +968,7 @@ function pgfx_should_add_to_legend(series::Series)
             :image,
         )
     )
-end
+)
 
 function pgfx_marker(plotattributes, i = 1)
     shape = _cycle(plotattributes[:markershape], i)

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -41,9 +41,13 @@ get_subplot_index(plt::Plot, sp::Subplot) = findfirst(x -> x === sp, plt.subplot
 
 series_list(sp::Subplot) = sp.series_list # filter(series -> series.plotattributes[:subplot] === sp, sp.plt.series_list)
 
-function should_add_to_legend(series::Series)
+should_add_to_legend(series::Series) = (
     series.plotattributes[:primary] &&
     series.plotattributes[:label] != "" &&
+    !(
+        length(series_list(series[:subplot])) == 1 &&
+        series.plotattributes[:label] == label_auto(series.plotattributes[:series_plotindex])
+    ) &&
     !(
         series.plotattributes[:seriestype] in (
             :hexbin,
@@ -60,6 +64,6 @@ function should_add_to_legend(series::Series)
             :image,
         )
     )
-end
+)
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Disable legend entry when a single series is present and the label has been auto-generated for that series.

Fix https://github.com/JuliaPlots/Plots.jl/issues/3691.

- [x] generate ref images → [here](https://github.com/JuliaPlots/PlotReferenceImages.jl/pull/108)