### PR TITLE
support `unicodeplots` images - plot in term `ImageInTerminal - Sixel`

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -951,6 +951,7 @@ const _unicodeplots_seriestype = [
     :contour,
     # :contour3d,
     :permute,
+    :image,
     :spy,
     :surface,
     :wireframe,

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -169,7 +169,7 @@ function addUnicodeSeries!(
     elseif st === :spy
         return UnicodePlots.spy(Array(series[:z]); fix_ar = fix_ar, kw...)
     elseif st === :image
-        return UnicodePlots.image(Array(series[:z]); kw...)
+        return UnicodePlots.imageplot(Array(series[:z]); kw...)
     elseif st in (:contour, :heatmap)  # 2D
         colormap = get(se_kw, :colormap, :none)
         kw = (

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -168,6 +168,8 @@ function addUnicodeSeries!(
         return UnicodePlots.densityplot(x, y; kw...)
     elseif st === :spy
         return UnicodePlots.spy(Array(series[:z]); fix_ar = fix_ar, kw...)
+    elseif st === :image
+        return UnicodePlots.image(Array(series[:z]); kw...)
     elseif st in (:contour, :heatmap)  # 2D
         colormap = get(se_kw, :colormap, :none)
         kw = (

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1342,7 +1342,6 @@ _backend_skips = Dict(
     :inspectdr => [4, 6, 10, 22, 24, 28, 30, 38, 43, 45, 47, 48, 49, 50, 51, 55, 56],
     :unicodeplots => [
         5,  # limits issue
-        6,  # embedded images unsupported
         16,  # nested layout unsupported
         21,  # custom markers unsupported
         26,  # nested layout unsupported
@@ -1354,7 +1353,7 @@ _backend_skips = Dict(
         43,  # heatmap with DateTime
         45,  # error bars
         49,  # polar heatmap
-        51,  # embedded images unsupported
+        51,  # drawing on top of image unsupported
         55,  # mirror unsupported, resolution too low
         56,  # barplots
     ],

--- a/src/init.jl
+++ b/src/init.jl
@@ -106,13 +106,12 @@ function __init__()
     use_local_dependencies[] = use_local_plotlyjs[]
 
     @require ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254" begin
-        if (
-            get(ENV, "PLOTS_IMAGE_IN_TERMINAL", "true") == "true" &&
-            ImageInTerminal.Sixel.is_sixel_supported()
-        )
+        if get(ENV, "PLOTS_IMAGE_IN_TERMINAL", "true") == "true" &&
+           ImageInTerminal.ENCODER_BACKEND[] == :Sixel
+            get!(ENV, "GKSwstype", "nul")  # disable `gr` output, we display in the terminal instead
             for be in (
                 PyPlotBackend,
-                # UnicodePlotsBackend,  # better as MIME("text/plain") in terminal
+                # UnicodePlotsBackend,  # better and faster as MIME("text/plain") in terminal
                 PlotlyJSBackend,
                 GRBackend,
                 PGFPlotsXBackend,

--- a/src/init.jl
+++ b/src/init.jl
@@ -119,20 +119,15 @@ function __init__()
                 InspectDRBackend,
                 GastonBackend,
             )
-                # showable(MIME("image/png"), Plot{be}) || continue  # will only work for currently loaded backends
-                @eval function _display(plt::Plot{$be})
-                    I = findfirst(
-                        d -> d isa ImageInTerminal.TerminalGraphicDisplay,
-                        Base.Multimedia.displays,
-                    )
-                    dsp = if I === nothing
-                        ImageInTerminal.TerminalGraphicDisplay(stdout)
-                    else
-                        Base.Multimedia.displays[I]
-                    end
-                    buf = IOBuffer()
+                @eval function Base.display(::PlotsDisplay, plt::Plot{$be})
+                    prepare_output(plt)
+                    buf = PipeBuffer()
                     show(buf, MIME("image/png"), plt)
-                    display(dsp, MIME("image/png"), take!(buf))
+                    display(
+                        ImageInTerminal.TerminalGraphicDisplay(stdout),
+                        MIME("image/png"),
+                        read(buf),
+                    )
                 end
             end
         end

--- a/src/output.jl
+++ b/src/output.jl
@@ -224,7 +224,7 @@ for mime in (
             showjuno(io, m, plt)
         else
             prepare_output(plt)
-            _show(io, m, plt)
+            Base.invokelatest(_show, io, m, plt)
         end
         return nothing
     end

--- a/src/output.jl
+++ b/src/output.jl
@@ -200,7 +200,8 @@ function _show(io::IO, ::MIME"text/html", plt::Plot)
 end
 
 # delegate showable to _show instead
-Base.showable(m::M, plt::P) where {M<:MIME,P<:Plot} = hasmethod(_show, Tuple{IO,M,P})
+Base.showable(m::M, ::P) where {M<:MIME,P<:Plot} = showable(m, P)
+Base.showable(::M, ::Type{P}) where {M<:MIME,P<:Plot} = hasmethod(_show, Tuple{IO,M,P})
 
 _display(plt::Plot) = @warn("_display is not defined for this backend.")
 


### PR DESCRIPTION
Complements https://github.com/JuliaPlots/UnicodePlots.jl/pull/196.

Example [^1] :
[^1]: for sixel support, code snippet must be ran under a [compatible terminal](https://github.com/johnnychen94/Sixel.jl#terminals-that-support-sixel).

```julia
using ImageInTerminal
using TestImages, Plots

main() = begin
  img = testimage("mandril_color")
  unicodeplots(); display(plot(img, title="mandril - unicodeplots"))
  gr(); display(plot(img, title="mandril - gr"))
  return
end

main()
```

**mlterm**
![mandril_sixel](https://user-images.githubusercontent.com/13423344/188312522-5eb7b126-2cae-40d0-9d0d-9d20024c1984.png)

Also fixes https://github.com/JuliaPlots/Plots.jl/issues/1263, when using `UnicodePlots` backend, since it currently fails (`:image` series unsupported) with the rather cryptic error (`Plots` is trying to use the `heatmap` recipe instead):
```julia
julia> using Plots, Images; unicodeplots()
julia> img = colorview(RGB, rand(3, 100,100))
julia> show(plot(img))
ERROR: MethodError: no method matching replace_image_with_heatmap(::Base.ReinterpretArray{RGB{Float64}, 2, Float64, Array{Float64, 3}, true})
Closest candidates are:
  replace_image_with_heatmap(::Array{T}) where T<:Colorant at [...]/.julia/packages/Plots/FCM0H/src/utils.jl:6
Stacktrace:
 [1] macro expansion
   @ [...]/.julia/packages/Plots/FCM0H/src/recipes.jl:1412 [inlined]
 [2] apply_recipe(plotattributes::AbstractDict{Symbol, Any}, mat::Base.ReinterpretArray{RGB{Float64}, 2, Float64, Array{Float64, 3}, true})
   @ Plots [...]/.julia/packages/RecipesBase/qpxEX/src/RecipesBase.jl:289
 [3] _process_userrecipes!(plt::Any, plotattributes::Any, args::Any)
   @ RecipesPipeline [...]/.julia/packages/RecipesPipeline/Bxu2O/src/user_recipe.jl:36
 [4] recipe_pipeline!(plt::Any, plotattributes::Any, args::Any)
   @ RecipesPipeline [...]/.julia/packages/RecipesPipeline/Bxu2O/src/RecipesPipeline.jl:70
 [5] _plot!(plt::Plots.Plot, plotattributes::Any, args::Any)
   @ Plots [...]/.julia/packages/Plots/FCM0H/src/plot.jl:208
 [6] plot(args::Any; kw::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})
   @ Plots [...]/.julia/packages/Plots/FCM0H/src/plot.jl:91
 [7] plot(args::Any)
   @ Plots [...]/.julia/packages/Plots/FCM0H/src/plot.jl:85
 [8] top-level scope
   @ REPL[7]:1
```

Fix https://github.com/JuliaPlots/UnicodePlots.jl/issues/153 (display of plots in terminal when `ImageInTerminal` is loaded before `Plots`).
Fix https://github.com/JuliaImages/ImageInTerminal.jl/issues/55.