### PR TITLE
forward aspect ratio for 3D plots in pgfplotsx

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -233,6 +233,10 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 push!(axis_opt, "colorbar" => "false")
             end
             if RecipesPipeline.is3d(sp)
+                ar = sp[:aspect_ratio]
+                if ar !== :auto
+                    push!(axis_opt, "unit vector ratio" => join(ar, " "))
+                end
                 azim, elev = sp[:camera]
                 push!(axis_opt, "view" => (azim, elev))
             end

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -234,8 +234,10 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
             end
             if RecipesPipeline.is3d(sp)
                 ar = sp[:aspect_ratio]
-                if ar !== :auto
+                if ar !== :auto && ar !== :equal
                     push!(axis_opt, "unit vector ratio" => join(ar, " "))
+                else
+                    push!(axis_opt, "unit vector ratio" => 1)
                 end
                 azim, elev = sp[:camera]
                 push!(axis_opt, "view" => (azim, elev))


### PR DESCRIPTION
In 2D plots this yields sometimes undesired results as shown in https://github.com/JuliaPlots/Plots.jl/issues/3485, but in 3D its the best we have.