### PR TITLE
Fix setting of legend font via `legend_font`

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -2044,7 +2044,6 @@ function _update_subplot_args(
 
     _update_subplot_periphery(sp, anns)
     _update_subplot_colors(sp)
-    _update_subplot_legend(sp, plotattributes_in)
 
     lims_warned = false
     for letter in (:x, :y, :z)

--- a/src/args.jl
+++ b/src/args.jl
@@ -1484,7 +1484,7 @@ function RecipesPipeline.preprocess_attributes!(plotattributes::AKW)
 
     # fonts
     for fontname in
-        (:titlefont, :legendfont, :legendtitlefont, :plot_titlefont, :colorbar_titlefont)
+        (:titlefont, :legendtitlefont, :plot_titlefont, :colorbar_titlefont)
         args = RecipesPipeline.pop_kw!(plotattributes, fontname, ())
         for arg in wraptuple(args)
             processFontArg!(plotattributes, fontname, arg)
@@ -1947,6 +1947,11 @@ function _update_subplot_colors(sp::Subplot)
     return
 end
 
+function _update_subplot_legend(sp::Subplot, plotattributes_in)
+    @show plotattributes_in |> keys
+    # sp.attr[:legend] = Legend(background_color = sp[:legend_background_color], foreground_color = sp[:legend_foreground_color], position = sp[:legend_position], title = sp[:legend_title], font = font(sp[:legend_font]; )) # TODO: make legend_font and legend_font_* attributes coherent
+end
+
 function _update_axis(
     plt::Plot,
     sp::Subplot,
@@ -2039,6 +2044,7 @@ function _update_subplot_args(
 
     _update_subplot_periphery(sp, anns)
     _update_subplot_colors(sp)
+    _update_subplot_legend(sp, plotattributes_in)
 
     lims_warned = false
     for letter in (:x, :y, :z)

--- a/src/args.jl
+++ b/src/args.jl
@@ -1949,9 +1949,12 @@ end
 
 function _update_subplot_legend(sp::Subplot, plotattributes_in)
     f_attr = NamedTuple( k => plotattributes_in[Symbol(:legend_font_, k)] for k in (:family, :pointsize, :valign, :halign, :rotation, :color) if haskey(plotattributes_in, Symbol(:legend_font_, k)))
-    match_attr = NamedTuple( k => sp[Symbol(:legend_font_, k)] for k in (:family, :pointsize, :valign, :halign, :rotation, :color) if haskey(_match_map, Symbol(:legend_font_, k)))
-    sp.attr[:legend_font] = font(default(plotattributes_in, :legend_font);
-        merge(f_attr, match_attr)...
+    match_attr = NamedTuple( (lk = Symbol(:legend_font_, k); k => haskey(_match_map, lk) ? sp[lk] :
+            haskey(plotattributes_in, :legend_font) ? getproperty(plotattributes_in[:legend_font], k) :
+            default(plotattributes_in, lk))
+            for k in (:family, :pointsize, :valign, :halign, :rotation, :color))
+    sp.attr[:legend_font] = font(;
+        merge(match_attr, f_attr)...
     )
 end
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -1948,8 +1948,10 @@ function _update_subplot_colors(sp::Subplot)
 end
 
 function _update_subplot_legend(sp::Subplot, plotattributes_in)
-    @show plotattributes_in |> keys
-    # sp.attr[:legend] = Legend(background_color = sp[:legend_background_color], foreground_color = sp[:legend_foreground_color], position = sp[:legend_position], title = sp[:legend_title], font = font(sp[:legend_font]; )) # TODO: make legend_font and legend_font_* attributes coherent
+    f_attr = NamedTuple( k => plotattributes_in[Symbol(:legend_font_, k)] for k in (:family, :pointsize, :valign, :halign, :rotation, :color) if haskey(plotattributes_in, Symbol(:legend_font_, k)))
+    sp.attr[:legend_font] = font(default(plotattributes_in, :legend_font);
+        f_attr...
+    )
 end
 
 function _update_axis(

--- a/src/args.jl
+++ b/src/args.jl
@@ -1949,8 +1949,9 @@ end
 
 function _update_subplot_legend(sp::Subplot, plotattributes_in)
     f_attr = NamedTuple( k => plotattributes_in[Symbol(:legend_font_, k)] for k in (:family, :pointsize, :valign, :halign, :rotation, :color) if haskey(plotattributes_in, Symbol(:legend_font_, k)))
+    match_attr = NamedTuple( k => sp[Symbol(:legend_font_, k)] for k in (:family, :pointsize, :valign, :halign, :rotation, :color) if haskey(_match_map, Symbol(:legend_font_, k)))
     sp.attr[:legend_font] = font(default(plotattributes_in, :legend_font);
-        f_attr...
+        merge(f_attr, match_attr)...
     )
 end
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -246,6 +246,7 @@ function font(args...; kw...)
 
     for arg in args
         T = typeof(arg)
+        @assert arg !== :match
 
         if T == Font
             family = arg.family
@@ -269,12 +270,12 @@ function font(args...; kw...)
             catch
                 family = string(arg)
             end
-        elseif typeof(arg) <: Integer
+        elseif T <: Integer
             pointsize = arg
-        elseif typeof(arg) <: Real
+        elseif T <: Real
             rotation = convert(Float64, arg)
         else
-            @warn "Unused font arg: $arg ($(typeof(arg)))"
+            @warn "Unused font arg: $arg ($T)"
         end
     end
 

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -262,8 +262,8 @@ function _subplot_setup(plt::Plot, plotattributes::AKW, kw_list::Vector{KW})
         else
             get(sp_attrs, sp, KW())
         end
-        _update_subplot_args(plt, sp, attr, idx, false)
         _update_subplot_legend(sp, attr)
+        _update_subplot_args(plt, sp, attr, idx, false)
     end
 
     # do we need to link any axes together?

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -262,8 +262,8 @@ function _subplot_setup(plt::Plot, plotattributes::AKW, kw_list::Vector{KW})
         else
             get(sp_attrs, sp, KW())
         end
-        _update_subplot_legend(sp, attr)
         _update_subplot_args(plt, sp, attr, idx, false)
+        _update_subplot_legend(sp, attr)
     end
 
     # do we need to link any axes together?

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -263,6 +263,7 @@ function _subplot_setup(plt::Plot, plotattributes::AKW, kw_list::Vector{KW})
             get(sp_attrs, sp, KW())
         end
         _update_subplot_args(plt, sp, attr, idx, false)
+        _update_subplot_legend(sp, attr)
     end
 
     # do we need to link any axes together?

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -994,14 +994,7 @@ titlefont(sp::Subplot) = font(;
     color = sp[:titlefontcolor],
 )
 
-legendfont(sp::Subplot) = font(;
-    family = sp[:legend_font_family],
-    pointsize = sp[:legend_font_pointsize],
-    valign = sp[:legend_font_valign],
-    halign = sp[:legend_font_halign],
-    rotation = sp[:legend_font_rotation],
-    color = sp[:legend_font_color],
-)
+legendfont(sp::Subplot) = sp[:legend_font]
 
 legendtitlefont(sp::Subplot) = font(;
     family = sp[:legend_title_font_family],

--- a/test/test_defaults.jl
+++ b/test/test_defaults.jl
@@ -67,4 +67,7 @@ end # testset
     @test p[1][:legend_title_font_color] == :blue
     @test p[1][:legend_background_color] == RGBA{Float64}(0.0, 1.0, 1.0, 1.0)
     @test p[1][:legend_foreground_color] == RGBA{Float64}(0.0, 0.5019607843137255, 0.0, 1.0)
+
+    #setting whole font
+    @test plot(1:5, legendfont=font(12))[1][:legend_font_pointsize] == 12
 end # testset

--- a/test/test_defaults.jl
+++ b/test/test_defaults.jl
@@ -6,7 +6,7 @@ Plots.__init__()
 @testset "Loading theme" begin
     pl = plot(1:5)
     @test pl[1][1][:seriescolor] == RGBA(colorant"black")
-    @test guidefont(pl[1][:xaxis]).family == "palantino"
+    @test Plots.guidefont(pl[1][:xaxis]).family == "palantino"
 end
 
 empty!(PLOTS_DEFAULTS)
@@ -69,5 +69,10 @@ end # testset
     @test p[1][:legend_foreground_color] == RGBA{Float64}(0.0, 0.5019607843137255, 0.0, 1.0)
 
     #setting whole font
-    @test plot(1:5, legendfont=font(12))[1][:legend_font_pointsize] == 12
+    sp = plot(1:5, legendfont=font(12), legend_font_halign = :left, foreground_color_subplot = :red)[1]
+    @test Plots.legendfont(sp).pointsize == 12
+    @test Plots.legendfont(sp).halign == :left
+    # match mechanism
+    @test sp[:legend_font_color] == sp[:foreground_color_subplot]
+    @test Plots.legendfont(sp).color == sp[:foreground_color_subplot]
 end # testset


### PR DESCRIPTION
Reported on slack (https://julialang.slack.com/archives/C6E4SU1D3/p1636254485054400) https://github.com/JuliaPlots/Plots.jl/pull/2854 broke setting the legend font via `plot(1:5, legendfont = font(8))`

Furthermore this makes `sp[:legend_font]` the single point of truth for the legend font properties, since having both `sp[:legend_font]` and e.g. `sp[:legend_font_color]` is a bit dangerous since they can get out of sync pretty easily especially with property matching and so forth.. In the future we should remove them entirely from the subplot attributes. 