### PR TITLE
Merge `extra_kwargs` in plotly series

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -753,7 +753,8 @@ function plotly_series(plt::Plot, series::Series)
 
     plotly_polar!(plotattributes_out, series)
     plotly_adjust_hover_label!(plotattributes_out, series[:hover])
-    return [plotattributes_out]
+
+    return [merge(plotattributes_out, series[:extra_kwargs])]
 end
 
 function plotly_series_shapes(plt::Plot, series::Series, clims)
@@ -807,7 +808,7 @@ function plotly_series_shapes(plt::Plot, series::Series, clims)
         plotattributes_out[:showlegend] = k == 1 ? should_add_to_legend(series) : false
         plotly_polar!(plotattributes_out, series)
         plotly_adjust_hover_label!(plotattributes_out, _cycle(series[:hover], i))
-        plotattributes_outs[k] = plotattributes_out
+        plotattributes_outs[k] = merge(plotattributes_out, series[:extra_kwargs])
     end
     if series[:fill_z] !== nothing
         push!(plotattributes_outs, plotly_colorbar_hack(series, plotattributes_base, :fill))
@@ -968,6 +969,7 @@ function plotly_series_segments(series::Series, plotattributes_base::KW, x, y, z
         else
             plotattributes_outs[k] = plotattributes_out
         end
+        plotattributes_outs[k] = merge(plotattributes_outs[k], series[:extra_kwargs])
     end
 
     if series[:line_z] !== nothing

--- a/test/test_plotly.jl
+++ b/test/test_plotly.jl
@@ -55,4 +55,10 @@ using Plots, Test
             end
         end
     end
+    @testset "Extra kwargs" begin
+        pl = plot(1:5, test = "me")
+        @test Plots.plotly_series(pl)[1][:test] == "me"
+        pl = plot(1:5, test = "me", extra_kwargs = :plot)
+        @test Plots.plotly_layout(pl)[:test] == "me"
+    end
 end


### PR DESCRIPTION
Also merge `extra_kwargs` dict of series to `plotattributes_out` since at the moment this is only done in `plotly_layout`.

At the moment it is not possible to add e.g. [customdata](https://plotly.com/javascript/reference/scatter/#scatter-customdata) information to plotly plots without manually manipulating the returns of `plotly_series`.

I just merge all the entries of the `extra_kwargs` dict from the series into the output attributes, but I am not sure if it is alright.