### PR TITLE
UnicodePlots: basic `quiver` and `contour` support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -55,7 +55,7 @@ Scratch = "1"
 Showoff = "0.3.1, 1.0"
 StatsBase = "0.32 - 0.33"
 UnicodeFun = "0.4"
-UnicodePlots = "2.4"
+UnicodePlots = "2.6"
 Unzip = "0.1"
 julia = "1.6"
 

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -973,10 +973,10 @@ const _unicodeplots_marker = [
 const _unicodeplots_scale = [:identity, :ln, :log2, :log10]
 
 # Additional constants
-const _unicodeplots_canvas = Ref(:auto)
-const _unicodeplots_border = Ref(:auto)
-const _unicodeplots_height = Ref(15)
-const _unicodeplots_width = Ref(40)
+const _up_colormap = Ref(:none)
+const _up_canvas = Ref(:auto)
+const _up_border = Ref(:auto)
+const _up_fix_ar = Ref(true)
 
 # ------------------------------------------------------------------------------
 # hdf5

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -923,6 +923,8 @@ const _unicodeplots_attr = merge_with_base_supported([
     :linecolor,
     :linestyle,
     :markershape,
+    :quiver,
+    :arrow,
     :seriesalpha,
     :seriescolor,
     :scale,

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -938,6 +938,7 @@ const _unicodeplots_seriestype = [
     :shape,
     :histogram2d,
     :heatmap,
+    :contour,
     :spy,
 ]
 const _unicodeplots_style = [:auto, :solid]

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -88,6 +88,11 @@ up_color(col::RGBA) =
     (c = convert(ARGB32, col); map(Int, (red(c).i, green(c).i, blue(c).i)))
 up_color(col) = :auto
 
+function up_cmap(series)
+    rng = range(0, 1, length = length(UnicodePlots.COLOR_MAP_DATA[:viridis]))
+    [(red(c), green(c), blue(c)) for c in get(get_colorgradient(series), rng)]
+end
+
 # add a single series
 function addUnicodeSeries!(
     sp::Subplot{UnicodePlotsBackend},
@@ -112,16 +117,19 @@ function addUnicodeSeries!(
         kw[:xlim][:] .= kw[:ylim][:] .= 0
         return UnicodePlots.densityplot(x, y; kw...)
     elseif st == :heatmap
-        rng = range(0, 1, length = length(UnicodePlots.COLOR_MAP_DATA[:viridis]))
-        cmap = [(red(c), green(c), blue(c)) for c in get(get_colorgradient(series), rng)]
         return UnicodePlots.heatmap(
             series[:z].surf;
             zlabel = sp[:colorbar_title],
-            colormap = cmap,
+            colormap = up_cmap(series),
             kw...,
         )
     elseif st == :spy
         return UnicodePlots.spy(series[:z].surf; kw...)
+    elseif st == :contour
+        return UnicodePlots.contourplot(
+            x, y, series[:z].surf;
+            levels=series[:levels], colormap = up_cmap(series), kw...
+        )
     end
 
     # now use the ! functions to add to the plot

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -123,11 +123,10 @@ function addUnicodeSeries!(
         return UnicodePlots.spy(series[:z].surf; kw...)
     end
 
-    series_kw = (;)
-
     # now use the ! functions to add to the plot
     if st in (:path, :straightline, :shape)
         func = UnicodePlots.lineplot!
+        series_kw = (; head_tail = series[:arrow] isa Arrow ? series[:arrow].side : nothing)
     elseif st == :scatter || series[:markershape] != :none
         func = UnicodePlots.scatterplot!
         series_kw = (; marker = series[:markershape])

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -51,6 +51,7 @@ function unicodeplots_rebuild(plt::Plot{UnicodePlotsBackend})
             title = texmath2unicode(sp[:title]),
             xlabel = texmath2unicode(xaxis[:guide]),
             ylabel = texmath2unicode(yaxis[:guide]),
+            grid = xaxis[:grid] && yaxis[:grid],
             height = _unicodeplots_height[],
             width = _unicodeplots_width[],
             xscale = xaxis[:scale],

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1289,7 +1289,6 @@ _backend_skips = Dict(
         6,  # embedded images unsupported
         16,  # nested layout unsupported
         21,  # custom markers unsupported
-        22,  # contours unsupported
         24,  # 3D unsupported
         26,  # nested layout unsupported
         27,  # polar plots unsupported


### PR DESCRIPTION
Basic `quiver` and `contour` support.

**quiver** (needs https://github.com/JuliaPlots/UnicodePlots.jl/pull/198)
```julia
using Plots; unicodeplots()

main() = begin
  x = range(-2, 2, length=8)
  y = range(-1, 1, length=4)

  X = repeat(x, outer = [1, length(y)])'
  Y = repeat(y, outer = [1, length(x)])

  U = .2(X + Y)
  V = .2(Y - X)

  quiver(X[:], Y[:], quiver=(U[:], V[:])) |> display
  return
end

main()
```

**contour** (needs https://github.com/JuliaPlots/UnicodePlots.jl/pull/199)
```julia
using Plots; unicodeplots()

main() = begin
  x = 1:.5:20
  y = 1:.5:10
  f(x, y) = (3x + y ^ 2) * abs(sin(x) + cos(y))

  X = repeat(x', length(y), 1)
  Y = repeat(y, 1, length(x))
  z = collect(map(f, X, Y))

  contour(x, y, z, c=:grays) |> display
  return
end

main()
```

Example application on a 2D lid driven cavity problem:
![lid](https://user-images.githubusercontent.com/13423344/149526885-fd098db6-b96e-495b-8429-b2109b3037a4.png)

