### PR TITLE
UnicodePlots: fix setting linecolor

### DIFF
--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -93,7 +93,14 @@ function rebuildUnicodePlot!(plt::Plot, width, height)
 end
 
 # add a single series
-function addUnicodeSeries!(o, plotattributes, addlegend::Bool, xlim, ylim)
+function addUnicodeSeries!(
+    o,
+    plotattributes,
+    addlegend::Bool,
+    xlim,
+    ylim;
+    rev_color_names = Dict(v => k for (k, v) in Colors.color_names),
+)
     # get the function, or special handling for step/bar/hist
     st = plotattributes[:seriestype]
     if st == :histogram2d
@@ -124,9 +131,11 @@ function addUnicodeSeries!(o, plotattributes, addlegend::Bool, xlim, ylim)
     label = addlegend ? plotattributes[:label] : ""
 
     # if we happen to pass in allowed color symbols, great... otherwise let UnicodePlots decide
-    color =
-        plotattributes[:linecolor] in UnicodePlots.color_cycle ?
-        plotattributes[:linecolor] : :auto
+    lc = convert(ARGB32, plotattributes[:linecolor])
+    sym = Symbol(
+        get(rev_color_names, map(Int, (red(lc).i, green(lc).i, blue(lc).i)), nothing),
+    )
+    color = sym in UnicodePlots.color_cycle ? sym : :auto
 
     # add the series
     x, y = RecipesPipeline.unzip(

--- a/src/precompile_includer.jl
+++ b/src/precompile_includer.jl
@@ -7,10 +7,9 @@ ismultiversion = false
 @static if !should_precompile
     # nothing
 elseif !ismultios && !ismultiversion
-    @static if isfile(joinpath(
-        @__DIR__,
-        "../deps/SnoopCompile/precompile/precompile_Plots.jl",
-    ))
+    @static if isfile(
+        joinpath(@__DIR__, "../deps/SnoopCompile/precompile/precompile_Plots.jl"),
+    )
         include("../deps/SnoopCompile/precompile/precompile_Plots.jl")
         _precompile_()
     end


### PR DESCRIPTION
Currently not working as expected.

```julia
using Plots; unicodeplots()

display(plot([1, 2], linecolor=:blue))
```