### PR TITLE
Allow styling of magnification shape in lens!()

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -696,6 +696,12 @@
         {
             "name": "Jan Thorben Schneider",
             "type": "Other"
+        },
+        {
+            "orcid": "0000-0003-4102-2460",
+            "affiliation": "Alogus Research Corporation:,
+            "name": "Lee Phillips",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1042,11 +1042,7 @@ export lens!
     series_plotindex := backup[:series_plotindex]
     seriestype := :path
     primary := false
-    if haskey(backup, :linecolor)
-        linecolor := backup[:linecolor]
-    else
-        linecolor := :lightgray
-    end
+    linecolor := get(backup, :linecolor, :lightgray)
     if haskey(backup, :linestyle)
         linestyle := backup[:linestyle]
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1042,7 +1042,17 @@ export lens!
     series_plotindex := backup[:series_plotindex]
     seriestype := :path
     primary := false
-    linecolor := :lightgray
+    if haskey(backup, :linecolor)
+        linecolor := backup[:linecolor]
+    else
+        linecolor := :lightgray
+    end
+    if haskey(backup, :linestyle)
+        linestyle := backup[:linestyle]
+    end
+    if haskey(backup, :linewidth)
+        linewidth := backup[:linewidth]
+    end
     bbx_mag = (x1 + x2) / 2
     bby_mag = (y1 + y2) / 2
     xi_lens, yi_lens =


### PR DESCRIPTION
The guide lines that indicate the region of the plot magnified in the
inset lens plot, called the magnification shape, are hard-coded with
the :lightgray color and are drawn with the default other line
attributes. This is often too light to be seen clearly and could be a
problem for publication. This commit allows the user to set the
linecolor, linewidth, and linestyle in the call to lens!().