### PR TITLE
Allow passing collection of tuples to series_annotations

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -996,9 +996,9 @@ function processFontArg!(plotattributes::AKW, fontname::Symbol, arg)
     elseif arg == :center
         plotattributes[Symbol(fontname, :halign)] = :hcenter
         plotattributes[Symbol(fontname, :valign)] = :vcenter
-    elseif arg in (:hcenter, :left, :right)
+    elseif arg ∈ _haligns
         plotattributes[Symbol(fontname, :halign)] = arg
-    elseif arg in (:vcenter, :top, :bottom)
+    elseif arg ∈ _valigns
         plotattributes[Symbol(fontname, :valign)] = arg
     elseif T <: Colorant
         plotattributes[Symbol(fontname, :color)] = arg

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -70,6 +70,7 @@ function text_size(lablen::Int, sz::Number, rot::Number = 0)
     width, height
 end
 text_size(lab::AbstractString, sz::Number, rot::Number = 0) = text_size(length(lab), sz, rot)
+text_size(lab::PlotText, sz::Number, rot::Number = 0) = text_size(length(lab.str), sz, rot)
 
 # account for the size/length/rotation of tick labels
 function tick_padding(sp::Subplot, axis::Axis)

--- a/src/components.jl
+++ b/src/components.jl
@@ -4,10 +4,10 @@ const P3 = GeometryBasics.Point3{Float64}
 const _haligns = :hcenter, :left, :right
 const _valigns = :vcenter, :top, :bottom
 
-nanpush!(a::AbstractVector{P2}, b) = (push!(a, P2(NaN, NaN)); push!(a, b))
-nanappend!(a::AbstractVector{P2}, b) = (push!(a, P2(NaN, NaN)); append!(a, b))
-nanpush!(a::AbstractVector{P3}, b) = (push!(a, P3(NaN, NaN, NaN)); push!(a, b))
-nanappend!(a::AbstractVector{P3}, b) = (push!(a, P3(NaN, NaN, NaN)); append!(a, b))
+nanpush!(a::AVec{P2}, b) = (push!(a, P2(NaN, NaN)); push!(a, b))
+nanappend!(a::AVec{P2}, b) = (push!(a, P2(NaN, NaN)); append!(a, b))
+nanpush!(a::AVec{P3}, b) = (push!(a, P3(NaN, NaN, NaN)); push!(a, b))
+nanappend!(a::AVec{P3}, b) = (push!(a, P3(NaN, NaN, NaN)); append!(a, b))
 compute_angle(v::P2) = (angle = atan(v[2], v[1]); angle < 0 ? 2π - angle : angle)
 
 # -------------------------------------------------------------
@@ -449,9 +449,9 @@ end
 # -----------------------------------------------------------------------
 
 mutable struct SeriesAnnotations
-    strs::AbstractVector  # the labels/names
+    strs::AVec  # the labels/names
     font::Font
-    baseshape::Union{Shape, AbstractVector{Shape}, Nothing}
+    baseshape::Union{Shape, AVec{Shape}, Nothing}
     scalefactor::Tuple
 end
 
@@ -464,12 +464,12 @@ series_annotations(scalar) = series_annotations([scalar])
 series_annotations(anns::SeriesAnnotations) = anns
 series_annotations(::Nothing) = nothing
 
-function series_annotations(strs::AbstractVector, args...)
+function series_annotations(strs::AVec, args...)
     fnt = font()
     shp = nothing
     scalefactor = 1, 1
     for arg in args
-        if isa(arg, Shape) || (isa(arg, AbstractVector) && eltype(arg) == Shape)
+        if isa(arg, Shape) || (isa(arg, AVec) && eltype(arg) == Shape)
             shp = arg
         elseif isa(arg, Font)
             fnt = arg
@@ -479,6 +479,8 @@ function series_annotations(strs::AbstractVector, args...)
             scalefactor = arg, arg
         elseif is_2tuple(arg)
             scalefactor = arg
+        elseif isa(arg, AVec)
+            strs = collect(zip(strs, arg))
         else
             @warn "Unused SeriesAnnotations arg: $arg ($(typeof(arg)))"
         end
@@ -495,7 +497,7 @@ function series_annotations_shapes!(series::Series, scaletype::Symbol=:pixels)
     anns = series[:series_annotations]
     # msw, msh = anns.scalefactor
     # ms = series[:markersize]
-    # msw, msh = if isa(ms, AbstractVector)
+    # msw, msh = if isa(ms, AVec)
     #     1, 1
     # elseif is_2tuple(ms)
     #     ms

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -116,7 +116,7 @@ end
 end
 
 @testset "Series Annotations" begin
-    square = Shape([(0, 0), (1, 0), (1, 1), (0, 1)])
+    square = Shape([(0., 0.), (1., 0.), (1., 1.), (0., 1.)])
     @test_logs (:warn, "Unused SeriesAnnotations arg: triangle (Symbol)") begin
         p = plot(
             [1, 2, 3],
@@ -130,7 +130,7 @@ end
             ),
         )
         sa = p.series_list[1].plotattributes[:series_annotations]
-        @test sa.strs == ["a"]
+        @test only(sa.strs).str == "a"
         @test sa.font.family == "courier"
         @test sa.baseshape == square
         @test sa.scalefactor == (1, 4)
@@ -141,21 +141,19 @@ end
         layout = (5, 1),
         ylims = (-1.1, 1.1),
         xlims = (0, 5),
-        series_annotations = permutedims([["1/1"],["1/2"],["1/3"],["1/4"],["1/5"]]),
+        series_annotations = permutedims([["1/1"], ["1/2"], ["1/3"], ["1/4"], ["1/5"]]),
     )
-    @test spl.series_list[1].plotattributes[:series_annotations].strs == ["1/1"]
-    @test spl.series_list[2].plotattributes[:series_annotations].strs == ["1/2"]
-    @test spl.series_list[3].plotattributes[:series_annotations].strs == ["1/3"]
-    @test spl.series_list[4].plotattributes[:series_annotations].strs == ["1/4"]
-    @test spl.series_list[5].plotattributes[:series_annotations].strs == ["1/5"]
+    for i ∈ 1:5
+        @test only(spl.series_list[i].plotattributes[:series_annotations].strs).str == "1/$i"
+    end
 
     p = plot([1, 2], annotations=(1.5, 2, text("foo", :left)))
-    x, y, txt = p.subplots[end][:annotations][end]
+    x, y, txt = only(p.subplots[end][:annotations])
     @test (x, y) == (1.5, 2)
     @test txt.str == "foo"
 
     p = plot([1, 2], annotations=((.1, .5), :auto))
-    pos, txt = p.subplots[end][:annotations][end]
+    pos, txt = only(p.subplots[end][:annotations])
     @test pos == (.1, .5)
     @test txt.str == "(a)"
 end


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/3629. And some code cleanup.

Example
---
```julia
using Plots
plot([1, 2], [3, 4], series_annotations=[("A", :red), ("B", :blue)])
plot([1, 2], [3, 4], series_annotations=(["A", "B"], [:red, :blue]))  # also supported
plot([1, 2], [3, 4], series_annotations=[["A", "B"], [:red, :blue]])  # same as previous
```
Output
---
![rel1](https://user-images.githubusercontent.com/13423344/127910024-301e2f38-df6e-4556-8834-acfb0f203150.png)
