### PR TITLE
Add `:log10`-`colorbar_scale` support in GR

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -377,6 +377,8 @@ const _gr_attr = merge_with_base_supported([
     :colorbar,
     :colorbar_title,
     :colorbar_entry,
+    :colorbar_scale,
+    :clims,
     :fill_z,
     :line_z,
     :marker_z,

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -569,8 +569,11 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, clims, viewport_plotare
 
     ztick = 0.5 * GR.tick(zmin, zmax)
     gr_set_line(1, :solid, plot_color(:black), sp)
+    if sp[:colorbar_scale] == :log10
+        GR.setscale(2)
+    end
     GR.axes(0, ztick, xmax, zmin, 0, 1, 0.005)
-
+    
     title = if isa(sp[:colorbar_title], PlotText)
         sp[:colorbar_title]
     else
@@ -949,6 +952,9 @@ function get_z_normalized(z, clims...)
 end
 
 function gr_clims(args...)
+    if args[1][:clims] != :auto
+        return args[1][:clims]
+    end
     lo, hi = get_clims(args...)
     if lo == hi
         if lo == 0
@@ -992,7 +998,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
 
     # init the colorbar
     cbar = GRColorbar()
-
+    
     for series in series_list(sp)
         gr_add_series(sp, series)
         gr_update_colorbar!(cbar, series)
@@ -2085,15 +2091,41 @@ function gr_draw_heatmap(series, x, y, z, clims)
         # pdf output, and also supports alpha values.
         # Note that drawimage draws uniformly spaced data correctly
         # even on log scales, where it is visually non-uniform.
-        colors = plot_color.(get(fillgrad, z, clims), series[:fillalpha])
+        colors = if series[:subplot][:colorbar_scale] == :identity
+            colors = plot_color.(get(fillgrad, z, clims), series[:fillalpha])
+        elseif series[:subplot][:colorbar_scale] == :log10
+            z_log = log10.(z)
+            z_normalized = get_z_normalized.(z_log, log10.(clims)...)
+            colors = plot_color.(map(z -> get(fillgrad, z), z_normalized), series[:fillalpha])
+        end
+        for i in eachindex(colors)
+            if z[i] < (clims[1])
+                colors[i] = set_RGBA_alpha(0, colors[i])
+            end
+        end
         rgba = gr_color.(colors)
         GR.drawimage(first(x), last(x), last(y), first(y), w, h, rgba)
     else
         if something(series[:fillalpha], 1) < 1
             @warn "GR: transparency not supported in non-uniform heatmaps. Alpha values ignored."
         end
-        z_normalized = get_z_normalized.(z, clims...)
+        z_normalized = if series[:subplot][:colorbar_scale] == :identity
+            get_z_normalized.(z, clims...)
+        elseif series[:subplot][:colorbar_scale] == :log10
+            z_log = log10.(z)
+            z_log = map(z -> isinf(z) ? Inf : z, z_log)
+            z_min = minimum(z_log)
+            z_log = map(z -> isinf(z) ? z_min : z, z_log)
+            get_z_normalized.(z_log, minimum(z_log), maximum(z_log))
+        end
         rgba = Int32[round(Int32, 1000 + _i * 255) for _i in z_normalized]
+        for i in eachindex(rgba)
+            if z[i] < (clims[1])
+                rgba[i] = 0 # White, not transparent 
+            elseif z[i] > (clims[end])
+                rgba[i] = 1255 
+            end
+        end
         if !ispolar(series)
             GR.nonuniformcellarray(x, y, w, h, rgba)
         else


### PR DESCRIPTION
Relates to https://github.com/JuliaPlots/Plots.jl/issues/3174
I added support for log10 scale of the colormap in heatmaps in GR. Please have a look. 

Notes:
* It is not possible that `z` contains negative values.
* In the non-uniform case, "pixels" with `z < clims[1]` are plotted white and not transparent as it seems that this is not yet supported by GR.jl (though I am not sure about that).

Some example: 

```julia
using Plots

x = 0:0.2:1;
# y = [0.0, 0.2, 0.4, 0.6]; # also works for evenly spaced heatmaps
y = [0.0, 0.15, 0.45, 0.6]; 
z = Array{Float64,2}(undef, length(y)-1, length(x)-1);
map(i -> z[i] = 10.0^(i-5), eachindex(z));

plot(
    plot(x, y, z, st=:heatmap, colorbar_scale = :identity),
    plot(x, y, z, st=:heatmap, colorbar_scale = :log10),
    plot(x, y, z, st=:heatmap, colorbar_scale = :log10, clims = (z[4], z[end-3])),
    layout = (3, 1), size = (800, 900)
)

```
![clog_heatmaps_gr](https://user-images.githubusercontent.com/16963906/139579730-c67a1721-23ee-4c6e-b71d-cd4946f0807c.png)
