### PR TITLE
handling fonts better, moving to stable 3.4

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -178,14 +178,19 @@ py_fillstyle(::Nothing) = nothing
 py_fillstyle(fillstyle::Symbol) = string(fillstyle)
 
 function py_get_matching_math_font(parent_fontfamily)
-    math_font_family = if parent_fontfamily == "sans-serif"
-        "dejavusans"
-    elseif parent_fontfamily == "serif"
-        "dejavuserif"
-    else
-        parent_fontfamily
-    end
-    return math_font_family
+    # matplotlib supported math fonts according to
+    # https://matplotlib.org/stable/tutorials/text/mathtext.html
+    py_math_supported_fonts = Dict{String, String}(
+        "sans-serif" => "dejavusans", 
+        "serif" => "dejavuserif", 
+        "cm" => "cm", 
+        "stix" => "stix", 
+        "stixsans" => "stixsans"
+    )
+    # Fallback to "dejavusans" or "dejavuserif" in case the parentfont is different
+    # from supported by matplotlib fonts
+    matching_font(font) = occursin("serif", lowercase(font)) ? "dejavuserif" : "dejavusans"
+    return get(py_math_supported_fonts, parent_fontfamily, matching_font(parent_fontfamily))
 end
 
 # # untested... return a FontProperties object from a Plots.Font


### PR DESCRIPTION
Better handling fonts overall for pyplot. I've been waiting to to add this only when conda.jl starts providing 3.4 matplotlib (which is already)
Matplotlib introduces sane way of setting math_fontfamily per every text element separately, for the pyplot backend i set it to be inherited from the relevant plots text element. So mathfont will change everywhere it needs to change (per user choosing). Also so no need for latex surrounding anymore. So all in all an overall improvement.

```

julia> 

p = plot(x, 10 .^x, zline=x,xticks=(x, [raw"ttext $\alpha$" for i in x]), title=raw"test $\beta$", xlabel = raw"$\Gamma \Pi$", label = raw"text: $\Gamma \Pi$", fontfamily="serif", thickness_scaling=2)

p = plot(x, 10 .^x, zline=x,xticks=(x, [raw"ttext $\alpha$" for i in x]), title=raw"test $\beta$", xlabel = raw"$\Gamma \Pi$", label = raw"text: $\Gamma \Pi$", fontfamily="sans-serif", thickness_scaling=2)
```
![image](https://user-images.githubusercontent.com/24591123/132089985-32a45517-f357-4e52-b46c-33321ef9e892.png)
![image](https://user-images.githubusercontent.com/24591123/132089990-1f54b69c-c0c8-4c07-9215-28c4fc47b861.png)
