### PR TITLE
Avoid drawing markers for empty 3D scatter plots in GR

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1840,7 +1840,7 @@ function gr_add_series(sp, series)
         gr_draw_shapes(series, clims)
     elseif st in (:path3d, :scatter3d)
         gr_draw_segments_3d(series, x, y, z, clims)
-        if st === :scatter3d || series[:markershape] !== :none
+        if (st === :scatter3d || series[:markershape] !== :none) && !isempty(x)
             # TODO: Do we need to transform to 2d coordinates here?
             x2, y2 = RecipesPipeline.unzip(map(GR.wc3towc, x, y, z))
             gr_draw_markers(series, x2, y2, clims)


### PR DESCRIPTION
This is a very naive approach to fix #4146:

When plotting an empty 3D scatter plot in GR, the following [piece of code](https://github.com/JuliaPlots/Plots.jl/blob/5c4fbc5e1abc5322738494588169111ae55ab63c/src/backends/gr.jl#L1841) gets called:
```julia
#...
    elseif st in (:path3d, :scatter3d)
        gr_draw_segments_3d(series, x, y, z, clims)
        if st === :scatter3d || series[:markershape] !== :none
            # TODO: Do we need to transform to 2d coordinates here?
            x2, y2 = RecipesPipeline.unzip(map(GR.wc3towc, x, y, z))
            gr_draw_markers(series, x2, y2, clims)
        end
#...
```
When `x`, `y` and `z` are empty, calling `map(GR.wc3towc, x, y, z)` returns an empty `Tuple{Float64, Float64, Float64}[]`.
This results in an error in [`RecipesPipeline.unzip`](https://github.com/JuliaPlots/RecipesPipeline.jl/blob/e19b84f4297890d36837fc35f398d56159a0ab45/src/utils.jl#L211):
```julia
unzip(v::AVec{<:Tuple}) = tuple((([t[j] for t in v]) for j in 1:length(v[1]))...)
```
 as this method looks up the first entry of the array, which in this specific case does not exist and results in the cryptic error message reported in #4146.

One very naive to fix this would be to add an additional `!isempty` requirement in the source code of Plots.jl, which is proposed in this PR. This avoids this error and results in an empty 3D plot:
```julia
scatter([],[],[])
```
![scatter3D](https://user-images.githubusercontent.com/30291312/159656268-f27146ad-54cc-4952-8d52-651cecbfdb34.png)



Alternatively, `unzip` in RecipesPipeline should be updated such that it can also handle empty arrays.