### PR TITLE
CI: julia-uploadcodecov is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,11 @@ jobs:
           $TESTCMD -e 'using Pkg; Pkg.activate(tempdir()); Pkg.develop(path=abspath(".")); Pkg.add("StatsPlots"); Pkg.test("StatsPlots")'
           $TESTCMD -e 'using Pkg; Pkg.activate(tempdir()); Pkg.develop(path=abspath(".")); Pkg.add("GraphRecipes"); Pkg.test("GraphRecipes")'
 
-      - name: Codecov
-        uses: julia-actions/julia-uploadcodecov@latest
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # Codecov
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
 
   Skip:
     if: "contains(github.event.head_commit.message, '[skip ci]')"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+  annotations: false

--- a/.github/workflows/format.yml.disabled
+++ b/.github/workflows/format.yml.disabled
@@ -5,8 +5,7 @@ on:
 
 jobs:
   JuliaFormatter:
-    if: false
-    # if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
And disable codecov annotations on `PR`s, since they make them un-readable.