### PR TITLE
Fix bug when a theme uses a colorbar attribute

### DIFF
--- a/src/themes.jl
+++ b/src/themes.jl
@@ -57,7 +57,7 @@ _get_showtheme_args(thm::Symbol, func::Symbol) = thm, get(_color_functions, func
             cfunc(RGB(def))
         elseif eltype(def) <: Colorant
             cfunc.(RGB.(def))
-        elseif occursin("color", string(arg))
+        elseif occursin("color", string(arg)) && !startswith(string(arg), "colorbar")
             cfunc.(RGB.(plot_color.(def)))
         else
             def


### PR DESCRIPTION
Example of the avoided error when `colorbar_tickfontsize` is set:

```julia
# ╔═╡ a66757cc-f706-11ec-10c3-c75e60498268
using Plots

# ╔═╡ 73ffd478-2dc9-4829-9374-6d8731c4f9f2
example_theme = PlotThemes.PlotTheme(Dict([
	:colorbar_tickfontsize => 10,]))

# ╔═╡ 3a7f13fa-3bbc-4d8d-a907-8690fcc42f7c
begin
	add_theme(:example_theme, example_theme)
	showtheme(:example_theme)
end
```

![image](https://user-images.githubusercontent.com/2822757/176245306-b453714f-5553-4462-b0f7-c260cb87f5c5.png)
