### PR TITLE
Fix fillranges with OffsetVectors for plotly

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -940,15 +940,18 @@ function plotly_series_segments(series::Series, plotattributes_base::KW, x, y, z
             plotattributes_out_fillrange[:showlegend] = false
             # if fillrange is provided as real or tuple of real, expand to array
             if typeof(series[:fillrange]) <: Real
-                series[:fillrange] = fill(series[:fillrange], length(rng))
+                plotattributes_out[:fillrange] = fill(series[:fillrange], length(rng))
             elseif typeof(series[:fillrange]) <: Tuple
+                @show rng
+                @show typeof(series[:fillrange][1])
+                @show series[:fillrange][1]
                 f1 =
                     typeof(series[:fillrange][1]) <: Real ?
                     fill(series[:fillrange][1], length(rng)) : series[:fillrange][1][rng]
                 f2 =
                     typeof(series[:fillrange][2]) <: Real ?
                     fill(series[:fillrange][2], length(rng)) : series[:fillrange][2][rng]
-                series[:fillrange] = (f1, f2)
+                plotattributes_out[:fillrange] = (f1, f2)
             end
             if isa(series[:fillrange], AbstractVector)
                 plotattributes_out_fillrange[:y] = series[:fillrange][rng]

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -942,9 +942,6 @@ function plotly_series_segments(series::Series, plotattributes_base::KW, x, y, z
             if typeof(series[:fillrange]) <: Real
                 plotattributes_out[:fillrange] = fill(series[:fillrange], length(rng))
             elseif typeof(series[:fillrange]) <: Tuple
-                @show rng
-                @show typeof(series[:fillrange][1])
-                @show series[:fillrange][1]
                 f1 =
                     typeof(series[:fillrange][1]) <: Real ?
                     fill(series[:fillrange][1], length(rng)) : series[:fillrange][1][rng]

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -962,9 +962,9 @@ const _examples = PlotExample[
         """
         Allows to plot arbitrary 3d meshes. If only x,y,z are given the mesh is generated automatically.
         You can also specify the connections using the connections keyword.
-        The connections can be specified in two ways: Either as a tuple of vectors where each vector 
-        contains the 0-based indices of one point of a triangle, such that elements at the same 
-        position of these vectors form a triangle. Or as a vector of NTuple{3,Ints} where each element 
+        The connections can be specified in two ways: Either as a tuple of vectors where each vector
+        contains the 0-based indices of one point of a triangle, such that elements at the same
+        position of these vectors form a triangle. Or as a vector of NTuple{3,Ints} where each element
         contains the 1-based indices of the three points of a triangle.
         """,
         [
@@ -1235,7 +1235,7 @@ const _examples = PlotExample[
     PlotExample( # 56
         "Bar plot customizations",
         """
-        Width of bars may be specified as `bar_width`. 
+        Width of bars may be specified as `bar_width`.
         The bars' baseline may be specified as `fillto`.
         Each may be scalar, or a vector spcifying one value per bar.
         """,
@@ -1271,7 +1271,7 @@ _animation_examples = [2, 31]
 _backend_skips = Dict(
     :gr => [25, 30],
     :pyplot => [2, 25, 30, 31, 49, 55, 56],
-    :plotlyjs => [2, 21, 24, 25, 30, 31, 49, 51, 55, 56],
+    :plotlyjs => [2, 21, 24, 25, 30, 31, 49, 50, 51, 55, 56],
     :pgfplotsx => [
         2,  # animation
         6,  # images

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -432,9 +432,9 @@ end
 
 #turn tuple of fillranges to one path
 function concatenate_fillrange(x, y::Tuple)
-    rib1, rib2 = first(y), last(y)
-    yline = vcat(rib1, (rib2)[end:-1:1])
-    xline = vcat(x, x[end:-1:1])
+    rib1, rib2 = collect(first(y)), collect(last(y)) # collect needed until https://github.com/JuliaLang/julia/pull/37629 is merged
+    yline = vcat(rib1, reverse(rib2))
+    xline = vcat(x, reverse(x))
     return xline, yline
 end
 


### PR DESCRIPTION
Since the backend was mutating the Plot object indices got out of sync

came up in https://github.com/JuliaPlots/PlotDocs.jl/pull/256
would be easier with https://github.com/JuliaLang/julia/pull/37629