### PR TITLE
Even faster series adding

### DIFF
--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -25,6 +25,18 @@ function update_clims(sp::Subplot, op = process_clims(sp[:clims]))::Tuple{Float6
     return sp[:clims_calculated] = zmin <= zmax ? (zmin, zmax) : (NaN, NaN)
 end
 
+function update_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]))::Tuple{Float64,Float64}
+    zmin, zmax = get_clims(sp)
+    old_zmin, old_zmax = zmin, zmax
+    if series[:colorbar_entry]::Bool
+        zmin, zmax = _update_clims(zmin, zmax, update_clims(series, op)...)
+    else
+        update_clims(series, op)
+    end
+    zmin == old_zmin || zmax == old_zmax && update_clims(sp)
+    return zmin <= zmax ? (zmin, zmax) : (NaN, NaN)
+end
+
 """
     update_clims(::Series, op=Plots.ignorenan_extrema)
 Finds the limits for the colorbar by taking the "z-values" for the series and passing them into `op`,
@@ -102,4 +114,9 @@ end
 function _update_subplot_colorbars(sp::Subplot)
     # Dynamic callback from the pipeline if needed
     update_clims(sp)
+end
+
+function _update_subplot_colorbars(sp::Subplot, series::Series)
+    # Dynamic callback from the pipeline if needed
+    update_clims(sp, series)
 end

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -33,7 +33,7 @@ function update_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]
     else
         update_clims(series, op)
     end
-    zmin == old_zmin || zmax == old_zmax && update_clims(sp)
+    zmin == old_zmin && zmax == old_zmax || update_clims(sp)
     return zmin <= zmax ? (zmin, zmax) : (NaN, NaN)
 end
 

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -25,7 +25,11 @@ function update_clims(sp::Subplot, op = process_clims(sp[:clims]))::Tuple{Float6
     return sp[:clims_calculated] = zmin <= zmax ? (zmin, zmax) : (NaN, NaN)
 end
 
-function update_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]))::Tuple{Float64,Float64}
+function update_clims(
+    sp::Subplot,
+    series::Series,
+    op = process_clims(sp[:clims]),
+)::Tuple{Float64,Float64}
     zmin, zmax = get_clims(sp)
     old_zmin, old_zmax = zmin, zmax
     if series[:colorbar_entry]::Bool

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -33,7 +33,9 @@ function update_clims(sp::Subplot, series::Series, op = process_clims(sp[:clims]
     else
         update_clims(series, op)
     end
-    zmin == old_zmin && zmax == old_zmax || update_clims(sp)
+    isnan(zmin) && isnan(old_zmin) && isnan(zmax) && isnan(old_zmax) ||
+        zmin == old_zmin && zmax == old_zmax ||
+        update_clims(sp)
     return zmin <= zmax ? (zmin, zmax) : (NaN, NaN)
 end
 

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -462,5 +462,5 @@ function _add_the_series(plt, sp, plotattributes)
         @error "Wrong type $(typeof(z_order)) for attribute z_order"
     end
     _series_added(plt, series)
-    _update_subplot_colorbars(sp)
+    _update_subplot_colorbars(sp, series)
 end


### PR DESCRIPTION
This eliminates the last bit of unnecessary churn in the clims updating code.

Previous work ensured the updates only occur at series addition or other parameter change, rather than every time they need to be read.

This work ensures the other series are only updated if a new series would change the existing color limits.

Currently my US county plot takes `1.569 s (12306720 allocations: 342.66 MiB)`

With this PR: `553.153 ms (2647060 allocations: 121.55 MiB)`

FINALLY,

The profiler bottleneck is no longer colorbar updates, but is now something in argument processing:
```
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
  ╎330 @Base\task.jl:482; (::VSCodeServer.var"#60#61")()
  ╎ 330 @VSCodeServer\src\eval.jl:34; macro expansion
  ╎  330 @Base\essentials.jl:726; invokelatest(::Any)
  ╎   330 @Base\essentials.jl:729; #invokelatest#2
  ╎    330 @VSCodeServer\src\repl.jl:124; (::VSCodeServer.var"#77#79"{Module, Expr, REPL.LineEdit...
  ╎     330 @Base\logging.jl:623; with_logger
  ╎    ╎ 330 @Base\logging.jl:511; with_logstate(f::Function, logstate::Any)
  ╎    ╎  330 @VSCodeServer\src\repl.jl:123; (::VSCodeServer.var"#78#80"{Module, Expr, REPL.LineEdi...
  ╎    ╎   330 @VSCodeServer\src\repl.jl:157; repleval(m::Module, code::Expr, #unused#::String)
  ╎    ╎    330 @Base\Base.jl:65; eval
  ╎    ╎     330 @Base\boot.jl:368; eval
  ╎    ╎    ╎ 330 @Plots\src\plot.jl:82; (::RecipesBase.var"#plot##kw")(::NamedTuple{(:fillco...
  ╎    ╎    ╎  330 @Plots\src\plot.jl:91; #plot#143
  ╎    ╎    ╎   330 @Plots\src\plot.jl:208; _plot!(plt::Plots.Plot, plotattributes::Any, args:...
  ╎    ╎    ╎    284 ...sPipeline\src\RecipesPipeline.jl:97; recipe_pipeline!(plt::Any, plotattributes::Any, ar...        
  ╎    ╎    ╎     277 ...pesPipeline\src\series_recipe.jl:27; _process_seriesrecipes!(plt::Any, kw_list::Any)
  ╎    ╎    ╎    ╎ 275 ...esPipeline\src\series_recipe.jl:46; _process_seriesrecipe(plt::Any, plotattributes::Any)        
  ╎    ╎    ╎    ╎  61  @Plots\src\pipeline.jl:351; add_series!(plt::Plots.Plot{Plots.GRBackend}, pl...
  ╎    ╎    ╎    ╎   55  @Plots\src\pipeline.jl:376; _prepare_subplot(plt::Plots.Plot{Plots.GRBacken...
  ╎    ╎    ╎    ╎  134 @Plots\src\pipeline.jl:366; add_series!(plt::Plots.Plot{Plots.GRBackend}, pl...
  ╎    ╎    ╎    ╎   108 @Plots\src\args.jl:2164; _update_series_attributes!(plotattributes::Rec...
 2╎    ╎    ╎    ╎    100 @Plots\src\args.jl:2250; _series_index(plotattributes::RecipesPipeline....
 2╎    ╎    ╎    ╎     98  @Plots\src\args.jl:1897; getindex
  ╎    ╎    ╎    ╎    ╎ 77  @RecipesPipeline\src\utils.jl:18; getindex(dd::RecipesPipeline.DefaultsDict, k::...
  ╎    ╎    ╎    ╎    ╎  71  @Base\dict.jl:569; haskey
  ╎    ╎    ╎    ╎    ╎   51  @Base\dict.jl:283; ht_keyindex
51╎    ╎    ╎    ╎    ╎    51  @Base\Base.jl:38; getproperty
  ╎    ╎    ╎    ╎  59  @Plots\src\pipeline.jl:367; add_series!(plt::Plots.Plot{Plots.GRBackend}, pl...
```