### PR TITLE
Fix #3967 Pluto white plot

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1079,10 +1079,10 @@ function plotly_html_body(plt, style = nothing)
         requirejs_prefix = """
             requirejs.config({
                 paths: {
-                    Plotly2: '$(plotly_no_ext)'
+                    Plotly: '$(plotly_no_ext)'
                 }
             });
-            require(['Plotly2'], function (Plotly2) {
+            require(['Plotly'], function (Plotly) {
         """
         requirejs_suffix = "});"
     end
@@ -1101,7 +1101,7 @@ end
 
 function js_body(plt::Plot, uuid)
     js = """
-        Plotly2.newPlot('$(uuid)', $(plotly_series_json(plt)), $(plotly_layout_json(plt)));
+        Plotly.newPlot('$(uuid)', $(plotly_series_json(plt)), $(plotly_layout_json(plt)));
     """
 end
 


### PR DESCRIPTION
Bug cause:  
In JS code, we use variable of `Plotly` to ref the `plotly.js` lib, this variable has different sources in different environments.
- IJulia: use `require.js` to load `plotly.js`
- Pluto: directly use the `plotly.js`

When updating the `plotly.js` to v2.x.x, I changed the variable name loaded by `required.js` to `Plotly2` which is not the original name in `plotly.js`. So failed in Pluto.

fix #3967 