### PR TITLE
Set max_methods=1

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -3,6 +3,9 @@ module Plots
 if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
     @eval Base.Experimental.@optlevel 1
 end
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_methods"))
+    @eval Base.Experimental.@max_methods 1
+end
 
 const _current_plots_version = VersionNumber(
     split(


### PR DESCRIPTION
See [here](https://github.com/JuliaLang/julia/pull/43370) for more information.
Benchmarks, latest release (or perhaps master? I don't recall):
```julia
julia> using Plots, SnoopCompile, BenchmarkTools

julia> tinf = @snoopi_deep plot(1:10, 1:10)
InferenceTimingNode: 2.085727/12.130569 on Core.Compiler.Timings.ROOT() with 98 direct children

julia> @benchmark plot(1:10, 1:10)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  171.533 μs …   6.345 ms  ┊ GC (min … max): 0.00% … 91.09%
 Time  (median):     177.000 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   187.454 μs ± 173.048 μs  ┊ GC (mean ± σ):  2.97% ±  3.13%

    █▆
  ▂▆██▆▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▁▂▁▂▁▁▁▁▂▁▂▂▁▁▁▁▂▁▁▁▁▁▁▂▁▂▁▁▁▁▁▁▁▁▁▁▁▂▂▃▂ ▂
  172 μs           Histogram: frequency by time          275 μs <

 Memory estimate: 63.12 KiB, allocs estimate: 976.
```
This PR:
```julia
julia> using Plots, SnoopCompile, BenchmarkTools

julia> tinf = @snoopi_deep plot(1:10, 1:10)
InferenceTimingNode: 1.709860/6.303342 on Core.Compiler.Timings.ROOT() with 109 direct children

julia> @benchmark plot(1:10, 1:10)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  226.586 μs …   5.654 ms  ┊ GC (min … max): 0.00% … 92.18%
 Time  (median):     232.976 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   243.641 μs ± 191.944 μs  ┊ GC (mean ± σ):  2.78% ±  3.39%

  ▂▇█▆▅▄▄▃▂▁                                                    ▂
  ███████████▆▅▅▅▅▄▄▄▄▅▄▃▄▄▁▅▁▁▁▄▄▄▁▄▁▁▅▃▄▃▁▁▃▄▁▁▄▄▃▅▃▄▃▃▃▄▅▅▇▇ █
  227 μs        Histogram: log(frequency) by time        378 μs <

 Memory estimate: 63.54 KiB, allocs estimate: 987.
```