### PR TITLE
Fix module eval (example 41)

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1342,11 +1342,8 @@ function test_examples(pkgname::Symbol, idx::Int; debug = false, disp = true)
     Base.eval(m, :(using Plots))
     map(exprs -> Base.eval(m, exprs), _examples[idx].exprs)
 
-    plt = current()
-    if disp
-        gui(plt)
-    end
-    plt
+    disp && Base.eval(m, :(gui(current())))
+    current()
 end
 
 # generate all plots and create a dict mapping idx --> plt


### PR DESCRIPTION
Fixes the following

```julia
julia> using Plots
julia> Plots.test_examples(:unicodeplots, 41, disp=true)
ERROR: LoadError: type IdOffsetRange has no field stop
Stacktrace:
  [1] getproperty(x::OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}}, f::Symbol)
    @ Base ./Base.jl:33
  [2] last(r::OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}})
    @ Base ./range.jl:613
  [3] length
    @ ./range.jl:586 [inlined]
  [4] size(r::OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}})
    @ Base ./range.jl:515
  [5] axes
    @ ./abstractarray.jl:89 [inlined]
  [6] similar(a::OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}}, #unused#::Type{Float64})
    @ Base ./abstractarray.jl:739
  [7] AbstractVector{Float64}(A::OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}})
    @ Base ./array.jl:541
  [8] (AbstractArray{Float64, N} where N)(A::OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}})
    @ Core ./boot.jl:475
  [9] convert(#unused#::Type{AbstractArray{Float64, N} where N}, a::OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}})
    @ Base ./abstractarray.jl:15
 [10] float(A::OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}})
    @ Base ./float.jl:896
[...]
```