### PR TITLE
Fixing the colorbar title for colorbars on the top.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -712,6 +712,10 @@
         {
             "name": "Steve Leung",
             "type": "Other"
+        },
+        {
+            "name": "Xu Zhi-Yuan",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -206,8 +206,8 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
 
             if hascolorbar(sp)
                 cticks = get_colorbar_ticks(sp)[2]
-                colorbar_style = PGFPlotsX.Options("ylabel" => sp[:colorbar_title])
                 if sp[:colorbar] === :top
+                    colorbar_style = PGFPlotsX.Options("xlabel" => sp[:colorbar_title])
                     push!(
                         colorbar_style,
                         "at" => string((0.5, 1.05)),
@@ -217,6 +217,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                         "xticklabel style" => pgfx_get_colorbar_ticklabel_style(sp),
                     )
                 else
+                    colorbar_style = PGFPlotsX.Options("ylabel" => sp[:colorbar_title])
                     push!(
                         colorbar_style,
                         "ytick" => string("{", join(cticks, ","), "}"),


### PR DESCRIPTION
Related: #4183.

For the following test code:
```julia
using Plots
pgfplotsx()
plot(rand(10, 2), marker_z=rand(10), seriestype=:scatter, cb=:top, cb_title="mark")
```
before this fix: 
<img width="996" alt="截屏2022-05-02 11 31 19" src="https://user-images.githubusercontent.com/37478391/166181206-76536265-9d0a-492a-9d7f-1c993930db50.png">
while after this fix:
![mark](https://user-images.githubusercontent.com/37478391/166181226-4b8b2806-011b-4658-a575-065504e2f508.png)

