### PR TITLE
Change default white space in legend

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1271,7 +1271,7 @@ function gr_get_legend_geometry(viewport_plotarea, sp)
     x_legend_offset = (viewport_plotarea[2] - viewport_plotarea[1]) / 30
     y_legend_offset = (viewport_plotarea[4] - viewport_plotarea[3]) / 30
 
-    dy *= get(sp[:extra_kwargs], :legend_hfactor, 1)
+    dy *= get(sp[:extra_kwargs], :legend_hfactor, 1.05)  # default arbitrary 5% white space
 
     legendh = dy * legendn
 


### PR DESCRIPTION
Follow up of https://github.com/JuliaPlots/Plots.jl/pull/3598, add `5%` default whitespace.

Fix https://github.com/JuliaPlots/Plots.jl/issues/3884.

```julia
using Plots, LaTeXStrings
plot([rand(10) rand(10)],labels=[L"\textrm{ABC}" L"\textrm{DEF}"])
```
![bar](https://user-images.githubusercontent.com/13423344/138071429-c2b47691-3782-4858-b0b6-32a3363376aa.png)

- [ ] new images