### PR TITLE
UnicodePlots: support layout

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1253,16 +1253,15 @@ _backend_skips = Dict(
         6,  # embedded images unsupported
         10,  # histogram2d
         13,  # markers unsupported
-        16,  # subplots unsupported
-        17,  # grid layout unsupported
+        16,  # nested layout unsupported
         20,  # annotations unsupported
         21,  # custom markers unsupported
         22,  # contours unsupported
         24,  # 3D unsupported
-        26,  # subplots unsupported
-        29,  # layout unsupported
+        26,  # nested layout unsupported
+        29,  # nested layout unsupported
         33,  # grid lines unsupported
-        34,  # framestyles unsupported
+        34,  # framestyle unsupported
         37,  # ribbons / filled unsupported
         38,  # histogram2D 
         43,  # heatmap with DateTime


### PR DESCRIPTION
Preliminary support of layout for UnicodePlots (un-nested layouts).

```julia
using Plots; unicodeplots()

main() = begin
  plot(
    rand(10, 4), layout=(@layout [_ °; ° _; ° °]),
    xguide="x", yguide="y",
    seriestype=[:bar :scatter :path :stepmid],
    legend=false,
  )
  show(current())

  plot(
    Plots.fakedata(100, 10), layout=4,
    palette=cgrad.([:grays :blues :heat :lightrainbow]),
  )
  show(current())

  return
end

main()
```

![sp1](https://user-images.githubusercontent.com/13423344/131642031-1179772f-a0e9-43f1-956c-86a12a04ce30.png)
![sp2](https://user-images.githubusercontent.com/13423344/131641892-56fe572d-b31b-429a-942f-b6689c211704.png)

