### PR TITLE
Revert "Fix annotations getting drawn under markers in pgfplotsx backend"

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -162,7 +162,6 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 "anchor" => "north west",
                 "xshift" => string(dx),
                 "yshift" => string(-dy),
-                "clip mode" => "individual",
             )
             sp_width > 0 * mm ? push!(axis_opt, "width" => string(axis_width)) : nothing
             sp_height > 0 * mm ? push!(axis_opt, "height" => string(axis_height)) : nothing
@@ -1056,11 +1055,7 @@ function pgfx_add_annotation!(
     push!(
         o,
         join([
-            raw"""
-            \begin{scope}
-                \clip \pgfextra{\pgfplotspathaxisoutline};
-                \node
-            """,
+            "\\node",
             sprint(
                 PGFPlotsX.print_tex,
                 merge(
@@ -1079,7 +1074,6 @@ function pgfx_add_annotation!(
                 ),
             ),
             string(" at (", cs, x, ",", y, ") {", val.str, "};"),
-            "\\end{scope}",
         ]),
     )
 end


### PR DESCRIPTION
Reverts JuliaPlots/Plots.jl#3957 because of #4141 
Fix #4141
CC: @chwons 