### PR TITLE
Fix img axes

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -677,7 +677,6 @@ end
 # we return (continuous_value, discrete_index)
 function discrete_value!(axis::Axis, dv)
     cv_idx = get(axis[:discrete_map], dv, -1)
-    # @show axis[:discrete_map], axis[:discrete_values], dv
     if cv_idx == -1
         ex = axis[:extrema]
         cv = NaNMath.max(0.5, ex.emax + 1.0)

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -849,7 +849,6 @@ const _examples = PlotExample[
         [
             quote
                 begin
-                    using Plots
                     default(
                         titlefont = (20, "times"),
                         legendfontsize = 18,
@@ -1071,7 +1070,6 @@ const _examples = PlotExample[
         "",
         [
             quote
-                using Plots
                 using TestImages
                 img = testimage("lighthouse")
 
@@ -1092,8 +1090,6 @@ const _examples = PlotExample[
         "3d quiver",
         "",
         [quote
-            using Plots
-
             ϕs = range(-π, π, length = 50)
             θs = range(0, π, length = 25)
             θqs = range(1, π - 1, length = 25)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1380,7 +1380,7 @@ function clamp_greys!(mat::AMat{<:Gray})
 end
 
 @recipe function f(mat::AMat{<:Gray})
-    n, m = map(a -> 0:(a.stop), axes(mat))
+    n, m = map(a -> range(0.5, stop = a.stop + 0.5), axes(mat))
 
     if is_seriestype_supported(:image)
         seriestype := :image
@@ -1399,7 +1399,7 @@ end
 
 # images - colors
 @recipe function f(mat::AMat{T}) where {T<:Colorant}
-    n, m = map(a -> 0:(a.stop), axes(mat))
+    n, m = map(a -> range(0.5, stop = a.stop + 0.5), axes(mat))
 
     if is_seriestype_supported(:image)
         seriestype := :image

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1380,7 +1380,8 @@ function clamp_greys!(mat::AMat{<:Gray})
 end
 
 @recipe function f(mat::AMat{<:Gray})
-    n, m = axes(mat)
+    n, m = map(a -> 0:(a.stop), axes(mat))
+
     if is_seriestype_supported(:image)
         seriestype := :image
         yflip --> true
@@ -1398,7 +1399,7 @@ end
 
 # images - colors
 @recipe function f(mat::AMat{T}) where {T<:Colorant}
-    n, m = axes(mat)
+    n, m = map(a -> 0:(a.stop), axes(mat))
 
     if is_seriestype_supported(:image)
         seriestype := :image

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,15 +249,6 @@ end
         @test show(io, p) isa Nothing
     end
 
-    @testset "PlotlyJS" begin
-        @test plotlyjs() == Plots.PlotlyJSBackend()
-        @test backend() == Plots.PlotlyJSBackend()
-
-        p = plot(rand(10))
-        @test p isa Plots.Plot
-        @test_broken display(p) isa Nothing
-    end
-
     @testset "GR" begin
         ENV["PLOTS_TEST"] = "true"
         ENV["GKSwstype"] = "100"
@@ -273,5 +264,14 @@ end
                 skip = Plots._backend_skips[:gr],
             )
         end
+    end
+
+    @testset "PlotlyJS" begin
+        @test plotlyjs() == Plots.PlotlyJSBackend()
+        @test backend() == Plots.PlotlyJSBackend()
+
+        p = plot(rand(10))
+        @test p isa Plots.Plot
+        @test_broken display(p) isa Nothing
     end
 end


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/4087.


```julia
using Plots

png(plot(Gray.(randn(10,15))), "foo")
```
![foo](https://user-images.githubusercontent.com/13423344/152186172-533ac270-a78c-4eb0-a6f9-c000d5b2d422.png)

