### PR TITLE
improve axis decorations

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -1232,6 +1232,8 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
         opt,
         string(letter, "label style") => PGFPlotsX.Options(
             labelpos => nothing,
+            "at" => string("{(ticklabel cs:", get((left = 0, right = 1), axis[:guidefonthalign], 0.5),")}"),
+            "anchor" => "near ticklabel",
             "font" => pgfx_font(axis[:guidefontsize], pgfx_thickness_scaling(sp)),
             "color" => cstr,
             "draw opacity" => α,


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/3375 though I wonder if people mix normal strings and LaTeXStrings in ticklabels.
Implements `guidefonthalign` as reported in https://github.com/JuliaPlots/Plots.jl/issues/3524, but I am not quite sure what `guidefontvalign` should do.