### PR TITLE
Implementation of filling the space between and under curves

### DIFF
--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -303,10 +303,14 @@ function gaston_seriesconf!(
         lc, dt, lw = gaston_lc_ls_lw(series, clims, i)
         pt, ps, mc = gaston_mk_ms_mc(series, clims, i)
         push!(curveconf, "w points pt $pt ps $ps lc $mc")
-    elseif st ∈ (:path, :straightline, :path3d)
+    elseif st ∈ (:path, :straightline, :path3d)      
+        fr = series[:fillrange]
+        fc = gaston_color(get_fillcolor(series, i), get_fillalpha(series, i))
         lc, dt, lw = gaston_lc_ls_lw(series, clims, i)
-        if series[:markershape] == :none  # simplepath
-            push!(curveconf, "w lines lc $lc dt $dt lw $lw")
+        if fr !== nothing # filled curves, but not filled curves with markers
+            push!(curveconf, "w filledcurves fc $fc fs solid border lc $lc lw $lw dt $dt")
+        elseif series[:markershape] == :none  # simplepath
+            push!(curveconf, "w lines  lc $lc dt $dt lw $lw")
         else
             pt, ps, mc = gaston_mk_ms_mc(series, clims, i)
             push!(curveconf, "w lp lc $mc dt $dt lw $lw pt $pt ps $ps")

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -308,7 +308,8 @@ function gaston_seriesconf!(
         fc = gaston_color(get_fillcolor(series, i), get_fillalpha(series, i))
         lc, dt, lw = gaston_lc_ls_lw(series, clims, i)
         if fr !== nothing # filled curves, but not filled curves with markers
-            push!(curveconf, "w filledcurves fc $fc fs solid border lc $lc lw $lw dt $dt")
+            push!(curveconf, "w filledcurves y=$fr fc $fc fs solid border lc $lc lw $lw dt $dt,'' w lines lc $lc lw $lw dt $dt")
+            #push!(curveconf, "w lines lc $lc lw $lw dt $dt")
         elseif series[:markershape] == :none  # simplepath
             push!(curveconf, "w lines  lc $lc dt $dt lw $lw")
         else

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -225,13 +225,13 @@ function gaston_add_series(plt::Plot{GastonBackend}, series::Series)
     gsp = sp.o
     x, y, z = series[:x], series[:y], series[:z]
     st = series[:seriestype]
-
     curves = []
     if gsp.dims == 2 && z === nothing
         for (n, seg) in enumerate(series_segments(series, st; check = true))
             i, rng = seg.attr_index, seg.range
+            fr =_cycle(series[:fillrange], 1:length(x[rng])) ####
             for sc in gaston_seriesconf!(sp, series, i, n == 1)
-                push!(curves, Gaston.Curve(x[rng], y[rng], nothing, nothing, sc))
+                push!(curves, Gaston.Curve(x[rng], y[rng], nothing, fr, sc)) 
             end
         end
     else
@@ -307,9 +307,8 @@ function gaston_seriesconf!(
         fr = series[:fillrange]
         fc = gaston_color(get_fillcolor(series, i), get_fillalpha(series, i))
         lc, dt, lw = gaston_lc_ls_lw(series, clims, i)
-        if fr !== nothing # filled curves, but not filled curves with markers
-            push!(curveconf, "w filledcurves y=$fr fc $fc fs solid border lc $lc lw $lw dt $dt,'' w lines lc $lc lw $lw dt $dt")
-            #push!(curveconf, "w lines lc $lc lw $lw dt $dt")
+        if fr !== nothing # filled curves, but not filled curves with markers 
+            push!(curveconf, "w filledcurves fc $fc fs solid border lc $lc lw $lw dt $dt,'' w lines lc $lc lw $lw dt $dt")
         elseif series[:markershape] == :none  # simplepath
             push!(curveconf, "w lines  lc $lc dt $dt lw $lw")
         else


### PR DESCRIPTION
It it now possible to fill the space between a parametric function or under (between graph and x-axis) several curves. In addition one can pass a vector as argument to fill the space between altering y-values.
The plots:

``
plot(sin, (x->begin
            sin(2x)
        end), 0, 2π, line = 4, leg = false, fill = (0, :orange))
``

and 

``
y = rand(100)
plot(0:10:100, rand(11, 4), lab = "lines", w = 3, palette = cgrad(:grays), fill = 0, α = 0.6)
``
and 

``
plot(1:5, fillrange = [1,2])
``

are now possible and the output is:

![Parametric_plot](https://user-images.githubusercontent.com/88666946/129887216-36c2a82a-d36c-4f97-9667-baeac9de52e4.png)
![several_filledcurves](https://user-images.githubusercontent.com/88666946/129887244-84b0279c-08c3-45ce-a87f-62ec6dbc28b0.png)
![vector_input](https://user-images.githubusercontent.com/88666946/129887261-da7afe89-0a96-4814-a905-08bd6df528c0.png)

Possibility for adding markers is still missing when using the `fill` option.
