### PR TITLE
GR margin 0-point set to allow no padding

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -780,10 +780,10 @@ function _update_min_padding!(sp::Subplot{GRBackend})
         end
     end
     # Add margin given by the user
-    leftpad   = 2mm + sp[:left_margin]
-    toppad    = 2mm + sp[:top_margin]
-    rightpad  = 2mm + sp[:right_margin]
-    bottompad = 2mm + sp[:bottom_margin]
+    leftpad   = sp[:left_margin] == :match ? 2mm : sp[:left_margin]
+    toppad    = sp[:top_margin] == :match ? 2mm : sp[:top_margin]
+    rightpad  = sp[:right_margin] == :match ? 2mm : sp[:right_margin]
+    bottompad = sp[:bottom_margin] == :match ? 2mm : sp[:bottom_margin]
     # Add margin for title
     if sp[:title] != ""
         gr_set_font(titlefont(sp), sp)


### PR DESCRIPTION
Currently, a 2mm pad is added to all plots, and the user-provided margin is added to it.

I propose that the 0-point for margins should be the box where all ink is visible and no larger. If a user wants no padding, `0mm` is the natural choice to indicate that.

This change makes the user-provided margins override the default, rather than add to it.

Borderless plots can be generated with: `plot([1, 2, 3], [5, 3, 6], widen = false, axis = false, ticks = false, margin=0(Plots.mm))`