### PR TITLE
Update Plots.jl's `colorbar_titel` maps to PGFPlotsX's `color bar style={ylabel}`

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -692,6 +692,10 @@
         {
             "name": "Fred Callaway",
             "type": "Other"
+        },
+        {
+            "name": "Jan Thorben Schneider",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -203,7 +203,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
 
             if hascolorbar(sp)
                 cticks = get_colorbar_ticks(sp)[2]
-                colorbar_style = PGFPlotsX.Options("title" => sp[:colorbar_title])
+                colorbar_style = PGFPlotsX.Options("ylabel" => sp[:colorbar_title])
                 if sp[:colorbar] === :top
                     push!(
                         colorbar_style,


### PR DESCRIPTION
For most of the backends supported by Plots.jl the `colorbar_title` attribute maps to the attribute in the backend that ultimately is displayed on the vertical axis of the colorbar, which is vertically aligned as well.
However, this is not the case for PGFPlotsX as in this backend the `title` attribute is displayed on top of the colorbar while the `ylabel` is shown on the vertical bar.

This PR proposes this change for consistency and, admittedly very subjective, better looks.

Let me know if this is appreciated and/or desired.

Cheers
Jan