### PR TITLE
Sort supported args

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1626,7 +1626,7 @@ function warn_on_unsupported_args(pkg::AbstractBackend, plotattributes)
         for k in sort(collect(_to_warn))
             push!(already_warned, k)
             @warn(
-                "Keyword argument $k not supported with $pkg.  Choose from: $(sort(collect(supported_attrs(pkg))))"
+                "Keyword argument $k not supported with $pkg.  Choose from: $(join(sort(collect(supported_attrs(pkg))), ", "))"
             )
         end
     end

--- a/src/args.jl
+++ b/src/args.jl
@@ -1626,7 +1626,7 @@ function warn_on_unsupported_args(pkg::AbstractBackend, plotattributes)
         for k in sort(collect(_to_warn))
             push!(already_warned, k)
             @warn(
-                "Keyword argument $k not supported with $pkg.  Choose from: $(join(sort(collect(supported_attrs(pkg))), ", "))"
+                "Keyword argument $k not supported with $pkg.  Choose from: $(join(supported_attrs(pkg), ", "))"
             )
         end
     end

--- a/src/args.jl
+++ b/src/args.jl
@@ -1626,7 +1626,7 @@ function warn_on_unsupported_args(pkg::AbstractBackend, plotattributes)
         for k in sort(collect(_to_warn))
             push!(already_warned, k)
             @warn(
-                "Keyword argument $k not supported with $pkg.  Choose from: $(supported_attrs(pkg))"
+                "Keyword argument $k not supported with $pkg.  Choose from: $(sort(collect(supported_attrs(pkg))))"
             )
         end
     end

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -285,7 +285,7 @@ for s in (:attr, :seriestype, :marker, :style, :scale)
         v = Symbol("_", bend, "_", s)
         @eval begin
             $f(::$bend_type, $s::Symbol) = $s in $v
-            $f2(::$bend_type) = $v
+            $f2(::$bend_type) = sort(collect($v))
         end
     end
 end


### PR DESCRIPTION
Adds sorting to this tip because the unsorted options are hard to scan.

![Screenshot from 2022-03-27 20-02-44](https://user-images.githubusercontent.com/1694067/160306970-a7b0dc82-48b5-4321-be36-899fc6e46a34.png)

