### PR TITLE
UnicodePlots: support `polarplot`

### DIFF
--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -158,6 +158,10 @@ function addUnicodeSeries!(
         series[:x], series[:y]
     end
 
+    if ispolar(sp) || ispolar(series)
+        return UnicodePlots.polarplot(x, y)
+    end
+
     # special handling (src/interface)
     fix_ar = get(se_kw, :fix_ar, true)
     if st === :histogram2d

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1317,7 +1317,6 @@ _backend_skips = Dict(
         16,  # nested layout unsupported
         21,  # custom markers unsupported
         26,  # nested layout unsupported
-        27,  # polar plots unsupported
         29,  # nested layout unsupported
         33,  # grid lines unsupported
         34,  # framestyle unsupported


### PR DESCRIPTION
Following https://github.com/JuliaPlots/UnicodePlots.jl/pull/249.