### PR TITLE
fix the wand binning

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -795,7 +795,7 @@ function _auto_binning_nbins(
     elseif mode == :fd  # Freedman–Diaconis rule
         _cl(_span(v) / (2 * _iqr(v) / nd))
     elseif mode == :wand
-        _cl(wand_edges(v))  # this makes this function not type stable, but the type instability does not propagate
+        wand_edges(v)  # this makes this function not type stable, but the type instability does not propagate
     else
         error("Unknown auto-binning mode $mode")
     end


### PR DESCRIPTION
The commit https://github.com/JuliaPlots/Plots.jl/commit/b3336229ab21e863b6750df70454df8b7851102f broke the "wand" binning - and doesn't really achieve much else, so I guess this is just an oversight (@yha ?).
This fixes it again.