### PR TITLE
Upgrade plotly.js to v2.6.3

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -203,7 +203,7 @@ import RecipesPipeline:
 
 # Use fixed version of Plotly instead of the latest one for stable dependency
 # Ref: https://github.com/JuliaPlots/Plots.jl/pull/2779
-const _plotly_min_js_filename = "plotly-1.57.1.min.js"
+const _plotly_min_js_filename = "plotly-2.6.3.min.js"
 
 include("types.jl")
 include("utils.jl")

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1078,10 +1078,10 @@ function plotly_html_body(plt, style = nothing)
         requirejs_prefix = """
             requirejs.config({
                 paths: {
-                    Plotly: '$(plotly_no_ext)'
+                    Plotly2: '$(plotly_no_ext)'
                 }
             });
-            require(['Plotly'], function (Plotly) {
+            require(['Plotly2'], function (Plotly2) {
         """
         requirejs_suffix = "});"
     end
@@ -1100,8 +1100,7 @@ end
 
 function js_body(plt::Plot, uuid)
     js = """
-        var PLOT = document.getElementById('$(uuid)');
-        Plotly.plot(PLOT, $(plotly_series_json(plt)), $(plotly_layout_json(plt)));
+        Plotly2.newPlot('$(uuid)', $(plotly_series_json(plt)), $(plotly_layout_json(plt)));
     """
 end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1013,8 +1013,9 @@ function plotly_polar!(plotattributes_out::KW, series::Series)
     # convert polar plots x/y to theta/radius
     if ispolar(series[:subplot])
         theta, r = pop!(plotattributes_out, :x), pop!(plotattributes_out, :y)
-        plotattributes_out[:t] = rad2deg.(theta)
+        plotattributes_out[:theta] = rad2deg.(theta)
         plotattributes_out[:r] = r
+        plotattributes_out[:type] = :scatterpolar
     end
 end
 


### PR DESCRIPTION
[Announcing Plotly.js 2.0!](https://community.plotly.com/t/announcing-plotly-js-2-0/53675)

# Changes in this pr
1. Change version of plotly.js from 1.57.1 to 2.6.3
2. Use `Plotly.newPlot()` instead of the `Plotly.plot()` function which has been deprecated/under-documented for years and deleted in v2.x.x
3. The legacy polar r and t attributes of the otherwise-cartesian scatter and bar traces: these attributes have been marked as deprecated and un/under-documented for years and deleted in v2.x.x; the **scatterpolar** and barpolar trace types should be used instead.

# Test result
```sh
$ julia test/test_plotly.jl 
Test Summary: | Pass  Total
Plotly        |   14     14
```
# Bugs fixed
Because there is no enough test for Plotly(JS), I checked some bug about them.

## Fixed bugs duplicated in current version
- fix #3826
- fix #3203
- fix #2642
- fix #3768

## Bugs not duplicated in either current version or pr version, so fix them
- fix #2831 (also fixed in gr)
- fix #1887
- fix #2412
- #3945 (not marked as fixed due to duplicated in gr)
- fix #1555
- fix #1410
- fix #1013
- fix #912
- fix #606
- fix #2992
- fix #2887
- fix #846