### PR TITLE
Check if plot title already exists before adding again

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -277,26 +277,35 @@ end
 
 function _add_plot_title!(plt)
     plot_title = plt[:plot_title]
+
     if plot_title != ""
-        the_layout = plt.layout
-        vspan = plt[:plot_titlevspan]
-        plt.layout = grid(2, 1, heights = (vspan, 1 - vspan))
-        plt.layout.grid[1, 1] = subplot = Subplot(plt.backend, parent = plt.layout[1, 1])
-        plt.layout.grid[2, 1] = the_layout
-        subplot.plt = plt
+        # make new subplot for plot title
+        if plt[:plot_titleindex] == 0
+            the_layout = plt.layout
+            vspan = plt[:plot_titlevspan]
+            plt.layout = grid(2, 1, heights = (vspan, 1 - vspan))
+            plt.layout.grid[1, 1] = subplot = Subplot(plt.backend, parent = plt.layout[1, 1])
+            plt.layout.grid[2, 1] = the_layout
+            subplot.plt = plt
+
+            top = plt.backend isa PyPlotBackend ? nothing : 0mm
+            bot = 0mm
+            plt[:force_minpad] = nothing, top, nothing, bot
+            subplot[:subplot_index] = last(plt.subplots)[:subplot_index] + 1
+            plt[:plot_titleindex] = subplot[:subplot_index]
+            subplot[:framestyle] = :none
+            subplot[:margin] = 0px
+            push!(plt.subplots, subplot)
+        end
+
         # propagate arguments plt[:plot_titleXXX] --> subplot[:titleXXX]
+        plot_titleindex = plt[:plot_titleindex]
+        subplot = plt.subplots[plot_titleindex]
         for sym in filter(x -> startswith(string(x), "plot_title"), keys(_plot_defaults))
             subplot[Symbol(string(sym)[(length("plot_") + 1):end])] = plt[sym]
         end
-        top = plt.backend isa PyPlotBackend ? nothing : 0mm
-        bot = 0mm
-        plt[:force_minpad] = nothing, top, nothing, bot
-        subplot[:subplot_index] = last(plt.subplots)[:subplot_index] + 1
-        plt[:plot_titleindex] = subplot[:subplot_index]
-        subplot[:framestyle] = :none
-        subplot[:margin] = 0px
-        push!(plt.subplots, subplot)
     end
+
     return nothing
 end
 

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -11,3 +11,17 @@ using Plots, Test
     @test pl[3][:yaxis][:scale] == :log10
     @test pl[4][:yaxis][:scale] == :log10
 end
+
+@testset "Plot title" begin
+    pl = plot(rand(4, 8), layout = 4, plot_title = "My title")
+    @test pl[:plot_title] == "My title"
+    @test pl[:plot_titleindex] == 5
+
+    plot!(pl)
+    @test pl[:plot_title] == "My title"
+    @test pl[:plot_titleindex] == 5
+
+    plot!(pl, plot_title = "My new title")
+    @test pl[:plot_title] == "My new title"
+    @test pl[:plot_titleindex] == 5
+end


### PR DESCRIPTION
I noticed that `_add_plot_title!` doesn't check if a plot title already exists before adding a new plot title.

Old behavior:
```julia
using Plots
data = rand(10,4)
p = plot(data; layout = grid(2,2), plot_title = "My title here")
plot!(p)
```
![two_titles](https://user-images.githubusercontent.com/6033297/148857802-17a27610-7180-4b3f-8989-16a82369ad9b.png)

New behavior:
![one_title](https://user-images.githubusercontent.com/6033297/148857845-565d8d4e-6a7b-42ec-a357-19f7042e0215.png)
