### PR TITLE
gr-constant-legendbox

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1272,7 +1272,7 @@ function gr_get_legend_geometry(viewport_plotarea, sp)
         GR.restorestate()
     end
 
-    legend_width_factor = (viewport_plotarea[2] - viewport_plotarea[1]) / 45 # Determines the width of legend box
+    legend_width_factor = 0.02
     legend_textw = legendw
     legend_rightw = legend_width_factor
     legend_leftw = legend_width_factor * 4


### PR DESCRIPTION
@BeastyBlacksmith @daschw I tried a few times more, but I consistently get stuck at plotly part of the tests, so I still could not push the relevant RefImages...

```
(Plots) pkg> test
     Testing Plots
┌ Warning: Could not use exact versions of packages in manifest, re-resolving
└ @ Pkg.Operations /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.7/Pkg/src/Operations.jl:1488
      Status `/tmp/jl_oo5khj/Project.toml`
  [5ae59095] Colors v0.12.8
  [d38c429a] Contour v0.5.7
  [31c24e10] Distributions v0.23.8
  [c87230d0] FFMPEG v0.4.1
  [5789e2e9] FileIO v1.12.0
  [53c48c17] FixedPointNumbers v0.8.4
  [28b8d3ca] GR v0.63.1
  [5c1252a2] GeometryBasics v0.3.12
  [4c0ca9eb] Gtk v1.1.11
  [f67ccb44] HDF5 v0.15.7
  [6218d12a] ImageMagick v1.2.2
  [916415d5] Images v0.24.1
  [682c06a0] JSON v0.21.2
  [23fbe1c1] Latexify v0.15.9
  [442fdcdd] Measures v0.3.1
  [77ba4419] NaNMath v0.3.6
  [6fe1bfb0] OffsetArrays v1.10.8
  [8314cec4] PGFPlotsX v1.4.1
  [ccf2f8ad] PlotThemes v2.0.1
  [995b91a9] PlotUtils v1.1.2
  [f0f68f2c] PlotlyJS v0.18.8
  [91a5bcdd] Plots v1.25.6 `~/Software/Plots`
  [ce6b1742] RDatasets v0.7.6
  [3cdcf5f2] RecipesBase v1.2.1
  [01d81517] RecipesPipeline v0.5.0
  [189a3867] Reexport v0.2.0
  [ae029012] Requires v1.3.0
  [6c6a2e73] Scratch v1.1.0
  [992d4aef] Showoff v1.0.3
  [860ef19b] StableRNGs v1.0.0
  [90137ffa] StaticArrays v0.12.5
  [2913bbd2] StatsBase v0.33.14
  [f3b207a7] StatsPlots v0.14.5
  [5e47fb64] TestImages v1.6.2
  [1cfade01] UnicodeFun v0.4.1
  [b8865327] UnicodePlots v2.5.1
  [41fe7b60] Unzip v0.1.2
  [34922c18] VisualRegressionTests v1.1.1
  [2a0f44e3] Base64 `@stdlib/Base64`
  [ade2ca70] Dates `@stdlib/Dates`
  [f43a241f] Downloads `@stdlib/Downloads`
  [76f85450] LibGit2 `@stdlib/LibGit2`
  [37e2e46d] LinearAlgebra `@stdlib/LinearAlgebra`
  [de0858da] Printf `@stdlib/Printf`
  [3fa0cd96] REPL `@stdlib/REPL`
  [9a3f8284] Random `@stdlib/Random`
  [2f01184e] SparseArrays `@stdlib/SparseArrays`
  [10745b16] Statistics `@stdlib/Statistics`
  [8dfed614] Test `@stdlib/Test`
  [cf7118a7] UUIDs `@stdlib/UUIDs`
      Status `/tmp/jl_oo5khj/Manifest.toml`
  [621f4979] AbstractFFTs v1.1.0
  [79e6a3ab] Adapt v3.3.3
  [dce04be8] ArgCheck v2.1.0
  [7d9fca2a] Arpack v0.4.0
  [4fba245c] ArrayInterface v4.0.1
  [bf4720bc] AssetRegistry v0.1.0
  [13072b0f] AxisAlgorithms v1.0.1
  [39de3d68] AxisArrays v0.4.4
  [9e28174c] BinDeps v1.0.2
  [ad839575] Blink v0.12.5
  [a74b3585] Blosc v0.7.2
  [fa961155] CEnum v0.4.1
  [336ed68f] CSV v0.9.11
  [159f3aea] Cairo v1.0.5
  [49dc2e85] Calculus v0.5.1
  [aafaddc9] CatIndices v0.2.2
  [324d7699] CategoricalArrays v0.10.2
  [d360d2e6] ChainRulesCore v1.11.4
  [9e997f8a] ChangesOfVariables v0.1.2
  [aaaa29a8] Clustering v0.14.2
  [944b1d66] CodecZlib v0.7.0
  [35d6a980] ColorSchemes v3.16.0
  [3da002f7] ColorTypes v0.10.12
  [c3611d14] ColorVectorSpace v0.8.7
  [5ae59095] Colors v0.12.8
  [bbf7d656] CommonSubexpressions v0.3.0
  [34da2185] Compat v3.41.0
  [ed09eef8] ComputationalResources v0.3.2
  [d38c429a] Contour v0.5.7
  [150eb455] CoordinateTransformations v0.6.2
  [a8cc5b0e] Crayons v4.1.0
  [dc8bdbbb] CustomUnitRanges v1.0.2
  [9a962f9c] DataAPI v1.9.0
  [a93c6f00] DataFrames v1.3.1
  [864edb3b] DataStructures v0.17.20
  [e2d170a0] DataValueInterfaces v1.0.0
  [e7dc6d0d] DataValues v0.4.13
  [3f0dd361] DefaultApplication v1.0.0
  [01453d9d] DiffEqDiffTools v0.14.0
  [163ba53b] DiffResults v1.0.3
  [b552c78f] DiffRules v1.9.0
  [b4f34e82] Distances v0.10.7
  [31c24e10] Distributions v0.23.8
  [ffbed154] DocStringExtensions v0.8.6
  [fa6b7ba4] DualNumbers v0.6.6
  [da5c29d0] EllipsisNotation v1.3.0
  [e2ba6199] ExprTools v0.1.7
  [c87230d0] FFMPEG v0.4.1
  [4f61f5a4] FFTViews v0.3.2
  [7a1cc6ca] FFTW v1.4.5
  [5789e2e9] FileIO v1.12.0
  [48062228] FilePathsBase v0.9.17
  [1a297f60] FillArrays v0.8.14
  [53c48c17] FixedPointNumbers v0.8.4
  [59287772] Formatting v0.4.2
  [f6369f11] ForwardDiff v0.10.24
  [de31a74c] FunctionalCollections v0.5.0
  [28b8d3ca] GR v0.63.1
  [5c1252a2] GeometryBasics v0.3.12
  [a2bd30eb] Graphics v1.1.1
  [42e2da0e] Grisu v1.0.2
  [4c0ca9eb] Gtk v1.1.11
  [f67ccb44] HDF5 v0.15.7
  [cd3eb016] HTTP v0.9.17
  [9fb69e20] Hiccup v0.2.2
  [bbac6d45] IdentityRanges v0.3.1
  [615f187c] IfElse v0.1.1
  [2803e5a7] ImageAxes v0.6.9
  [c817782e] ImageBase v0.1.4
  [f332f351] ImageContrastAdjustment v0.3.7
  [a09fc81d] ImageCore v0.8.22
  [51556ac3] ImageDistances v0.2.13
  [6a3955dd] ImageFiltering v0.6.21
  [82e4d734] ImageIO v0.5.9
  [6218d12a] ImageMagick v1.2.2
  [bc367c6b] ImageMetadata v0.9.5
  [787d08f9] ImageMorphology v0.2.11
  [2996bd0c] ImageQualityIndexes v0.2.2
  [4e3cecfd] ImageShow v0.3.1
  [02fcd773] ImageTransformations v0.8.13
  [916415d5] Images v0.24.1
  [9b13fd28] IndirectArrays v0.5.1
  [d25df0c9] Inflate v0.1.2
  [83e8ac13] IniFile v0.5.0
  [842dd82b] InlineStrings v1.1.1
  [a98d9a8b] Interpolations v0.12.10
  [8197267c] IntervalSets v0.5.3
  [3587e190] InverseFunctions v0.1.2
  [41ab1584] InvertedIndices v1.1.0
  [92d709cd] IrrationalConstants v0.1.1
  [c8e1da08] IterTools v1.4.0
  [82899510] IteratorInterfaceExtensions v1.0.0
  [692b3bcd] JLLWrappers v1.4.0
  [97c1335a] JSExpr v0.5.3
  [682c06a0] JSON v0.21.2
  [5ab0869b] KernelDensity v0.5.1
  [b964fa9f] LaTeXStrings v1.3.0
  [23fbe1c1] Latexify v0.15.9
  [50d2b5c4] Lazy v0.15.1
  [d3d80556] LineSearches v7.1.1
  [2ab3a3ac] LogExpFunctions v0.3.6
  [1914dd2f] MacroTools v0.5.9
  [dbb5928d] MappedArrays v0.4.1
  [739be429] MbedTLS v1.0.3
  [442fdcdd] Measures v0.3.1
  [e1d29d7a] Missings v1.0.2
  [78c3b35d] Mocking v0.7.3
  [e94cdb99] MosaicViews v0.3.3
  [6f286f6a] MultivariateStats v0.7.0
  [ffc61752] Mustache v1.0.12
  [a975b10e] Mux v0.7.6
  [d41bc354] NLSolversBase v7.5.0
  [77ba4419] NaNMath v0.3.6
  [b8a86587] NearestNeighbors v0.4.9
  [f09324ee] Netpbm v1.0.1
  [510215fc] Observables v0.3.3
  [6fe1bfb0] OffsetArrays v1.10.8
  [52e1d378] OpenEXR v0.3.2
  [429524aa] Optim v0.22.0
  [bac558e1] OrderedCollections v1.4.1
  [90014a1f] PDMats v0.10.1
  [8314cec4] PGFPlotsX v1.4.1
  [f57f5aa1] PNGFiles v0.3.12
  [5432bcbf] PaddedViews v0.5.11
  [d96e819e] Parameters v0.12.3
  [69de0a69] Parsers v2.2.0
  [fa939f87] Pidfile v1.2.0
  [eebad327] PkgVersion v0.1.1
  [ccf2f8ad] PlotThemes v2.0.1
  [995b91a9] PlotUtils v1.1.2
  [a03496cd] PlotlyBase v0.8.18
  [f0f68f2c] PlotlyJS v0.18.8
  [91a5bcdd] Plots v1.25.6 `~/Software/Plots`
  [2dfb63ee] PooledArrays v1.4.0
  [85a6dd25] PositiveFactorizations v0.2.4
  [21216c6a] Preferences v1.2.3
  [08abe8d2] PrettyTables v1.3.1
  [92933f4c] ProgressMeter v1.7.1
  [1fd47b50] QuadGK v2.4.2
  [dca85d43] QuartzImageIO v0.7.3
  [94ee1d12] Quaternions v0.4.2
  [df47a6cb] RData v0.8.3
  [ce6b1742] RDatasets v0.7.6
  [b3c3ace0] RangeArrays v0.3.2
  [c84ed2f1] Ratios v0.4.2
  [3cdcf5f2] RecipesBase v1.2.1
  [01d81517] RecipesPipeline v0.5.0
  [189a3867] Reexport v0.2.0
  [05181044] RelocatableFolders v0.1.3
  [ae029012] Requires v1.3.0
  [79098fc4] Rmath v0.7.0
  [6038ab10] Rotations v1.1.1
  [6c6a2e73] Scratch v1.1.0
  [91c51154] SentinelArrays v1.3.11
  [992d4aef] Showoff v1.0.3
  [699a6c99] SimpleTraits v0.9.4
  [a2af1166] SortingAlgorithms v1.0.1
  [276daf66] SpecialFunctions v0.10.3
  [860ef19b] StableRNGs v1.0.0
  [cae243ae] StackViews v0.1.1
  [aedffcd0] Static v0.5.1
  [90137ffa] StaticArrays v0.12.5
  [82ae8749] StatsAPI v1.2.0
  [2913bbd2] StatsBase v0.33.14
  [4c63d2b9] StatsFuns v0.9.7
  [f3b207a7] StatsPlots v0.14.5
  [88034a9c] StringDistances v0.11.2
  [09ab397b] StructArrays v0.5.1
  [ab02a1b2] TableOperations v0.2.1
  [3783bdb8] TableTraits v1.0.1
  [bd369af6] Tables v1.6.1
  [5e47fb64] TestImages v1.6.2
  [731e570b] TiffImages v0.4.3
  [06e1c1a7] TiledIteration v0.3.1
  [f269a46b] TimeZones v1.7.1
  [3bb67fe8] TranscodingStreams v0.9.6
  [30578b45] URIParser v0.4.1
  [5c2747f8] URIs v1.3.0
  [3a884ed6] UnPack v1.0.2
  [1cfade01] UnicodeFun v0.4.1
  [b8865327] UnicodePlots v2.5.1
  [41fe7b60] Unzip v0.1.2
  [34922c18] VisualRegressionTests v1.1.1
  [ea10d353] WeakRefStrings v1.4.1
  [0f1e0344] WebIO v0.8.16
  [104b5d7c] WebSockets v1.5.9
  [cc8bc4a8] Widgets v0.6.4
  [efce3f68] WoodburyMatrices v0.5.5
  [7b86fcea] ATK_jll v2.36.1+0
  [68821587] Arpack_jll v3.5.0+3
  [0b7ba130] Blosc_jll v1.21.1+0
  [6e34b625] Bzip2_jll v1.0.8+0
  [83423d85] Cairo_jll v1.16.1+1
  [ee1fde0b] Dbus_jll v1.12.16+3
  [5ae413db] EarCut_jll v2.2.3+0
  [2e619515] Expat_jll v2.2.10+0
  [b22a6f82] FFMPEG_jll v4.4.0+0
  [f5851436] FFTW_jll v3.3.10+0
  [a3f928ae] Fontconfig_jll v2.13.93+0
  [d7e528f0] FreeType2_jll v2.10.4+0
  [559328eb] FriBidi_jll v1.0.10+0
  [0656b61e] GLFW_jll v3.3.5+1
  [d2c73de3] GR_jll v0.63.1+0
  [77ec8976] GTK3_jll v3.24.31+0
  [78b55507] Gettext_jll v0.21.0+0
  [7746bdde] Glib_jll v2.68.3+2
  [3b182d85] Graphite2_jll v1.3.14+0
  [0234f1f7] HDF5_jll v1.12.1+0
  [2e76f6c2] HarfBuzz_jll v2.8.1+1
  [c73af94c] ImageMagick_jll v6.9.10-12+3
  [905a6f67] Imath_jll v3.1.2+0
  [1d5cc7b8] IntelOpenMP_jll v2018.0.3+2
  [aacddb02] JpegTurbo_jll v2.1.0+0
  [f7e6163d] Kaleido_jll v0.1.0+0
  [c1c5ebd0] LAME_jll v3.100.1+0
  [dd4b983a] LZO_jll v2.10.1+0
  [42c93a91] Libepoxy_jll v1.5.8+1
  [e9f186c6] Libffi_jll v3.2.2+1
  [d4300ac3] Libgcrypt_jll v1.8.7+0
  [7e76a0d4] Libglvnd_jll v1.3.0+3
  [7add5ba3] Libgpg_error_jll v1.42.0+0
  [94ce4f54] Libiconv_jll v1.16.1+1
  [4b2f31a3] Libmount_jll v2.35.0+0
  [89763e89] Libtiff_jll v4.3.0+0
  [38a345b3] Libuuid_jll v2.36.0+0
  [5ced341a] Lz4_jll v1.9.3+0
  [856f044c] MKL_jll v2021.1.1+2
  [e7412a2a] Ogg_jll v1.3.5+1
  [18a262bb] OpenEXR_jll v3.1.1+0
  [458c3c95] OpenSSL_jll v1.1.13+0
  [efe28fd5] OpenSpecFun_jll v0.5.5+0
  [91d4177d] Opus_jll v1.3.2+0
  [2f80f16e] PCRE_jll v8.44.0+0
  [36c8627f] Pango_jll v1.47.0+0
  [30392449] Pixman_jll v0.40.1+0
  [ea2cea3b] Qt5Base_jll v5.15.3+0
  [f50d1b31] Rmath_jll v0.3.0+0
  [a2964d1f] Wayland_jll v1.19.0+0
  [2381bf8a] Wayland_protocols_jll v1.23.0+0
  [02c8fc9c] XML2_jll v2.9.12+0
  [aed1982a] XSLT_jll v1.1.34+0
  [4f6342f7] Xorg_libX11_jll v1.6.9+4
  [0c0b7dd1] Xorg_libXau_jll v1.0.9+4
  [3c9796d7] Xorg_libXcomposite_jll v0.4.5+4
  [935fb764] Xorg_libXcursor_jll v1.2.0+4
  [0aeada51] Xorg_libXdamage_jll v1.1.5+4
  [a3789734] Xorg_libXdmcp_jll v1.1.3+4
  [1082639a] Xorg_libXext_jll v1.3.4+4
  [d091e8ba] Xorg_libXfixes_jll v5.0.3+4
  [a51aa0fd] Xorg_libXi_jll v1.7.10+4
  [d1454406] Xorg_libXinerama_jll v1.1.4+4
  [ec84b674] Xorg_libXrandr_jll v1.5.2+4
  [ea2f1a96] Xorg_libXrender_jll v0.9.10+4
  [b6f176f1] Xorg_libXtst_jll v1.2.3+4
  [14d82f49] Xorg_libpthread_stubs_jll v0.1.0+3
  [c7cfdc94] Xorg_libxcb_jll v1.13.0+3
  [cc61e674] Xorg_libxkbfile_jll v1.1.0+4
  [12413925] Xorg_xcb_util_image_jll v0.4.0+1
  [2def613f] Xorg_xcb_util_jll v0.4.0+1
  [975044d2] Xorg_xcb_util_keysyms_jll v0.4.0+1
  [0d47668e] Xorg_xcb_util_renderutil_jll v0.3.9+1
  [c22f9ab0] Xorg_xcb_util_wm_jll v0.4.1+1
  [35661453] Xorg_xkbcomp_jll v1.4.2+4
  [33bec58e] Xorg_xkeyboard_config_jll v2.27.0+4
  [c5fb5394] Xorg_xtrans_jll v1.4.0+3
  [3161d3a3] Zstd_jll v1.5.0+0
  [b437f822] adwaita_icon_theme_jll v3.33.92+5
  [de012916] at_spi2_atk_jll v2.34.1+4
  [0fc3237b] at_spi2_core_jll v2.34.0+4
  [da03df04] gdk_pixbuf_jll v2.42.6+1
  [059c91fe] hicolor_icon_theme_jll v0.17.0+3
  [bf975903] iso_codes_jll v4.3.0+4
  [0ac62f75] libass_jll v0.15.1+0
  [f638f0a6] libfdk_aac_jll v2.0.2+0
  [b53b4c65] libpng_jll v1.6.38+0
  [f27f6e37] libvorbis_jll v1.3.7+0
  [1270edf5] x264_jll v2021.5.5+0
  [dfaa095f] x265_jll v3.5.0+0
  [d8fb68d0] xkbcommon_jll v0.9.1+5
  [0dad84c5] ArgTools `@stdlib/ArgTools`
  [56f22d72] Artifacts `@stdlib/Artifacts`
  [2a0f44e3] Base64 `@stdlib/Base64`
  [ade2ca70] Dates `@stdlib/Dates`
  [8bb1440f] DelimitedFiles `@stdlib/DelimitedFiles`
  [8ba89e20] Distributed `@stdlib/Distributed`
  [f43a241f] Downloads `@stdlib/Downloads`
  [7b1f6079] FileWatching `@stdlib/FileWatching`
  [9fa8497b] Future `@stdlib/Future`
  [b77e0a4c] InteractiveUtils `@stdlib/InteractiveUtils`
  [4af54fe1] LazyArtifacts `@stdlib/LazyArtifacts`
  [b27032c2] LibCURL `@stdlib/LibCURL`
  [76f85450] LibGit2 `@stdlib/LibGit2`
  [8f399da3] Libdl `@stdlib/Libdl`
  [37e2e46d] LinearAlgebra `@stdlib/LinearAlgebra`
  [56ddb016] Logging `@stdlib/Logging`
  [d6f4376e] Markdown `@stdlib/Markdown`
  [a63ad114] Mmap `@stdlib/Mmap`
  [ca575930] NetworkOptions `@stdlib/NetworkOptions`
  [44cfe95a] Pkg `@stdlib/Pkg`
  [de0858da] Printf `@stdlib/Printf`
  [3fa0cd96] REPL `@stdlib/REPL`
  [9a3f8284] Random `@stdlib/Random`
  [ea8e919c] SHA `@stdlib/SHA`
  [9e88b42a] Serialization `@stdlib/Serialization`
  [1a1011a3] SharedArrays `@stdlib/SharedArrays`
  [6462fe0b] Sockets `@stdlib/Sockets`
  [2f01184e] SparseArrays `@stdlib/SparseArrays`
  [10745b16] Statistics `@stdlib/Statistics`
  [4607b0f0] SuiteSparse `@stdlib/SuiteSparse`
  [fa267f1f] TOML `@stdlib/TOML`
  [a4e569a6] Tar `@stdlib/Tar`
  [8dfed614] Test `@stdlib/Test`
  [cf7118a7] UUIDs `@stdlib/UUIDs`
  [4ec0a83e] Unicode `@stdlib/Unicode`
  [e66e0078] CompilerSupportLibraries_jll `@stdlib/CompilerSupportLibraries_jll`
  [deac9b47] LibCURL_jll `@stdlib/LibCURL_jll`
  [29816b5a] LibSSH2_jll `@stdlib/LibSSH2_jll`
  [c8ffd9c3] MbedTLS_jll `@stdlib/MbedTLS_jll`
  [14a3606d] MozillaCACerts_jll `@stdlib/MozillaCACerts_jll`
  [4536629a] OpenBLAS_jll `@stdlib/OpenBLAS_jll`
  [83775a58] Zlib_jll `@stdlib/Zlib_jll`
  [8e850b90] libblastrampoline_jll `@stdlib/libblastrampoline_jll`
  [8e850ede] nghttp2_jll `@stdlib/nghttp2_jll`
  [3f19e933] p7zip_jll `@stdlib/p7zip_jll`
     Testing Running tests...
Gtk-Message: 23:33:24.129: Failed to load module "xapp-gtk3-module"
Gtk-Message: 23:33:24.155: Failed to load module "canberra-gtk-module"
Gtk-Message: 23:33:24.156: Failed to load module "canberra-gtk-module"
Test Summary:  | Pass  Total
Infrastructure |    1      1
Test Summary:     | Pass  Total
Plotly standalone |    6      6
Test Summary: | Pass  Total
Loading theme |    2      2
Test Summary: | Pass  Total
default       |    2      2
Test Summary:   | Pass  Total
Legend defaults |   16     16
Test Summary: | Pass  Total
Legend API    |   20     20
Test Summary: | Pass  Total
plot          |    3      3
Test Summary:   | Pass  Total
get_axis_limits |    2      2
Test Summary: | Pass  Total
Slicing       |   13     13
Test Summary: | Pass  Total
Showaxis      |   50     50
Test Summary: | Pass  Total
Magic axis    |    2      2
Test Summary:     | Pass  Total
Categorical ticks |    3      3
Test Summary:          | Pass  Total
Ticks getter functions |    2      2
Test Summary: | Pass  Total
Axis limits   |    5      5
Test Summary: | Pass  Total
3D Axis       |    1      1
Test Summary: | Pass  Total
twinx         |    4      4
Test Summary: | Pass  Total
axis-aliases  |   14     14
Test Summary: | Pass  Total
aliases       |   12     12
Test Summary:    | Pass  Total
Subplot sclicing |    5      5
Test Summary: | Pass  Total
Plot title    |    6      6
Test Summary: | Pass  Total
Contours      |   24     24
Test Summary: | Pass  Total
axis letter   |   12     12
Test Summary: | Pass  Total
Shapes        |   15     15
Test Summary: | Pass  Total
Brush         |    7      7
Test Summary: | Pass  Total
Fonts         |    2      2
Test Summary:      | Pass  Total
Series Annotations |   14     14
Test Summary: | Pass  Total
Shorthands    |   10     10
QApplication: invalid style override 'kvantum' passed, ignoring it.
	Available styles: Windows, Fusion
Test Summary: | Pass  Total
Limits        |    3      3
QApplication: invalid style override 'kvantum' passed, ignoring it.
	Available styles: Windows, Fusion
Test Summary: | Pass  Total
Date xlims    |    2      2
QApplication: invalid style override 'kvantum' passed, ignoring it.
	Available styles: Windows, Fusion
Test Summary:  | Pass  Total
DateTime xlims |    2      2
Test Summary: | Pass  Total
User recipes  |    2      2
Test Summary: | Pass  Total
lens!         |    2      2
Test Summary: | Pass  Total
vline, vspan  |    8      8
Test Summary: | Pass  Total
offset axes   |    1      1
Test Summary:   | Pass  Total
framestyle axes |   18     18
WARNING: replacing module _hdf5_implementation.
WARNING: replacing module _hdf5_implementation.
WARNING: replacing module _hdf5_implementation.
Test Summary: | Pass  Total
HDF5_Plots    |    2      2
┌ Warning: Indices Base.OneTo(2) of attribute `seriescolor` does not match data indices 1:9.
└ @ Plots ~/Software/Plots/src/utils.jl:132
┌ Warning: Indices Base.OneTo(2) of attribute `linecolor` does not match data indices 1:9.
└ @ Plots ~/Software/Plots/src/utils.jl:132
┌ Warning: Indices Base.OneTo(2) of attribute `fillcolor` does not match data indices 1:9.
└ @ Plots ~/Software/Plots/src/utils.jl:132
┌ Warning: Indices Base.OneTo(2) of attribute `markercolor` does not match data indices 1:9.
└ @ Plots ~/Software/Plots/src/utils.jl:132
┌ Warning: Indices Base.OneTo(2) of attribute `markershape` does not match data indices 1:9.
└ @ Plots ~/Software/Plots/src/utils.jl:132
Test Summary: | Pass  Total
PGFPlotsX     |   44     44
Test Summary: | Pass  Total
Extra kwargs  |   11     11
Test Summary: | Pass  Total
Titlefonts    |   11     11
[ Info: For saving to png with the Plotly backend PlotlyBase has to be installed.
Test Summary: | Pass  Total
Plotly        |   14     14
Test Summary: | Pass  Total
Axes          |    6      6
Test Summary: | Pass  Total
NoFail        |    5      5
Test Summary: | Pass  Total
EmptyAnim     |    1      1
Test Summary:          | Pass  Total
NaN-separated Segments |    8      8
Test Summary: | Pass  Total
Utils         |   23     23
Error handling websocket connection:
Future can be set only once
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:33
  [2] put!(rr::Distributed.Future, v::Bool)
    @ Distributed ~/julias/julia-1.7.0/share/julia/stdlib/v1.7/Distributed/src/remotecall.jl:619
  [3] ws_handler(req::Dict{Any, Any})
    @ Blink ~/.julia/packages/Blink/mwJC9/src/content/server.jl:42
  [4] splitquery(app::typeof(Blink.ws_handler), req::Dict{Any, Any})
    @ Mux ~/.julia/packages/Mux/3h8RY/src/basics.jl:31
  [5] #1
    @ ~/.julia/packages/Mux/3h8RY/src/Mux.jl:10 [inlined]
  [6] wcatch(app::Mux.var"#1#2"{typeof(Mux.splitquery), typeof(Blink.ws_handler)}, req::Dict{Any, Any})
    @ Mux ~/.julia/packages/Mux/3h8RY/src/websockets_integration.jl:12
  [7] #1
    @ ~/.julia/packages/Mux/3h8RY/src/Mux.jl:10 [inlined]
  [8] todict
    @ ~/.julia/packages/Mux/3h8RY/src/basics.jl:25 [inlined]
  [9] #3 (repeats 2 times)
    @ ~/.julia/packages/Mux/3h8RY/src/Mux.jl:14 [inlined]
 [10] (::Mux.var"#1#2"{Mux.var"#3#4"{Mux.var"#3#4"{typeof(Mux.todict), typeof(Mux.wcatch)}, typeof(Mux.splitquery)}, typeof(Blink.ws_handler)})(x::Tuple{HTTP.Messages.Request, WebSockets.WebSocket{Sockets.TCPSocket}})
    @ Mux ~/.julia/packages/Mux/3h8RY/src/Mux.jl:10
 [11] (::Mux.var"#9#10"{Mux.App})(req::HTTP.Messages.Request, client::WebSockets.WebSocket{Sockets.TCPSocket})
    @ Mux ~/.julia/packages/Mux/3h8RY/src/server.jl:49
 [12] upgrade(f::Mux.var"#9#10"{Mux.App}, stream::HTTP.Streams.Stream{HTTP.Messages.Request, HTTP.ConnectionPool.Transaction{Sockets.TCPSocket}})
    @ WebSockets ~/.julia/packages/WebSockets/QcswW/src/HTTP.jl:201
 [13] (::WebSockets.var"#_servercoroutine#11"{WebSockets.ServerWS})(stream::HTTP.Streams.Stream{HTTP.Messages.Request, HTTP.ConnectionPool.Transaction{Sockets.TCPSocket}})
    @ WebSockets ~/.julia/packages/WebSockets/QcswW/src/HTTP.jl:370
 [14] macro expansion
    @ ~/.julia/packages/HTTP/aTjcj/src/Servers.jl:415 [inlined]
 [15] (::HTTP.Servers.var"#13#14"{WebSockets.var"#_servercoroutine#11"{WebSockets.ServerWS}, HTTP.ConnectionPool.Transaction{Sockets.TCPSocket}, HTTP.Servers.Server{Nothing, Sockets.TCPServer}, HTTP.Streams.Stream{HTTP.Messages.Request, HTTP.ConnectionPool.Transaction{Socke
ts.TCPSocket}}})()
    @ HTTP.Servers ./task.jl:423Unexpected end of input
 ...when parsing byte with value '0'
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:33
  [2] _error(message::String, ps::JSON.Parser.StreamingParserState{Sockets.TCPSocket})
    @ JSON.Parser ~/.julia/packages/JSON/QXB8U/src/Parser.jl:148
  [3] byteat(ps::JSON.Parser.StreamingParserState{Sockets.TCPSocket})
    @ JSON.Parser ~/.julia/packages/JSON/QXB8U/src/Parser.jl:57
  [4] current
    @ ~/.julia/packages/JSON/QXB8U/src/Parser.jl:70 [inlined]
  [5] chomp_space!
    @ ~/.julia/packages/JSON/QXB8U/src/Parser.jl:115 [inlined]
  [6] parse_value(pc::JSON.Parser.ParserContext{Dict{String, Any}, Int64, true, nothing}, ps::JSON.Parser.StreamingParserState{Sockets.TCPSocket})
    @ JSON.Parser ~/.julia/packages/JSON/QXB8U/src/Parser.jl:158
  [7] parse(io::Sockets.TCPSocket; dicttype::Type, inttype::Type{Int64}, allownan::Bool, null::Nothing)
    @ JSON.Parser ~/.julia/packages/JSON/QXB8U/src/Parser.jl:481
  [8] parse
    @ ~/.julia/packages/JSON/QXB8U/src/Parser.jl:479 [inlined]
  [9] macro expansion
    @ ~/.julia/packages/Lazy/9Xnd3/src/macros.jl:268 [inlined]
 [10] macro expansion
    @ ~/.julia/packages/Blink/mwJC9/src/AtomShell/process.jl:111 [inlined]
 [11] (::Blink.AtomShell.var"#7#8"{Blink.AtomShell.Electron})()
    @ Blink.AtomShell ./task.jl:423

```