### PR TITLE
Fix type inference failure in `get_clims`

### DIFF
--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -8,7 +8,7 @@ process_clims(f) = f
 function get_clims(sp::Subplot, op = process_clims(sp[:clims]))
     zmin, zmax = Inf, -Inf
     for series in series_list(sp)
-        if series[:colorbar_entry] && (series[:seriestype] != :shape || series[:fillcolor] === nothing)
+        if series[:colorbar_entry] && series[:seriestype] != :shape
             zmin, zmax = _update_clims(zmin, zmax, get_clims(series, op)...)
         end
     end
@@ -16,7 +16,7 @@ function get_clims(sp::Subplot, op = process_clims(sp[:clims]))
 end
 
 function get_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]))
-    series[:seriestype] != :shape || series[:fillcolor] === nothing || return -Inf, Inf
+    series[:seriestype] != :shape || return -Inf, Inf
     zmin, zmax = if series[:colorbar_entry]
         get_clims(sp, op)
     else

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -5,18 +5,17 @@ process_clims(s::Union{Symbol,Nothing,Missing}) = ignorenan_extrema
 # don't specialize on ::Function otherwise python functions won't work
 process_clims(f) = f
 
-function get_clims(sp::Subplot, op = process_clims(sp[:clims]))
+function get_clims(sp::Subplot, op = process_clims(sp[:clims]))::Tuple{Float64, Float64}
     zmin, zmax = Inf, -Inf
     for series in series_list(sp)
-        if series[:colorbar_entry] && series[:seriestype] != :shape
+        if series[:colorbar_entry]
             zmin, zmax = _update_clims(zmin, zmax, get_clims(series, op)...)
         end
     end
     return zmin <= zmax ? (zmin, zmax) : (NaN, NaN)
 end
 
-function get_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]))
-    series[:seriestype] != :shape || return NaN, NaN
+function get_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]))::Tuple{Float64, Float64}
     zmin, zmax = if series[:colorbar_entry]
         get_clims(sp, op)
     else
@@ -32,7 +31,7 @@ Finds the limits for the colorbar by taking the "z-values" for the series and pa
 which must return the tuple `(zmin, zmax)`. The default op is the extrema of the finite
 values of the input.
 """
-function get_clims(series::Series, op = ignorenan_extrema)
+function get_clims(series::Series, op = ignorenan_extrema)::Tuple{Float64, Float64}
     zmin, zmax = Inf, -Inf
     z_colored_series = (:contour, :contour3d, :heatmap, :histogram2d, :surface, :hexbin)
     for vals in (

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -8,7 +8,7 @@ process_clims(f) = f
 function get_clims(sp::Subplot, op = process_clims(sp[:clims]))
     zmin, zmax = Inf, -Inf
     for series in series_list(sp)
-        if series[:colorbar_entry]
+        if series[:colorbar_entry] && (series[:seriestype] != :shape || series[:fillcolor] === nothing)
             zmin, zmax = _update_clims(zmin, zmax, get_clims(series, op)...)
         end
     end
@@ -16,6 +16,7 @@ function get_clims(sp::Subplot, op = process_clims(sp[:clims]))
 end
 
 function get_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]))
+    series[:seriestype] != :shape || series[:fillcolor] === nothing || return -Inf, Inf
     zmin, zmax = if series[:colorbar_entry]
         get_clims(sp, op)
     else

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -16,7 +16,7 @@ function get_clims(sp::Subplot, op = process_clims(sp[:clims]))
 end
 
 function get_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]))
-    series[:seriestype] != :shape || return -Inf, Inf
+    series[:seriestype] != :shape || return NaN, NaN
     zmin, zmax = if series[:colorbar_entry]
         get_clims(sp, op)
     else


### PR DESCRIPTION
Resolves #3837 

The intent is to short-circuit the `clims` calculation with a `shape` series type. Each shape is a series and only has a single color (right?), so all that calculation is unnecessary.

Only issue with the current PR is that using `fill_z` instead of `fillcolor` is broken, plot shapes have no color. Has to be a way to detect this situation to allow `get_clims` to work properly?