### PR TITLE
[GR] Better legend marker size scaling

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1104,10 +1104,10 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                     ms = first(series[:markersize])
                     msw = first(series[:markerstrokewidth])
                     s, sw = if ms > 0
-                        0.8 * sp[:legend_font_pointsize],
-                        0.8 * sp[:legend_font_pointsize] * msw / ms
+                        0.4 * sp[:legend_font_pointsize],
+                        0.4 * sp[:legend_font_pointsize] * msw / ms
                     else
-                        0, 0.8 * sp[:legend_font_pointsize] * msw / 8
+                        0, 0.4 * sp[:legend_font_pointsize] * msw / 8
                     end
                     gr_draw_markers(series, xpos - leg.width_factor * 2, ypos, clims, s, sw)
                 end


### PR DESCRIPTION
Default marker size in the legend is too big for the legend font size.
Reducing scaling by half makes it to scale nicely with :legend_font_pointsize