### PR TITLE
Fix annotations getting drawn under markers in pgfplotsx backend

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -162,6 +162,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 "anchor" => "north west",
                 "xshift" => string(dx),
                 "yshift" => string(-dy),
+                "clip mode" => "individual",
             )
             sp_width > 0 * mm ? push!(axis_opt, "width" => string(axis_width)) : nothing
             sp_height > 0 * mm ? push!(axis_opt, "height" => string(axis_height)) : nothing
@@ -1055,7 +1056,11 @@ function pgfx_add_annotation!(
     push!(
         o,
         join([
-            "\\node",
+            raw"""
+            \begin{scope}
+                \clip \pgfextra{\pgfplotspathaxisoutline};
+                \node
+            """,
             sprint(
                 PGFPlotsX.print_tex,
                 merge(
@@ -1074,6 +1079,7 @@ function pgfx_add_annotation!(
                 ),
             ),
             string(" at (", cs, x, ",", y, ") {", val.str, "};"),
+            "\\end{scope}",
         ]),
     )
 end


### PR DESCRIPTION
When adding annotations to a scatter plot, the annotations get drawn under the markers.
I added the option `clip mode = individual` to fix this.

![annotation](https://user-images.githubusercontent.com/86314678/143618253-d3a8795a-7acf-4a8b-a0d2-21b4867888d8.png)