### PR TITLE
change docs link to httpS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [gitter-url]: https://gitter.im/tbreloff/Plots.jl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 [docs-img]: https://img.shields.io/badge/docs-stable-blue.svg
-[docs-url]: http://docs.juliaplots.org/latest/
+[docs-url]: https://docs.juliaplots.org/latest/
 
 [![][gh-ci-img]][gh-ci-url]
 [![][pkgeval-img]][pkgeval-url]


### PR DESCRIPTION
always bugs me to get a warning from my browser about the not secure connection.
Could someone also update the About section at the right of the Github page to a https URL?