### PR TITLE
add version check for 1.8 precompiles

### DIFF
--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -18,13 +18,14 @@ jobs:
       GKS_ENCODING: "utf8"
       GKSwstype: "100"
       PLOTS_TEST: "true"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
       matrix:
         version:   # NOTE: the versions below should match those in your botconfig
           - '1.6'       # ⎤
           - '1.7'       # |
+          - '~1.8.0-0'  # |
           # - 'nightly'   # ⎦ <<< keep these versions in sync with deps/SnoopCompile/snoop_bot_config.jl
           # ^^^^^^^^^ for 'nightly', see github.com/JuliaPlots/Plots.jl/issues/4079
         os:        # NOTE: should match the os setting of your botconfig
@@ -36,7 +37,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: ${{ matrix.version }}
+          version: ${{matrix.version}}
 
       - name: Install dependencies
         run: |
@@ -87,7 +88,6 @@ jobs:
             SnoopCompile
             no changelog
           branch: "Test_SnoopCompile_AutoPR_${{ github.ref }}"
-
 
   Skip:
     if: "contains(github.event.head_commit.message, '[skip ci]')"

--- a/deps/SnoopCompile/snoop_bot_config.jl
+++ b/deps/SnoopCompile/snoop_bot_config.jl
@@ -2,6 +2,6 @@ using CompileBot
 
 botconfig = BotConfig(
     "Plots",
-    version = ["1.6", "1.7", "nightly"],  # <<< keep these versions in sync with .github/workflows/SnoopCompile.yml
+    version = ["1.6", "1.7", "1.8", "nightly"],  # <<< keep these versions in sync with .github/workflows/SnoopCompile.yml
     # else_version = "nightly",
 )

--- a/src/precompile_includer.jl
+++ b/src/precompile_includer.jl
@@ -24,6 +24,11 @@ elseif v"1.7.0-DEV" <= VERSION <= v"1.7.9"
         include("../deps/SnoopCompile/precompile//1.7/precompile_Plots.jl")
         _precompile_()
     end
+elseif v"1.8.0-DEV" <= VERSION <= v"1.8.9" 
+    @static if isfile(joinpath(@__DIR__, "../deps/SnoopCompile/precompile//1.8/precompile_Plots.jl"))
+        include("../deps/SnoopCompile/precompile//1.8/precompile_Plots.jl")
+        _precompile_()
+    end
 elseif v"1.9.0-DEV" <= VERSION <= v"1.9.9" 
     @static if isfile(joinpath(@__DIR__, "../deps/SnoopCompile/precompile//1.9/precompile_Plots.jl"))
         include("../deps/SnoopCompile/precompile//1.9/precompile_Plots.jl")


### PR DESCRIPTION
I'm not sure why there was no case for including precompile statements for v1.8. Is there some reason? In any case adding this fixes it and significantly improves TTFP.

(Also the version checks are wrong; you can have 1.8 versions greater than 1.8.9, but that can be fixed separately.)