### PR TITLE
Use Unzip.unzip

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,8 +31,9 @@ Showoff = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-UnicodeFun = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+UnicodeFun = "1cfade01-22cf-5700-b092-accc4b62d6e1"
+Unzip = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"
 
 [compat]
 Contour = "0.5"
@@ -55,6 +56,7 @@ Showoff = "0.3.1, 1.0"
 StatsBase = "0.32 - 0.33"
 UnicodeFun = "0.4"
 UnicodePlots = "2.4"
+Unzip = "0.1"
 julia = "1.6"
 
 [extras]

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -19,7 +19,7 @@ const _current_plots_version = VersionNumber(
 using Reexport
 
 import GeometryBasics
-using Dates, Printf, Statistics, Base64, LinearAlgebra, Random
+using Dates, Printf, Statistics, Base64, LinearAlgebra, Random, Unzip
 using SparseArrays
 
 using FFMPEG
@@ -196,7 +196,6 @@ import RecipesPipeline:
     pop_kw!,
     scale_func,
     inverse_scale_func,
-    unzip,
     dateformatter,
     datetimeformatter,
     timeformatter

--- a/src/components.jl
+++ b/src/components.jl
@@ -43,13 +43,7 @@ vertices(shape::Shape) = collect(zip(shape.x, shape.y))
 "return the vertex points from a Shape or Segments object"
 coords(shape::Shape) = shape.x, shape.y
 
-#coords(shapes::AVec{Shape}) = unzip(map(coords, shapes))
-function coords(shapes::AVec{<:Shape})
-    c = map(coords, shapes)
-    x = [q[1] for q in c]
-    y = [q[2] for q in c]
-    x, y
-end
+coords(shapes::AVec{<:Shape}) = unzip(map(coords, shapes))
 
 "get an array of tuples of points on a circle with radius `r`"
 partialcircle(start_θ, end_θ, n = 20, r = 1) =

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -305,11 +305,9 @@ function heatmap_edges(
     ismidpoints = prod(z_size) == (ny * nx)
     isedges = z_size == (ny - 1, nx - 1)
     if !ismidpoints && !isedges
-        error(
-            """Length of x & y does not match the size of z.
-              Must be either `size(z) == (length(y), length(x))` (x & y define midpoints)
-              or `size(z) == (length(y)+1, length(x)+1))` (x & y define edges).""",
-        )
+        error("""Length of x & y does not match the size of z.
+                Must be either `size(z) == (length(y), length(x))` (x & y define midpoints)
+                or `size(z) == (length(y)+1, length(x)+1))` (x & y define edges).""")
     end
     x, y = heatmap_edges(x, xscale, isedges), heatmap_edges(y, yscale, isedges, ispolar) # special handle for `r` in polar plots
     return x, y

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -215,20 +215,10 @@ makevec(v::T) where {T} = T[v]
 maketuple(x::Real) = (x, x)
 maketuple(x::Tuple{T,S}) where {T,S} = x
 
-for i in 2:4
-    @eval begin
-        RecipesPipeline.unzip(
-            v::Union{AVec{<:NTuple{$i,T} where {T}},AVec{<:GeometryBasics.Point{$i}}},
-        ) = $(Expr(:tuple, (:([t[$j] for t in v]) for j in 1:i)...))
-    end
-end
-
-RecipesPipeline.unzip(
-    ::Union{AVec{<:GeometryBasics.Point{N}},AVec{<:NTuple{N,T} where {T}}},
-) where {N} = error("$N-dimensional unzip not implemented.")
-
-RecipesPipeline.unzip(::Union{AVec{<:GeometryBasics.Point},AVec{<:Tuple}}) =
-    error("Can't unzip points of different dimensions.")
+RecipesPipeline.unzip(v) = unzip(v)
+RecipesPipeline.unzip(points::AbstractVector{<:GeometryBasics.Point}) = unzip(Tuple.(points))
+RecipesPipeline.unzip(points::AbstractVector{GeometryBasics.Point{N,T}}) where {N,T} =
+    isbitstype(T) && sizeof(T) > 0 ? unzip(reinterpret(NTuple{N,T}, points)) : unzip(Tuple.(points))
 
 # given 2-element lims and a vector of data x, widen lims to account for the extrema of x
 function _expand_limits(lims, x)
@@ -315,9 +305,11 @@ function heatmap_edges(
     ismidpoints = prod(z_size) == (ny * nx)
     isedges = z_size == (ny - 1, nx - 1)
     if !ismidpoints && !isedges
-        error("""Length of x & y does not match the size of z.
-                Must be either `size(z) == (length(y), length(x))` (x & y define midpoints)
-                or `size(z) == (length(y)+1, length(x)+1))` (x & y define edges).""")
+        error(
+            """Length of x & y does not match the size of z.
+              Must be either `size(z) == (length(y), length(x))` (x & y define midpoints)
+              or `size(z) == (length(y)+1, length(x)+1))` (x & y define edges).""",
+        )
     end
     x, y = heatmap_edges(x, xscale, isedges), heatmap_edges(y, yscale, isedges, ispolar) # special handle for `r` in polar plots
     return x, y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,8 +190,8 @@ end
         [(missing, missing, missing), ("a", "b", "c")],
     )
     for z in zipped
-        @test isequal(collect(zip(Plots.unzip(z)...)), z)
-        @test isequal(collect(zip(Plots.unzip(GeometryBasics.Point.(z))...)), z)
+        @test isequal(collect(zip(Plots.RecipesPipeline.unzip(z)...)), z)
+        @test isequal(collect(zip(Plots.RecipesPipeline.unzip(GeometryBasics.Point.(z))...)), z)
     end
     op1 = Plots.process_clims((1.0, 2.0))
     op2 = Plots.process_clims((1, 2.0))


### PR DESCRIPTION
Replaces the in-house implementation of `unzip` with the `Unzip` package.
Since `Unzip` doesn't (and arguably shouldn't) support unzipping `GeometryBasics.Point` vectors, I keep `RecipesPipeline.unzip` which adds support for `Point`s to `Unzip.unzip`.
Besides avoiding the duplicate functionality, this has the practical advantage of working around timholy/Revise.jl#607.
