### PR TITLE
Auto-layout mode that prevents plots from shrinking beyond readability

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -434,6 +434,7 @@ const _plot_defaults = KW(
     :thickness_scaling   => 1,
     :display_type        => :auto,
     :warn_on_unsupported => true,
+    :plotarea => :auto,
     :extra_plot_kwargs   => Dict(),
     :extra_kwargs        => :series,    # directs collection of extra_kwargs
 )

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -141,6 +141,14 @@ function plot!(plt1::Plot, plt2::Plot, plts_tail::Plot...; kw...)
 
     # create the layout
     plt.layout, plt.subplots, plt.spmap = build_layout(layout, num_sp, copy(plts))
+    if layout === :auto
+        if plt.attr[:size][1] < plt.layout.attr[:width]
+            plt.attr[:size] = (plt.layout.attr[:width], plt.attr[:size][2])
+        end
+        if plt.attr[:size][2] < plt.layout.attr[:height]
+            plt.attr[:size] = (plt.attr[:size][1], plt.layout.attr[:height])
+        end
+    end
 
     # do we need to link any axes together?
     link_axes!(plt.layout, plt[:link])


### PR DESCRIPTION
This is a first pass that probably doesn't account for everything needed.

However, what it does is it simply computes a row and column count, the widths and sizes of them, passes the work down to the normal layout method, then the calling plot code reads the height and width attributes from the layout and overrides `size` if the total size needed is larger than the set size.

```
plot([plot(rand(3)) for x ∈ 1:20]..., layout = :auto, legend = :none)
```
Current:
![image](https://user-images.githubusercontent.com/1438610/173115445-ff670fc3-29c7-4d39-a923-4ee8f99e4d3d.png)


This PR:
![image](https://user-images.githubusercontent.com/1438610/173115366-f2d88bba-e274-49c7-bd82-0107f16e6a69.png)
