### PR TITLE
Make layouts tolerant of having too-few items

### DIFF
--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -455,9 +455,9 @@ end
 
 function layout_args(plotattributes::AKW, n_override::Integer)
     layout, n = layout_args(n_override, get(plotattributes, :layout, n_override))
-    if n != n_override
+    if n < n_override
         error(
-            "When doing layout, n ($n) != n_override ($(n_override)).  You're probably trying to force existing plots into a layout that doesn't fit them.",
+            "When doing layout, n ($n) < n_override ($(n_override)).  You're probably trying to force existing plots into a layout that doesn't fit them.",
         )
     end
     layout, n


### PR DESCRIPTION
A big headache I have is that you currently have to have exactly the right number of layout spots for the number of plots you want to render. It makes rendering variable numbers of plots a bit of a headache.

This PR loosens the constraints so that fewer plots are acceptable, while too many plots still errors.
```
plot(plot(), plot(), plot(), layout = grid(2, 2))
```
![image](https://user-images.githubusercontent.com/1438610/174935465-197729f5-31f2-4f00-ad1a-c45880de03a0.png)

