### PR TITLE
Sanitize symbol and nothing Comparisons

### DIFF
--- a/deps/SnoopCompile/precompile/1.6/precompile_Plots.jl
+++ b/deps/SnoopCompile/precompile/1.6/precompile_Plots.jl
@@ -38,7 +38,7 @@ function __lookup_kwbody__(mnokw::Method)
         ast = Base.uncompressed_ast(mnokw)
         if isa(ast, Core.CodeInfo) && length(ast.code) >= 2
             callexpr = ast.code[end-1]
-            if isa(callexpr, Expr) && callexpr.head == :call
+            if isa(callexpr, Expr) && callexpr.head === :call
                 fsym = callexpr.args[1]
                 if isa(fsym, Symbol)
                     f = getfield(fmod, fsym)

--- a/deps/SnoopCompile/precompile/1.7/precompile_Plots.jl
+++ b/deps/SnoopCompile/precompile/1.7/precompile_Plots.jl
@@ -38,7 +38,7 @@ function __lookup_kwbody__(mnokw::Method)
         ast = Base.uncompressed_ast(mnokw)
         if isa(ast, Core.CodeInfo) && length(ast.code) >= 2
             callexpr = ast.code[end-1]
-            if isa(callexpr, Expr) && callexpr.head == :call
+            if isa(callexpr, Expr) && callexpr.head === :call
                 fsym = callexpr.args[1]
                 if isa(fsym, Symbol)
                     f = getfield(fmod, fsym)

--- a/src/animation.jl
+++ b/src/animation.jl
@@ -174,14 +174,14 @@ function _animate(forloop::Expr, args...; callgif = false)
         # no filter... every iteration gets a frame
         true
 
-    elseif args[1] == :every
+    elseif args[1] === :every
         # filter every `freq` frames (starting with the first frame)
         @assert n == 2
         freq = args[2]
         freqassert = :(@assert isa($freq, Integer) && $freq > 0)
         :(mod1($countersym, $freq) == 1)
 
-    elseif args[1] == :when
+    elseif args[1] === :when
         # filter on custom expression
         @assert n == 2
         args[2]

--- a/src/args.jl
+++ b/src/args.jl
@@ -565,7 +565,7 @@ function aliasesAndAutopick(
     options::AVec,
     plotIndex::Int,
 )
-    if plotattributes[sym] == :auto
+    if plotattributes[sym] === :auto
         plotattributes[sym] = autopick_ignore_none_auto(options, plotIndex)
     elseif haskey(aliases, plotattributes[sym])
         plotattributes[sym] = aliases[plotattributes[sym]]
@@ -1073,7 +1073,7 @@ function default(k::Symbol)
         letter, key = axis_k
         return _axis_defaults_byletter[letter][key]
     end
-    k == :letter && return k # for type recipe processing
+    k === :letter && return k # for type recipe processing
     return missing
 end
 
@@ -1121,7 +1121,7 @@ end
 # if arg is a valid color value, then set plotattributes[csym] and return true
 function handleColors!(plotattributes::AKW, arg, csym::Symbol)
     try
-        if arg == :auto
+        if arg === :auto
             plotattributes[csym] = :auto
         else
             # c = colorscheme(arg)
@@ -1147,7 +1147,7 @@ function processLineArg(plotattributes::AKW, arg)
         arg.width === nothing || (plotattributes[:linewidth] = arg.width)
         arg.color === nothing || (
             plotattributes[:linecolor] =
-                arg.color == :auto ? :auto : plot_color(arg.color)
+                arg.color === :auto ? :auto : plot_color(arg.color)
         )
         arg.alpha === nothing || (plotattributes[:linealpha] = arg.alpha)
         arg.style === nothing || (plotattributes[:linestyle] = arg.style)
@@ -1156,7 +1156,7 @@ function processLineArg(plotattributes::AKW, arg)
         arg.size === nothing || (plotattributes[:fillrange] = arg.size)
         arg.color === nothing || (
             plotattributes[:fillcolor] =
-                arg.color == :auto ? :auto : plot_color(arg.color)
+                arg.color === :auto ? :auto : plot_color(arg.color)
         )
         arg.alpha === nothing || (plotattributes[:fillalpha] = arg.alpha)
         arg.style === nothing || (plotattributes[:fillstyle] = arg.style)
@@ -1191,7 +1191,7 @@ function processMarkerArg(plotattributes::AKW, arg)
         arg.width === nothing || (plotattributes[:markerstrokewidth] = arg.width)
         arg.color === nothing || (
             plotattributes[:markerstrokecolor] =
-                arg.color == :auto ? :auto : plot_color(arg.color)
+                arg.color === :auto ? :auto : plot_color(arg.color)
         )
         arg.alpha === nothing || (plotattributes[:markerstrokealpha] = arg.alpha)
         arg.style === nothing || (plotattributes[:markerstrokestyle] = arg.style)
@@ -1200,7 +1200,7 @@ function processMarkerArg(plotattributes::AKW, arg)
         arg.size === nothing || (plotattributes[:markersize] = arg.size)
         arg.color === nothing || (
             plotattributes[:markercolor] =
-                arg.color == :auto ? :auto : plot_color(arg.color)
+                arg.color === :auto ? :auto : plot_color(arg.color)
         )
         arg.alpha === nothing || (plotattributes[:markeralpha] = arg.alpha)
 
@@ -1228,7 +1228,7 @@ function processFillArg(plotattributes::AKW, arg)
         arg.size === nothing || (plotattributes[:fillrange] = arg.size)
         arg.color === nothing || (
             plotattributes[:fillcolor] =
-                arg.color == :auto ? :auto : plot_color(arg.color)
+                arg.color === :auto ? :auto : plot_color(arg.color)
         )
         arg.alpha === nothing || (plotattributes[:fillalpha] = arg.alpha)
         arg.style === nothing || (plotattributes[:fillstyle] = arg.style)
@@ -1349,7 +1349,7 @@ function processFontArg!(plotattributes::AKW, fontname::Symbol, arg)
         plotattributes[Symbol(fontname, :valign)] = arg.valign
         plotattributes[Symbol(fontname, :rotation)] = arg.rotation
         plotattributes[Symbol(fontname, :color)] = arg.color
-    elseif arg == :center
+    elseif arg === :center
         plotattributes[Symbol(fontname, :halign)] = :hcenter
         plotattributes[Symbol(fontname, :valign)] = :vcenter
     elseif arg ∈ _haligns
@@ -1515,7 +1515,7 @@ function RecipesPipeline.preprocess_attributes!(plotattributes::AKW)
     RecipesPipeline.reset_kw!(plotattributes, :marker)
     if haskey(plotattributes, :markershape)
         plotattributes[:markershape] = _replace_markershape(plotattributes[:markershape])
-        if plotattributes[:markershape] == :none &&
+        if plotattributes[:markershape] === :none &&
            get(plotattributes, :seriestype, :path) in
            (:scatter, :scatterbins, :scatterhist, :scatter3d) #the default should be :auto, not :none, so that :none can be set explicitly and would be respected
             plotattributes[:markershape] = :circle
@@ -1702,7 +1702,7 @@ function convertLegendValue(val::Symbol)
         :inline,
     )
         val
-    elseif val == :horizontal
+    elseif val === :horizontal
         -1
     else
         error("Invalid symbol for legend: $val")
@@ -1781,7 +1781,7 @@ end
 # -----------------------------------------------------------------------------
 
 function color_or_nothing!(plotattributes, k::Symbol)
-    plotattributes[k] = (v = plotattributes[k]) == :match ? v : plot_color(v)
+    plotattributes[k] = (v = plotattributes[k]) === :match ? v : plot_color(v)
     return
 end
 
@@ -1834,7 +1834,7 @@ const _match_map2 = KW(
 
 # properly retrieve from plt.attr, passing `:match` to the correct key
 function Base.getindex(plt::Plot, k::Symbol)
-    if (v = plt.attr[k]) == :match
+    if (v = plt.attr[k]) === :match
         plt[_match_map[k]]
     else
         v
@@ -1843,7 +1843,7 @@ end
 
 # properly retrieve from sp.attr, passing `:match` to the correct key
 function Base.getindex(sp::Subplot, k::Symbol)
-    if (v = sp.attr[k]) == :match
+    if (v = sp.attr[k]) === :match
         if haskey(_match_map2, k)
             sp.plt[_match_map2[k]]
         else
@@ -1856,7 +1856,7 @@ end
 
 # properly retrieve from axis.attr, passing `:match` to the correct key
 function Base.getindex(axis::Axis, k::Symbol)
-    if (v = axis.plotattributes[k]) == :match
+    if (v = axis.plotattributes[k]) === :match
         if haskey(_match_map2, k)
             axis.sps[1][_match_map2[k]]
         else
@@ -1883,7 +1883,7 @@ Base.get(series::Series, k::Symbol, v) = get(series.plotattributes, k, v)
 
 function fg_color(plotattributes::AKW)
     fg = get(plotattributes, :foreground_color, :auto)
-    if fg == :auto
+    if fg === :auto
         bg = plot_color(get(plotattributes, :background_color, :white))
         fg = isdark(bg) ? colorant"white" : colorant"black"
     else
@@ -1892,7 +1892,7 @@ function fg_color(plotattributes::AKW)
 end
 
 function fg_color_sp(plotattributes::AKW)
-    if (fg = get(plotattributes, :foreground_color_subplot, :match)) == :match
+    if (fg = get(plotattributes, :foreground_color_subplot, :match)) === :match
         fg_color(plotattributes)
     else
         plot_color(fg)
@@ -1911,7 +1911,7 @@ function _update_plot_args(plt::Plot, plotattributes_in::AKW)
     plt[:foreground_color] = fg_color(plotattributes)
     # bg = plot_color(plt.attr[:background_color])
     # fg = plt.attr[:foreground_color]
-    # if fg == :auto
+    # if fg === :auto
     #     fg = isdark(bg) ? colorant"white" : colorant"black"
     # end
     # plt.attr[:background_color] = bg
@@ -1932,7 +1932,7 @@ function _update_subplot_periphery(sp::Subplot, anns::AVec)
     # handle legend/colorbar
     sp.attr[:legend_position] = convertLegendValue(sp.attr[:legend_position])
     sp.attr[:colorbar] = convertLegendValue(sp.attr[:colorbar])
-    if sp.attr[:colorbar] == :legend
+    if sp.attr[:colorbar] === :legend
         sp.attr[:colorbar] = sp.attr[:legend_position]
     end
     return
@@ -2073,7 +2073,7 @@ has_black_border_for_default(st::Symbol) =
 # converts a symbol or string into a Colorant or ColorGradient
 # and assigns a color automatically
 function get_series_color(c, sp::Subplot, n::Int, seriestype)
-    if c == :auto
+    if c === :auto
         c = like_surface(seriestype) ? cgrad() : _cycle(sp[:color_palette], n)
     elseif isa(c, Int)
         c = _cycle(sp[:color_palette], c)
@@ -2100,7 +2100,7 @@ end
 
 function _replace_linewidth(plotattributes::AKW)
     # get a good default linewidth... 0 for surface and heatmaps
-    if plotattributes[:linewidth] == :auto
+    if plotattributes[:linewidth] === :auto
         plotattributes[:linewidth] = (
             get(plotattributes, :seriestype, :path) in (:surface, :heatmap, :image) ? 0 : 1
         )
@@ -2120,9 +2120,9 @@ label_to_string(label::Bool, series_plotindex) =
 label_to_string(label::Nothing, series_plotindex) = ""
 label_to_string(label::Missing, series_plotindex) = ""
 function label_to_string(label::Symbol, series_plotindex)
-    if label == :auto
+    if label === :auto
         return string("y", series_plotindex)
-    elseif label == :none
+    elseif label === :none
         return ""
     else
         throw(ArgumentError("unsupported symbol $(label) passed to `label`"))
@@ -2168,13 +2168,13 @@ function _update_series_attributes!(plotattributes::AKW, plt::Plot, sp::Subplot)
     # update other colors
     for s in (:line, :marker, :fill)
         csym, asym = Symbol(s, :color), Symbol(s, :alpha)
-        plotattributes[csym] = if plotattributes[csym] == :auto
-            plot_color(if has_black_border_for_default(stype) && s == :line
+        plotattributes[csym] = if plotattributes[csym] === :auto
+            plot_color(if has_black_border_for_default(stype) && s === :line
                 sp[:foreground_color_subplot]
             else
                 scolor
             end)
-        elseif plotattributes[csym] == :match
+        elseif plotattributes[csym] === :match
             plot_color(scolor)
         else
             get_series_color(plotattributes[csym], sp, plotIndex, stype)
@@ -2182,9 +2182,9 @@ function _update_series_attributes!(plotattributes::AKW, plt::Plot, sp::Subplot)
     end
 
     # update markerstrokecolor
-    plotattributes[:markerstrokecolor] = if plotattributes[:markerstrokecolor] == :match
+    plotattributes[:markerstrokecolor] = if plotattributes[:markerstrokecolor] === :match
         plot_color(sp[:foreground_color_subplot])
-    elseif plotattributes[:markerstrokecolor] == :auto
+    elseif plotattributes[:markerstrokecolor] === :auto
         get_series_color(plotattributes[:markercolor], sp, plotIndex, stype)
     else
         get_series_color(plotattributes[:markerstrokecolor], sp, plotIndex, stype)
@@ -2204,7 +2204,7 @@ function _update_series_attributes!(plotattributes::AKW, plt::Plot, sp::Subplot)
     # scatter plots don't have a line, but must have a shape
     if plotattributes[:seriestype] in (:scatter, :scatterbins, :scatterhist, :scatter3d)
         plotattributes[:linewidth] = 0
-        if plotattributes[:markershape] == :none
+        if plotattributes[:markershape] === :none
             plotattributes[:markershape] = :circle
         end
     end

--- a/src/args.jl
+++ b/src/args.jl
@@ -1385,7 +1385,7 @@ function _add_markershape(plotattributes::AKW)
     # add the markershape if it needs to be added... hack to allow "m=10" to add a shape,
     # and still allow overriding in _apply_recipe
     ms = pop!(plotattributes, :markershape_to_add, :none)
-    if !haskey(plotattributes, :markershape) && ms != :none
+    if !haskey(plotattributes, :markershape) && ms !== :none
         plotattributes[:markershape] = ms
     end
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -91,16 +91,16 @@ function attr!(axis::Axis, args...; kw...)
     # then override for any keywords... only those keywords that already exists in plotattributes
     for (k, v) in kw
         if haskey(plotattributes, k)
-            if k == :discrete_values
+            if k === :discrete_values
                 # add these discrete values to the axis
                 for vi in v
                     discrete_value!(axis, vi)
                 end
                 #could perhaps use TimeType here, as Date and DateTime are both subtypes of TimeType
                 # or could perhaps check if dateformatter or datetimeformatter is in use
-            elseif k == :lims && isa(v, Tuple{Date,Date})
+            elseif k === :lims && isa(v, Tuple{Date,Date})
                 plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
-            elseif k == :lims && isa(v, Tuple{DateTime,DateTime})
+            elseif k === :lims && isa(v, Tuple{DateTime,DateTime})
                 plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
             else
                 plotattributes[k] = v
@@ -148,7 +148,7 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
     # or DateTime) is chosen based on the time span between amin and amax
     # rather than on the input format
     # TODO: maybe: non-trivial scale (:ln, :log2, :log10) for date/datetime
-    if ticks === nothing && scale == :identity
+    if ticks === nothing && scale === :identity
         if formatter == RecipesPipeline.dateformatter
             # optimize_datetime_ticks returns ticks and labels(!) based on
             # integers/floats corresponding to the DateTime type. Thus, the axes
@@ -195,7 +195,7 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
     labels = if any(isfinite, unscaled_ticks)
         if formatter in (:auto, :plain, :scientific, :engineering)
             map(labelfunc(scale, backend()), Showoff.showoff(scaled_ticks, formatter))
-        elseif formatter == :latex
+        elseif formatter === :latex
             map(
                 x -> string("\$", replace(convert_sci_unicode(x), '×' => "\\times"), "\$"),
                 Showoff.showoff(unscaled_ticks, :auto),
@@ -215,7 +215,7 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
     end
 
     # @show unscaled_ticks labels
-    # labels = Showoff.showoff(unscaled_ticks, scale == :log10 ? :scientific : :auto)
+    # labels = Showoff.showoff(unscaled_ticks, scale === :log10 ? :scientific : :auto)
     unscaled_ticks, labels
 end
 
@@ -362,7 +362,7 @@ function get_minor_ticks(sp, axis, ticks)
     end
 
     # default to 9 intervals between major ticks for log10 scale and 5 intervals otherwise
-    n_default = (scale == :log10) ? 9 : 5
+    n_default = (scale === :log10) ? 9 : 5
     n =
         typeof(axis[:minorticks]) <: Integer && axis[:minorticks] > 1 ? axis[:minorticks] :
         n_default
@@ -440,11 +440,11 @@ function expand_extrema!(sp::Subplot, plotattributes::AKW)
         data = plotattributes[if vert
             letter
         else
-            letter == :x ? :y : letter == :y ? :x : :z
+            letter === :x ? :y : letter === :y ? :x : :z
         end]
         if (
             letter != :z &&
-            plotattributes[:seriestype] == :straightline &&
+            plotattributes[:seriestype] === :straightline &&
             any(series[:seriestype] != :straightline for series in series_list(sp)) &&
             data[1] != data[2]
         )
@@ -482,7 +482,7 @@ function expand_extrema!(sp::Subplot, plotattributes::AKW)
 
     # expand for fillrange
     fr = plotattributes[:fillrange]
-    if fr === nothing && plotattributes[:seriestype] == :bar
+    if fr === nothing && plotattributes[:seriestype] === :bar
         fr = 0.0
     end
     if fr !== nothing && !RecipesPipeline.is3d(plotattributes)
@@ -497,7 +497,7 @@ function expand_extrema!(sp::Subplot, plotattributes::AKW)
     end
 
     # expand for bar_width
-    if plotattributes[:seriestype] == :bar
+    if plotattributes[:seriestype] === :bar
         dsym = vert ? :x : :y
         data = plotattributes[dsym]
 
@@ -513,7 +513,7 @@ function expand_extrema!(sp::Subplot, plotattributes::AKW)
     end
 
     # expand for heatmaps
-    if plotattributes[:seriestype] == :heatmap
+    if plotattributes[:seriestype] === :heatmap
         for letter in (:x, :y)
             data = plotattributes[letter]
             axis = sp[get_attr_symbol(letter, :axis)]
@@ -568,7 +568,7 @@ function default_should_widen(axis::Axis)
         return axis[:widen]
     end
     # automatic behavior: widen if limits aren't specified and series type is appropriate
-    (is_2tuple(axis[:lims]) || axis[:lims] == :round) && return false
+    (is_2tuple(axis[:lims]) || axis[:lims] === :round) && return false
     for sp in axis.sps
         for series in series_list(sp)
             if series.plotattributes[:seriestype] in _widen_seriestypes
@@ -601,16 +601,16 @@ function axis_limits(
     has_user_lims = (isa(lims, Tuple) || isa(lims, AVec)) && length(lims) == 2
     if has_user_lims
         lmin, lmax = lims
-        if lmin == :auto
+        if lmin === :auto
         elseif isfinite(lmin)
             amin = lmin
         end
-        if lmax == :auto
+        if lmax === :auto
         elseif isfinite(lmax)
             amax = lmax
         end
     end
-    if lims == :symmetric
+    if lims === :symmetric
         aval = max(abs(amin), abs(amax))
         amin = -aval
         amax = aval
@@ -622,9 +622,9 @@ function axis_limits(
         amin, amax = 0.0, 1.0
     end
     amin, amax = if ispolar(axis.sps[1])
-        if axis[:letter] == :x
+        if axis[:letter] === :x
             amin, amax = 0, 2pi
-        elseif lims == :auto
+        elseif lims === :auto
             # widen max radius so ticks dont overlap with theta axis
             0, amax + 0.1 * abs(amax - amin)
         else
@@ -632,7 +632,7 @@ function axis_limits(
         end
     elseif should_widen
         widen(amin, amax, axis[:scale])
-    elseif lims == :round
+    elseif lims === :round
         round_limits(amin, amax, axis[:scale])
     else
         amin, amax
@@ -648,7 +648,7 @@ function axis_limits(
         plot_ratio = height(plotarea(sp)) / width(plotarea(sp))
         dist = amax - amin
 
-        if letter == :x
+        if letter === :x
             yamin, yamax = axis_limits(sp, :y, default_should_widen(sp[:yaxis]), false)
             ydist = yamax - yamin
             axis_ratio = aspect_ratio * ydist / dist
@@ -763,7 +763,7 @@ function axis_drawing_info(sp, letter)
                 push!(segments, reverse_if((amin, oa1), isy), reverse_if((amax, oa1), isy))
                 # don't show the 0 tick label for the origin framestyle
                 if (
-                    sp[:framestyle] == :origin &&
+                    sp[:framestyle] === :origin &&
                     !(ticks in (:none, nothing, false)) &&
                     length(ticks) > 1
                 )
@@ -789,11 +789,11 @@ function axis_drawing_info(sp, letter)
             add_major_or_minor_segments(ticks, grid, segments, factor, cond) = begin
                 ticks === nothing && return
                 if cond
-                    tick_start, tick_stop = if sp[:framestyle] == :origin
+                    tick_start, tick_stop = if sp[:framestyle] === :origin
                         t = invf(f(0) + factor * (f(oamax) - f(oamin)))
                         (-t, t)
                     else
-                        ticks_in = ax[:tick_direction] == :out ? -1 : 1
+                        ticks_in = ax[:tick_direction] === :out ? -1 : 1
                         t = invf(f(oa1) + factor * (f(oa2) - f(oa1)) * ticks_in)
                         (oa1, t)
                     end
@@ -903,7 +903,7 @@ function axis_drawing_info_3d(sp, letter)
                 )
                 # don't show the 0 tick label for the origin framestyle
                 if (
-                    sp[:framestyle] == :origin &&
+                    sp[:framestyle] === :origin &&
                     !(ticks in (:none, nothing, false)) &&
                     length(ticks) > 1
                 )
@@ -932,11 +932,11 @@ function axis_drawing_info_3d(sp, letter)
             add_major_or_minor_segments(ticks, grid, segments, factor, cond) = begin
                 ticks === nothing && return
                 if cond
-                    tick_start, tick_stop = if sp[:framestyle] == :origin
+                    tick_start, tick_stop = if sp[:framestyle] === :origin
                         t = invf(f(0) + factor * (f(namax) - f(namin)))
                         (-t, t)
                     else
-                        ticks_in = ax[:tick_direction] == :out ? -1 : 1
+                        ticks_in = ax[:tick_direction] === :out ? -1 : 1
                         t = invf(f(na0) + factor * (f(na1) - f(na0)) * ticks_in)
                         (na0, t)
                     end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -443,9 +443,9 @@ function expand_extrema!(sp::Subplot, plotattributes::AKW)
             letter === :x ? :y : letter === :y ? :x : :z
         end]
         if (
-            letter != :z &&
+            letter !== :z &&
             plotattributes[:seriestype] === :straightline &&
-            any(series[:seriestype] != :straightline for series in series_list(sp)) &&
+            any(series[:seriestype] !== :straightline for series in series_list(sp)) &&
             data[1] != data[2]
         )
             data = [NaN]
@@ -752,14 +752,14 @@ function axis_drawing_info(sp, letter)
     minorgrid_segments = Segments(2)
     border_segments = Segments(2)
 
-    if sp[:framestyle] != :none
+    if sp[:framestyle] !== :none
         oa1, oa2 = if sp[:framestyle] in (:origin, :zerolines)
             0.0, 0.0
         else
             xor(ax[:mirror], oax[:flip]) ? (oamax, oamin) : (oamin, oamax)
         end
         if ax[:showaxis]
-            if sp[:framestyle] != :grid
+            if sp[:framestyle] !== :grid
                 push!(segments, reverse_if((amin, oa1), isy), reverse_if((amax, oa1), isy))
                 # don't show the 0 tick label for the origin framestyle
                 if (
@@ -882,7 +882,7 @@ function axis_drawing_info_3d(sp, letter)
     minorgrid_segments = Segments(3)
     border_segments = Segments(3)
 
-    if sp[:framestyle] != :none  # && letter === :x
+    if sp[:framestyle] !== :none  # && letter === :x
         na0, na1 = if sp[:framestyle] in (:origin, :zerolines)
             0, 0
         else
@@ -895,7 +895,7 @@ function axis_drawing_info_3d(sp, letter)
             reverse_if((famin, famax), xor(ax[:mirror], fax[:flip]))
         end
         if ax[:showaxis]
-            if sp[:framestyle] != :grid
+            if sp[:framestyle] !== :grid
                 push!(
                     segments,
                     sort_3d_axes(amin, na0, fa0, letter),

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -85,7 +85,7 @@ function tick_padding(sp::Subplot, axis::Axis)
         longest_label = maximum(length(lab) for lab in labs)
 
         # generalize by "rotating" y labels
-        rot = axis[:rotation] + (axis[:letter] == :y ? 90 : 0)
+        rot = axis[:rotation] + (axis[:letter] === :y ? 90 : 0)
 
         # # we need to compute the size of the ticks generically
         # # this means computing the bounding box and then getting the width/height
@@ -160,7 +160,7 @@ end
 Returns the current plotting package name.  Initializes package on first call.
 """
 function backend()
-    if CURRENT_BACKEND.sym == :none
+    if CURRENT_BACKEND.sym === :none
         _pick_default_backend()
     end
 
@@ -195,7 +195,7 @@ const _deprecated_backends =
 
 function warn_on_deprecated_backend(bsym::Symbol)
     if bsym in _deprecated_backends
-        if bsym == :pgfplots
+        if bsym === :pgfplots
             @warn("Backend $bsym has been deprecated. Use pgfplotsx instead.")
         else
             @warn("Backend $bsym has been deprecated.")

--- a/src/backends/deprecated/pgfplots.jl
+++ b/src/backends/deprecated/pgfplots.jl
@@ -227,7 +227,7 @@ function pgf_series(sp::Subplot, series::Series)
             end
 
             # add to legend?
-            if i == 1 && sp[:legend_position] != :none && should_add_to_legend(series)
+            if i == 1 && sp[:legend_position] !== :none && should_add_to_legend(series)
                 if plotattributes[:fillrange] !== nothing
                     push!(style, "forget plot")
                     push!(series_collection, pgf_fill_legend_hack(plotattributes, args))
@@ -250,7 +250,7 @@ function pgf_series(sp::Subplot, series::Series)
             kw[:style] = join(style, ',')
 
             # add fillrange
-            if series[:fillrange] !== nothing && st != :shape
+            if series[:fillrange] !== nothing && st !== :shape
                 push!(
                     series_collection,
                     pgf_fillrange_series(
@@ -388,7 +388,7 @@ function pgf_axis(sp::Subplot, letter)
     end
 
     # grid on or off
-    if axis[:grid] && framestyle != :none
+    if axis[:grid] && framestyle !== :none
         push!(style, "$(letter)majorgrids = true")
     else
         push!(style, "$(letter)majorgrids = false")
@@ -396,7 +396,7 @@ function pgf_axis(sp::Subplot, letter)
 
     # limits
     # TODO: support zlims
-    if letter != :z
+    if letter !== :z
         lims =
             ispolar(sp) && letter === :x ? rad2deg.(axis_limits(sp, :x)) :
             axis_limits(sp, letter)
@@ -404,7 +404,7 @@ function pgf_axis(sp::Subplot, letter)
         kw[get_attr_symbol(letter, :max)] = lims[2]
     end
 
-    if !(axis[:ticks] in (nothing, false, :none, :native)) && framestyle != :none
+    if !(axis[:ticks] in (nothing, false, :none, :native)) && framestyle !== :none
         ticks = get_ticks(sp, axis)
         #pgf plot ignores ticks with angle below 90 when xmin = 90 so shift values
         tick_values =
@@ -544,7 +544,7 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
 
         # add to style/kw for each axis
         for letter in (:x, :y, :z)
-            if letter != :z || RecipesPipeline.is3d(sp)
+            if letter !== :z || RecipesPipeline.is3d(sp)
                 axisstyle, axiskw = pgf_axis(sp, letter)
                 append!(style, axisstyle)
                 merge!(kw, axiskw)

--- a/src/backends/deprecated/pgfplots.jl
+++ b/src/backends/deprecated/pgfplots.jl
@@ -135,12 +135,12 @@ function pgf_marker(plotattributes, i = 1)
     return string(
         "mark = $(get(_pgfplots_markers, shape, "*")),\n",
         "mark size = $(pgf_thickness_scaling(plotattributes) * 0.5 * _cycle(plotattributes[:markersize], i)),\n",
-        plotattributes[:seriestype] == :scatter ? "only marks,\n" : "",
+        plotattributes[:seriestype] === :scatter ? "only marks,\n" : "",
         "mark options = {
             color = $cstr_stroke, draw opacity = $a_stroke,
             fill = $cstr, fill opacity = $a,
             line width = $(pgf_thickness_scaling(plotattributes) * _cycle(plotattributes[:markerstrokewidth], i)),
-            rotate = $(shape == :dtriangle ? 180 : 0),
+            rotate = $(shape === :dtriangle ? 180 : 0),
             $(get(_pgfplots_linestyles, _cycle(plotattributes[:markerstrokestyle], i), "solid"))
         }",
     )
@@ -174,13 +174,13 @@ function pgf_series(sp::Subplot, series::Series)
     series_collection = PGFPlots.Plot[]
 
     # function args
-    args = if st == :contour
+    args = if st === :contour
         plotattributes[:z].surf, plotattributes[:x], plotattributes[:y]
     elseif RecipesPipeline.is3d(st)
         plotattributes[:x], plotattributes[:y], plotattributes[:z]
-    elseif st == :straightline
+    elseif st === :straightline
         straightline_data(series)
-    elseif st == :shape
+    elseif st === :shape
         shape_data(series)
     elseif ispolar(sp)
         theta, r = plotattributes[:x], plotattributes[:y]
@@ -204,7 +204,7 @@ function pgf_series(sp::Subplot, series::Series)
         push!(style, "forget plot")
 
         kw[:style] = join(style, ',')
-        func = if st == :histogram2d
+        func = if st === :histogram2d
             PGFPlots.Histogram2
         else
             kw[:labels] = series[:contour_labels]
@@ -222,7 +222,7 @@ function pgf_series(sp::Subplot, series::Series)
             push!(style, pgf_linestyle(plotattributes, i))
             push!(style, pgf_marker(plotattributes, i))
 
-            if st == :shape
+            if st === :shape
                 push!(style, pgf_fillstyle(plotattributes, i))
             end
 
@@ -233,7 +233,7 @@ function pgf_series(sp::Subplot, series::Series)
                     push!(series_collection, pgf_fill_legend_hack(plotattributes, args))
                 else
                     kw[:legendentry] = plotattributes[:label]
-                    if st == :shape # || plotattributes[:fillrange] !== nothing
+                    if st === :shape # || plotattributes[:fillrange] !== nothing
                         push!(style, "area legend")
                     end
                 end
@@ -263,9 +263,9 @@ function pgf_series(sp::Subplot, series::Series)
             end
 
             # build/return the series object
-            func = if st == :path3d
+            func = if st === :path3d
                 PGFPlots.Linear3
-            elseif st == :scatter
+            elseif st === :scatter
                 PGFPlots.Scatter
             else
                 PGFPlots.Linear
@@ -318,9 +318,9 @@ function pgf_fill_legend_hack(plotattributes, args)
     kw[:legendentry] = plotattributes[:label]
     kw[:style] = join(style, ',')
     st = plotattributes[:seriestype]
-    func = if st == :path3d
+    func = if st === :path3d
         PGFPlots.Linear3
-    elseif st == :scatter
+    elseif st === :scatter
         PGFPlots.Scatter
     else
         PGFPlots.Linear
@@ -346,9 +346,9 @@ function pgf_axis(sp::Subplot, letter)
 
     # axis label position
     labelpos = ""
-    if letter == :x && axis[:guide_position] == :top
+    if letter === :x && axis[:guide_position] === :top
         labelpos = "at={(0.5,1)},above,"
-    elseif letter == :y && axis[:guide_position] == :right
+    elseif letter === :y && axis[:guide_position] === :right
         labelpos = "at={(1,0.5)},below,"
     end
 
@@ -379,11 +379,11 @@ function pgf_axis(sp::Subplot, letter)
     scale = axis[:scale]
     if scale in (:log2, :ln, :log10)
         kw[get_attr_symbol(letter, :mode)] = "log"
-        scale == :ln || push!(style, "log basis $letter=$(scale == :log2 ? 2 : 10)")
+        scale === :ln || push!(style, "log basis $letter=$(scale === :log2 ? 2 : 10)")
     end
 
     # ticks on or off
-    if axis[:ticks] in (nothing, false, :none) || framestyle == :none
+    if axis[:ticks] in (nothing, false, :none) || framestyle === :none
         push!(style, "$(letter)majorticks=false")
     end
 
@@ -398,7 +398,7 @@ function pgf_axis(sp::Subplot, letter)
     # TODO: support zlims
     if letter != :z
         lims =
-            ispolar(sp) && letter == :x ? rad2deg.(axis_limits(sp, :x)) :
+            ispolar(sp) && letter === :x ? rad2deg.(axis_limits(sp, :x)) :
             axis_limits(sp, letter)
         kw[get_attr_symbol(letter, :min)] = lims[1]
         kw[get_attr_symbol(letter, :max)] = lims[2]
@@ -408,10 +408,10 @@ function pgf_axis(sp::Subplot, letter)
         ticks = get_ticks(sp, axis)
         #pgf plot ignores ticks with angle below 90 when xmin = 90 so shift values
         tick_values =
-            ispolar(sp) && letter == :x ? [rad2deg.(ticks[1])[3:end]..., 360, 405] :
+            ispolar(sp) && letter === :x ? [rad2deg.(ticks[1])[3:end]..., 360, 405] :
             ticks[1]
         push!(style, string(letter, "tick = {", join(tick_values, ","), "}"))
-        if axis[:showaxis] && axis[:scale] in (:ln, :log2, :log10) && axis[:ticks] == :auto
+        if axis[:showaxis] && axis[:scale] in (:ln, :log2, :log10) && axis[:ticks] === :auto
             # wrap the power part of label with }
             tick_labels = Vector{String}(undef, length(ticks[2]))
             for (i, label) in enumerate(ticks[2])
@@ -425,7 +425,7 @@ function pgf_axis(sp::Subplot, letter)
             )
         elseif axis[:showaxis]
             tick_labels =
-                ispolar(sp) && letter == :x ? [ticks[2][3:end]..., "0", "45"] : ticks[2]
+                ispolar(sp) && letter === :x ? [ticks[2][3:end]..., "0", "45"] : ticks[2]
             if axis[:formatter] in (:scientific, :auto)
                 tick_labels = string.("\$", convert_sci_unicode.(tick_labels), "\$")
                 tick_labels = replace.(tick_labels, Ref("×" => "\\times"))
@@ -439,7 +439,7 @@ function pgf_axis(sp::Subplot, letter)
             string(
                 letter,
                 "tick align = ",
-                (axis[:tick_direction] == :out ? "outside" : "inside"),
+                (axis[:tick_direction] === :out ? "outside" : "inside"),
             ),
         )
         cstr, α = pgf_color(plot_color(axis[:tickfontcolor]))
@@ -476,7 +476,7 @@ function pgf_axis(sp::Subplot, letter)
 
     # framestyle
     if framestyle in (:axes, :origin)
-        axispos = framestyle == :axes ? "left" : "middle"
+        axispos = framestyle === :axes ? "left" : "middle"
         if axis[:draw_arrow]
             push!(style, string("axis ", letter, " line = ", axispos))
         else
@@ -485,7 +485,7 @@ function pgf_axis(sp::Subplot, letter)
         end
     end
 
-    if framestyle == :zerolines
+    if framestyle === :zerolines
         push!(style, string("extra ", letter, " ticks = 0"))
         push!(style, string("extra ", letter, " tick labels = "))
         push!(
@@ -617,7 +617,7 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
             ),
         )
 
-        if any(s[:seriestype] == :contour for s in series_list(sp))
+        if any(s[:seriestype] === :contour for s in series_list(sp))
             kw[:view] = "{0}{90}"
             kw[:colorbar] = !(sp[:colorbar] in (:none, :off, :hide, false))
         elseif RecipesPipeline.is3d(sp)
@@ -626,7 +626,7 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
         end
 
         axisf = PGFPlots.Axis
-        if sp[:projection] == :polar
+        if sp[:projection] === :polar
             axisf = PGFPlots.PolarAxis
             #make radial axis vertical
             kw[:xmin] = 90
@@ -651,7 +651,7 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
                         "colormap={plots}{$(pgf_colormap(series.plotattributes[col]))}",
                     )
 
-                    if sp[:colorbar] == :none
+                    if sp[:colorbar] === :none
                         kw[:colorbar] = "false"
                     else
                         kw[:colorbar] = "true"

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -398,7 +398,7 @@ function gaston_parse_axes_args(
             )
 
             # major tick locations
-            if axis[:ticks] != :native
+            if axis[:ticks] !== :native
                 if axis[:flip]
                     hi, lo = axis_limits(sp, letter)
                 else
@@ -409,7 +409,7 @@ function gaston_parse_axes_args(
                 ticks = get_ticks(sp, axis)
                 gaston_set_ticks!(axesconf, ticks, letter, "", "")
 
-                if axis[:minorticks] != :native
+                if axis[:minorticks] !== :native
                     minor_ticks = get_minor_ticks(sp, axis, ticks)
                     gaston_set_ticks!(axesconf, minor_ticks, letter, "m", "add")
                 end
@@ -423,7 +423,7 @@ function gaston_parse_axes_args(
         end
 
         ratio = get_aspect_ratio(sp)
-        if ratio != :none
+        if ratio !== :none
             ratio === :equal && (ratio = -1)
             push!(axesconf, "set size ratio $ratio")
         end

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -235,7 +235,7 @@ function gaston_add_series(plt::Plot{GastonBackend}, series::Series)
     else
         if z isa Surface
             z = z.surf
-            if st == :image
+            if st === :image
                 z = reverse(Float32.(Gray.(z)), dims = 1)  # flip y axis
                 nr, nc = size(z)
                 if (ly = length(y)) == 2 && ly != nr
@@ -248,7 +248,7 @@ function gaston_add_series(plt::Plot{GastonBackend}, series::Series)
             length(x) == size(z, 2) + 1 && (x = (x[1:(end - 1)] + x[2:end]) / 2)
             length(y) == size(z, 1) + 1 && (y = (y[1:(end - 1)] + y[2:end]) / 2)
         end
-        if st == :mesh3d
+        if st === :mesh3d
             x, y, z = mesh3d_triangles(x, y, z, series[:connections])
         end
         for sc in gaston_seriesconf!(sp, series, 1, true)
@@ -309,45 +309,45 @@ function gaston_seriesconf!(
                 curveconf,
                 "w filledcurves fc $fc fs solid border lc $lc lw $lw dt $dt,'' w lines lc $lc lw $lw dt $dt",
             )
-        elseif series[:markershape] == :none  # simplepath
+        elseif series[:markershape] === :none  # simplepath
             push!(curveconf, "w lines lc $lc dt $dt lw $lw")
         else
             pt, ps, mc = gaston_mk_ms_mc(series, clims, i)
             push!(curveconf, "w lp lc $mc dt $dt lw $lw pt $pt ps $ps")
         end
-    elseif st == :shape
+    elseif st === :shape
         fc = gaston_color(get_fillcolor(series, i), get_fillalpha(series, i))
         lc, _ = gaston_lc_ls_lw(series, clims, i)
         push!(curveconf, "w filledcurves fc $fc fs solid border lc $lc")
     elseif st ∈ (:steppre, :stepmid, :steppost)
-        step = if st == :steppre
+        step = if st === :steppre
             "fsteps"
-        elseif st == :stepmid
+        elseif st === :stepmid
             "histeps"
-        elseif st == :steppost
+        elseif st === :steppost
             "steps"
         end
         push!(curveconf, "w $step")
         lc, dt, lw = gaston_lc_ls_lw(series, clims, i)
         push!(extra, "w points lc $lc dt $dt lw $lw notitle")
-    elseif st == :image
+    elseif st === :image
         palette = gaston_palette(series[:seriescolor])
         gsp.axesconf *= "\nset palette model RGB defined $palette"
         push!(curveconf, "w image pixels")
     elseif st ∈ (:contour, :contour3d)
         push!(curveconf, "w lines")
-        st == :contour && (gsp.axesconf *= "\nset view map\nunset surface")  # 2D
+        st === :contour && (gsp.axesconf *= "\nset view map\nunset surface")  # 2D
         levels = join(map(string, collect(contour_levels(series, clims))), ", ")
         gsp.axesconf *= "\nset contour base\nset cntrparam levels discrete $levels"
     elseif st ∈ (:surface, :heatmap)
         push!(curveconf, "w pm3d")
         palette = gaston_palette(series[:seriescolor])
         gsp.axesconf *= "\nset palette model RGB defined $palette"
-        st == :heatmap && (gsp.axesconf *= "\nset view map")
+        st === :heatmap && (gsp.axesconf *= "\nset view map")
     elseif st ∈ (:wireframe, :mesh3d)
         lc, dt, lw = gaston_lc_ls_lw(series, clims, i)
         push!(curveconf, "w lines lc $lc dt $dt lw $lw")
-    elseif st == :quiver
+    elseif st === :quiver
         push!(curveconf, "w vectors filled")
     else
         @warn "Gaston: $st is not implemented yet"
@@ -368,7 +368,7 @@ function gaston_parse_axes_args(
     polar = ispolar(sp) && dims == 2  # cannot splot in polar coordinates
 
     for letter in (:x, :y, :z)
-        (letter == :z && dims == 2) && continue
+        (letter === :z && dims == 2) && continue
         axis = sp.attr[get_attr_symbol(letter, :axis)]
         # label names
         push!(
@@ -377,13 +377,13 @@ function gaston_parse_axes_args(
         )
         mirror = axis[:mirror] ? "mirror" : "nomirror"
 
-        if axis[:scale] == :identity
+        if axis[:scale] === :identity
             logscale, base = "nologscale", ""
-        elseif axis[:scale] == :log10
+        elseif axis[:scale] === :log10
             logscale, base = "logscale", "10"
-        elseif axis[:scale] == :log2
+        elseif axis[:scale] === :log2
             logscale, base = "logscale", "2"
-        elseif axis[:scale] == :ln
+        elseif axis[:scale] === :ln
             logscale, base = "logscale", "e"
         end
         push!(axesconf, "set $logscale $letter $base")
@@ -424,7 +424,7 @@ function gaston_parse_axes_args(
 
         ratio = get_aspect_ratio(sp)
         if ratio != :none
-            ratio == :equal && (ratio = -1)
+            ratio === :equal && (ratio = -1)
             push!(axesconf, "set size ratio $ratio")
         end
     end
@@ -443,9 +443,9 @@ function gaston_parse_axes_args(
         tmin, tmax = axis_limits(sp, :x, false, false)
         rmin, rmax = axis_limits(sp, :y, false, false)
         rticks = get_ticks(sp, :y)
-        if (ttype = ticksType(rticks)) == :ticks
+        if (ttype = ticksType(rticks)) === :ticks
             gaston_ticks = string.(rticks)
-        elseif ttype == :ticks_and_labels
+        elseif ttype === :ticks_and_labels
             gaston_ticks = String["'$l' $t" for (t, l) in zip(rticks...)]
         end
         push!(
@@ -467,14 +467,14 @@ function gaston_parse_axes_args(
 end
 
 function gaston_set_ticks!(axesconf, ticks, letter, maj_min, add)
-    ticks == :auto && return
+    ticks === :auto && return
     if ticks ∈ (:none, nothing, false)
         push!(axesconf, "unset $(maj_min)$(letter)tics")
         return
     end
 
     gaston_ticks = String[]
-    if (ttype = ticksType(ticks)) == :ticks
+    if (ttype = ticksType(ticks)) === :ticks
         tick_locs = @view ticks[:]
         for i in eachindex(tick_locs)
             tick = if maj_min == "m"
@@ -484,7 +484,7 @@ function gaston_set_ticks!(axesconf, ticks, letter, maj_min, add)
             end
             push!(gaston_ticks, tick)
         end
-    elseif ttype == :ticks_and_labels
+    elseif ttype === :ticks_and_labels
         tick_locs = @view ticks[1][:]
         tick_labels = @view ticks[2][:]
         for i in eachindex(tick_locs)
@@ -504,7 +504,7 @@ end
 function gaston_set_legend!(axesconf, sp, any_label)
     leg = sp[:legend_position]
     if sp[:legend_position] ∉ (:none, :inline) && any_label
-        leg == :best && (leg = :topright)
+        leg === :best && (leg = :topright)
 
         push!(
             axesconf,
@@ -567,17 +567,17 @@ end
 function gaston_marker(marker, alpha)
     # NOTE: :rtriangle, :ltriangle, :hexagon, :heptagon, :octagon seems unsupported by gnuplot
     filled = gaston_alpha(alpha) == 0
-    marker == :none && return -1
-    marker == :pixel && return 0
+    marker === :none && return -1
+    marker === :pixel && return 0
     marker ∈ (:+, :cross) && return 1
     marker ∈ (:x, :xcross) && return 2
-    marker == :star5 && return 3
-    marker == :rect && return filled ? 5 : 4
-    marker == :circle && return filled ? 7 : 6
-    marker == :utriangle && return filled ? 9 : 8
-    marker == :dtriangle && return filled ? 11 : 10
-    marker == :diamond && return filled ? 13 : 12
-    marker == :pentagon && return filled ? 15 : 14
+    marker === :star5 && return 3
+    marker === :rect && return filled ? 5 : 4
+    marker === :circle && return filled ? 7 : 6
+    marker === :utriangle && return filled ? 9 : 8
+    marker === :dtriangle && return filled ? 11 : 10
+    marker === :diamond && return filled ? 13 : 12
+    marker === :pentagon && return filled ? 15 : 14
 
     @warn "Gaston: unsupported marker $marker"
     return 1
@@ -590,11 +590,11 @@ function gaston_color(col, alpha = 0)
 end
 
 function gaston_linestyle(style)
-    style == :solid && return "1"
-    style == :dash && return "2"
-    style == :dot && return "3"
-    style == :dashdot && return "4"
-    style == :dashdotdot && return "5"
+    style === :solid && return "1"
+    style === :dash && return "2"
+    style === :dot && return "3"
+    style === :dashdot && return "4"
+    style === :dashdotdot && return "5"
 end
 
 function gaston_enclose_tick_string(tick_string)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -577,7 +577,7 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, clims, viewport_plotare
 
     ztick = 0.5 * GR.tick(zmin, zmax)
     gr_set_line(1, :solid, plot_color(:black), sp)
-    if sp[:colorbar_scale] == :log10
+    if sp[:colorbar_scale] === :log10
         GR.setscale(2)
     end
     GR.axes(0, ztick, xmax, zmin, 0, 1, 0.005)
@@ -604,18 +604,18 @@ gr_view_yposition(viewport_plotarea, position) =
     viewport_plotarea[3] + position * (viewport_plotarea[4] - viewport_plotarea[3])
 
 function position(symb)
-    if symb == :top || symb == :right
+    if symb === :top || symb === :right
         return 0.95
-    elseif symb == :left || symb == :bottom
+    elseif symb === :left || symb === :bottom
         return 0.05
     end
     return 0.5
 end
 
 function alignment(symb)
-    if symb == :top || symb == :right
+    if symb === :top || symb === :right
         return GR.TEXT_HALIGN_RIGHT
-    elseif symb == :left || symb == :bottom
+    elseif symb === :left || symb === :bottom
         return GR.TEXT_HALIGN_LEFT
     end
     return GR.TEXT_HALIGN_CENTER
@@ -867,8 +867,8 @@ function _update_min_padding!(sp::Subplot{GRBackend})
         end
         if h > 0mm
             if (
-                xaxis[:guide_position] == :top ||
-                (xaxis[:guide_position] == :auto && xaxis[:mirror] == true)
+                xaxis[:guide_position] === :top ||
+                (xaxis[:guide_position] === :auto && xaxis[:mirror] == true)
             )
                 toppad += h
             else
@@ -881,8 +881,8 @@ function _update_min_padding!(sp::Subplot{GRBackend})
             l = last(gr_text_size(sp[:zaxis][:guide]))
             w = 1mm + get_size(sp)[2] * l * px
             if (
-                zaxis[:guide_position] == :right ||
-                (zaxis[:guide_position] == :auto && zaxis[:mirror] == true)
+                zaxis[:guide_position] === :right ||
+                (zaxis[:guide_position] === :auto && zaxis[:mirror] == true)
             )
                 rightpad += w
             else
@@ -919,8 +919,8 @@ function _update_min_padding!(sp::Subplot{GRBackend})
             l = last(gr_text_size(sp[:xaxis][:guide]))
             h = 1mm + get_size(sp)[2] * l * px
             if (
-                sp[:xaxis][:guide_position] == :top ||
-                (sp[:xaxis][:guide_position] == :auto && sp[:xaxis][:mirror] == true)
+                sp[:xaxis][:guide_position] === :top ||
+                (sp[:xaxis][:guide_position] === :auto && sp[:xaxis][:mirror] == true)
             )
                 toppad += h
             else
@@ -933,8 +933,8 @@ function _update_min_padding!(sp::Subplot{GRBackend})
             l = last(gr_text_size(sp[:yaxis][:guide]))
             w = 1mm + get_size(sp)[2] * l * px
             if (
-                sp[:yaxis][:guide_position] == :right ||
-                (sp[:yaxis][:guide_position] == :auto && sp[:yaxis][:mirror] == true)
+                sp[:yaxis][:guide_position] === :right ||
+                (sp[:yaxis][:guide_position] === :auto && sp[:yaxis][:mirror] == true)
             )
                 rightpad += w
             else
@@ -1072,7 +1072,7 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                 gr_set_line(sp[:legend_font_pointsize] / 8, get_linestyle(series), lc, sp)
 
                 if (
-                    (st == :shape || series[:fillrange] !== nothing) &&
+                    (st === :shape || series[:fillrange] !== nothing) &&
                     series[:ribbon] === nothing
                 )
                     fc = get_fillcolor(series, clims)
@@ -1088,7 +1088,7 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                     lc = get_linecolor(series, clims)
                     gr_set_transparency(lc, get_linealpha(series))
                     gr_set_line(get_linewidth(series), get_linestyle(series), lc, sp)
-                    st == :shape && gr_polyline(x, y)
+                    st === :shape && gr_polyline(x, y)
                 end
 
                 if st in (:path, :straightline, :path3d)
@@ -1140,11 +1140,11 @@ function gr_legend_pos(sp::Subplot, leg, viewport_plotarea)
 
         xaxis, yaxis = sp[:xaxis], sp[:yaxis]
         xmirror =
-            xaxis[:guide_position] == :top ||
-            (xaxis[:guide_position] == :auto && xaxis[:mirror] == true)
+            xaxis[:guide_position] === :top ||
+            (xaxis[:guide_position] === :auto && xaxis[:mirror] == true)
         ymirror =
-            yaxis[:guide_position] == :right ||
-            (yaxis[:guide_position] == :auto && yaxis[:mirror] == true)
+            yaxis[:guide_position] === :right ||
+            (yaxis[:guide_position] === :auto && yaxis[:mirror] == true)
         axisclearance = [
             !ymirror * gr_axis_width(sp, sp[:yaxis]),
             ymirror * gr_axis_width(sp, sp[:yaxis]),
@@ -1161,11 +1161,11 @@ function gr_legend_pos(sp::Subplot, leg, viewport_plotarea)
     if occursin("outer", str)
         xaxis, yaxis = sp[:xaxis], sp[:yaxis]
         xmirror =
-            xaxis[:guide_position] == :top ||
-            (xaxis[:guide_position] == :auto && xaxis[:mirror] == true)
+            xaxis[:guide_position] === :top ||
+            (xaxis[:guide_position] === :auto && xaxis[:mirror] == true)
         ymirror =
-            yaxis[:guide_position] == :right ||
-            (yaxis[:guide_position] == :auto && yaxis[:mirror] == true)
+            yaxis[:guide_position] === :right ||
+            (yaxis[:guide_position] === :auto && yaxis[:mirror] == true)
     end
     if occursin("right", str)
         if occursin("outer", str)
@@ -1193,7 +1193,7 @@ function gr_legend_pos(sp::Subplot, leg, viewport_plotarea)
             leg.leftw - leg.rightw - leg.textw - leg.xoffset * 2
     end
     if occursin("top", str)
-        if s == :outertop
+        if s === :outertop
             ypos =
                 viewport_plotarea[4] +
                 leg.yoffset +
@@ -1203,7 +1203,7 @@ function gr_legend_pos(sp::Subplot, leg, viewport_plotarea)
             ypos = viewport_plotarea[4] - leg.yoffset - leg.dy
         end
     elseif occursin("bottom", str)
-        if s == :outerbottom
+        if s === :outerbottom
             ypos =
                 viewport_plotarea[3] - leg.yoffset - leg.dy -
                 !xmirror * gr_axis_height(sp, sp[:xaxis])
@@ -1310,11 +1310,11 @@ function gr_update_viewport_legend!(viewport_plotarea, sp, leg)
 
     xaxis, yaxis = sp[:xaxis], sp[:yaxis]
     xmirror =
-        xaxis[:guide_position] == :top ||
-        (xaxis[:guide_position] == :auto && xaxis[:mirror] == true)
+        xaxis[:guide_position] === :top ||
+        (xaxis[:guide_position] === :auto && xaxis[:mirror] == true)
     ymirror =
-        yaxis[:guide_position] == :right ||
-        (yaxis[:guide_position] == :auto && yaxis[:mirror] == true)
+        yaxis[:guide_position] === :right ||
+        (yaxis[:guide_position] === :auto && yaxis[:mirror] == true)
 
     if s isa Tuple{<:Real,Symbol}
         if s[2] === :outer
@@ -1355,7 +1355,7 @@ function gr_update_viewport_legend!(viewport_plotarea, sp, leg)
                 leg.h + leg.dy + leg.yoffset + !xmirror * gr_axis_height(sp, sp[:xaxis])
         end
     end
-    if s == :inline
+    if s === :inline
         if sp[:yaxis][:mirror]
             viewport_plotarea[1] += leg.w
         else
@@ -1368,7 +1368,7 @@ function gr_update_viewport_ratio!(viewport_plotarea, sp)
     ratio = get_aspect_ratio(sp)
     if ratio != :none
         xmin, xmax, ymin, ymax = gr_xy_axislims(sp)
-        if ratio == :equal
+        if ratio === :equal
             ratio = 1
         end
         viewport_ratio =
@@ -1408,9 +1408,9 @@ function gr_set_window(sp, viewport_plotarea)
 
         scaleop = 0
         if xmax > xmin && ymax > ymin && zok
-            sp[:xaxis][:scale] == :log10 && (scaleop |= GR.OPTION_X_LOG)
-            sp[:yaxis][:scale] == :log10 && (scaleop |= GR.OPTION_Y_LOG)
-            needs_3d && sp[:zaxis][:scale] == :log10 && (scaleop |= GR.OPTION_Z_LOG)
+            sp[:xaxis][:scale] === :log10 && (scaleop |= GR.OPTION_X_LOG)
+            sp[:yaxis][:scale] === :log10 && (scaleop |= GR.OPTION_Y_LOG)
+            needs_3d && sp[:zaxis][:scale] === :log10 && (scaleop |= GR.OPTION_Z_LOG)
             sp[:xaxis][:flip] && (scaleop |= GR.OPTION_FLIP_X)
             sp[:yaxis][:flip] && (scaleop |= GR.OPTION_FLIP_Y)
             needs_3d && sp[:zaxis][:flip] && (scaleop |= GR.OPTION_FLIP_Z)
@@ -1537,7 +1537,7 @@ function gr_draw_spine(sp, axis, segments, func = gr_polyline)
 end
 
 function gr_draw_border(sp, axis, segments, func = gr_polyline)
-    intensity = sp[:framestyle] == :semi ? 0.5 : 1
+    intensity = sp[:framestyle] === :semi ? 0.5 : 1
     if sp[:framestyle] in (:box, :semi)
         GR.setclip(0)
         gr_set_line(intensity, :solid, axis[:foreground_color_border], sp)
@@ -1553,7 +1553,7 @@ function gr_draw_ticks(sp, axis, segments, func = gr_polyline)
             gr_set_line(1, :solid, axis[:foreground_color_grid], sp)
             gr_set_transparency(
                 axis[:foreground_color_grid],
-                axis[:tick_direction] == :out ? axis[:gridalpha] : 0,
+                axis[:tick_direction] === :out ? axis[:gridalpha] : 0,
             )
         else
             gr_set_line(1, :solid, axis[:foreground_color_axis], sp)
@@ -1576,7 +1576,7 @@ function gr_label_ticks(sp, letter, ticks)
     y_base_offset = isy ? 0 : -8e-3 * out_factor
 
     rot = axis[:rotation] % 360
-    ov = sp[:framestyle] == :origin ? 0 : xor(oaxis[:flip], axis[:mirror]) ? oamax : oamin
+    ov = sp[:framestyle] === :origin ? 0 : xor(oaxis[:flip], axis[:mirror]) ? oamax : oamin
     sgn = axis[:mirror] ? -1 : 1
     sgn2 = iseven(Int(floor(rot / 90))) ? -1 : 1
     sgn3 = if isy
@@ -1635,8 +1635,8 @@ function gr_label_ticks_3d(sp, letter, ticks)
     xax, yax, zax = getindex.(Ref(sp), asyms)
 
     gr_set_tickfont(sp, letter)
-    nt = sp[:framestyle] == :origin ? 0 : ax[:mirror] ? n1 : n0
-    ft = sp[:framestyle] == :origin ? 0 : ax[:mirror] ? famax : famin
+    nt = sp[:framestyle] === :origin ? 0 : ax[:mirror] ? n1 : n0
+    ft = sp[:framestyle] === :origin ? 0 : ax[:mirror] ? famax : famin
 
     rot = mod(ax[:rotation], 360)
     sgn = ax[:mirror] ? -1 : 1
@@ -1707,7 +1707,7 @@ function gr_label_axis(sp, letter, viewport_plotarea)
             GR.setcharup(cosd(angle), sind(angle))
             ypos = gr_view_yposition(viewport_plotarea, position(axis[:guidefontvalign]))
             yalign = alignment(axis[:guidefontvalign])
-            if guide_position === :right || (guide_position == :auto && mirror)
+            if guide_position === :right || (guide_position === :auto && mirror)
                 GR.settextalign(yalign, GR.TEXT_VALIGN_BOTTOM)
                 xpos = viewport_plotarea[2] + 0.03 + mirror * gr_axis_width(sp, axis)
             else
@@ -1719,7 +1719,7 @@ function gr_label_axis(sp, letter, viewport_plotarea)
             GR.setcharup(cosd(angle), sind(angle))
             xpos = gr_view_xposition(viewport_plotarea, position(axis[:guidefonthalign]))
             xalign = alignment(axis[:guidefonthalign])
-            if guide_position === :top || (guide_position == :auto && mirror)
+            if guide_position === :top || (guide_position === :auto && mirror)
                 GR.settextalign(xalign, GR.TEXT_VALIGN_TOP)
                 ypos =
                     viewport_plotarea[4] +
@@ -1784,10 +1784,10 @@ function gr_add_title(sp, viewport_plotarea, viewport_subplot)
         GR.savestate()
         gr_set_font(titlefont(sp), sp)
         loc = sp[:titlelocation]
-        if loc == :left
+        if loc === :left
             xpos = viewport_plotarea[1]
             halign = GR.TEXT_HALIGN_LEFT
-        elseif loc == :right
+        elseif loc === :right
             xpos = viewport_plotarea[2]
             halign = GR.TEXT_HALIGN_RIGHT
         else
@@ -1872,7 +1872,7 @@ function gr_add_series(sp, series)
         gr_text(GR.wctondc(xi, yi)..., str)
     end
 
-    if sp[:legend_position] == :inline && should_add_to_legend(series)
+    if sp[:legend_position] === :inline && should_add_to_legend(series)
         gr_set_font(legendfont(sp), sp)
         gr_set_textcolor(plot_color(sp[:legend_font_color]))
         if sp[:yaxis][:mirror]
@@ -2104,9 +2104,9 @@ function gr_draw_heatmap(series, x, y, z, clims)
         # pdf output, and also supports alpha values.
         # Note that drawimage draws uniformly spaced data correctly
         # even on log scales, where it is visually non-uniform.
-        colors, _z = if series[:subplot][:colorbar_scale] == :identity
+        colors, _z = if series[:subplot][:colorbar_scale] === :identity
             plot_color.(get(fillgrad, z, clims), series[:fillalpha]), z
-        elseif series[:subplot][:colorbar_scale] == :log10
+        elseif series[:subplot][:colorbar_scale] === :log10
             z_log = replace(x -> isinf(x) ? NaN : x, log10.(z))
             z_normalized = get_z_normalized.(z_log, log10.(clims)...)
             plot_color.(map(z -> get(fillgrad, z), z_normalized), series[:fillalpha]), z_log
@@ -2122,9 +2122,9 @@ function gr_draw_heatmap(series, x, y, z, clims)
         if something(series[:fillalpha], 1) < 1
             @warn "GR: transparency not supported in non-uniform heatmaps. Alpha values ignored."
         end
-        z_normalized, _z = if series[:subplot][:colorbar_scale] == :identity
+        z_normalized, _z = if series[:subplot][:colorbar_scale] === :identity
             get_z_normalized.(z, clims...), z
-        elseif series[:subplot][:colorbar_scale] == :log10
+        elseif series[:subplot][:colorbar_scale] === :log10
             z_log = replace(x -> isinf(x) ? NaN : x, log10.(z))
             get_z_normalized.(z_log, log10.(clims)...), z_log
         end
@@ -2186,7 +2186,7 @@ end
 
 function _display(plt::Plot{GRBackend})
     ENV["GKS_ENCODING"] = "utf8"
-    if plt[:display_type] == :inline
+    if plt[:display_type] === :inline
         GR.emergencyclosegks()
         filepath = tempname() * ".pdf"
         ENV["GKSwstype"] = "pdf"

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -235,7 +235,7 @@ gr_inqtext(x, y, s) = gr_inqtext(x, y, string(s))
 
 function gr_inqtext(x, y, s::AbstractString)
     if (occursin('\\', s) || occursin("10^{", s)) &&
-       match(r".*\$[^\$]+?\$.*", String(s)) == nothing
+       match(r".*\$[^\$]+?\$.*", String(s)) === nothing
         GR.inqtextext(x, y, s)
     else
         GR.inqtext(x, y, s)
@@ -246,7 +246,7 @@ gr_text(x, y, s) = gr_text(x, y, string(s))
 
 function gr_text(x, y, s::AbstractString)
     if (occursin('\\', s) || occursin("10^{", s)) &&
-       match(r".*\$[^\$]+?\$.*", String(s)) == nothing
+       match(r".*\$[^\$]+?\$.*", String(s)) === nothing
         GR.textext(x, y, s)
     else
         GR.text(x, y, s)
@@ -960,7 +960,7 @@ function get_z_normalized(z, clims...)
 end
 
 function gr_clims(args...)
-    if args[1][:clims] != :auto
+    if args[1][:clims] !== :auto
         return get_clims(args[1])
     end
     lo, hi = get_clims(args...)
@@ -1106,7 +1106,7 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                     end
                 end
 
-                if series[:markershape] != :none
+                if series[:markershape] !== :none
                     ms = first(series[:markersize])
                     msw = first(series[:markerstrokewidth])
                     s, sw = if ms > 0
@@ -1248,7 +1248,7 @@ end
 
 function gr_get_legend_geometry(viewport_plotarea, sp)
     legendn = legendw = dy = 0
-    if sp[:legend_position] != :none
+    if sp[:legend_position] !== :none
         GR.savestate()
         GR.selntran(0)
         GR.setcharup(0, 1)
@@ -1366,7 +1366,7 @@ end
 
 function gr_update_viewport_ratio!(viewport_plotarea, sp)
     ratio = get_aspect_ratio(sp)
-    if ratio != :none
+    if ratio !== :none
         xmin, xmax, ymin, ymax = gr_xy_axislims(sp)
         if ratio === :equal
             ratio = 1
@@ -1459,7 +1459,7 @@ function gr_draw_axes(sp, viewport_plotarea)
         #rmin, rmax = GR.adjustrange(ignorenan_minimum(r), ignorenan_maximum(r))
         rmin, rmax = axis_limits(sp, :y)
         gr_polaraxes(rmin, rmax, sp)
-    elseif sp[:framestyle] != :none
+    elseif sp[:framestyle] !== :none
         for letter in (:x, :y)
             gr_draw_axis(sp, letter, viewport_plotarea)
         end
@@ -1953,7 +1953,7 @@ function gr_draw_markers(
     GR.setfillintstyle(GR.INTSTYLE_SOLID)
 
     shapes = series[:markershape]
-    if shapes != :none
+    if shapes !== :none
         for segment in series_segments(series, :scatter)
             i = segment.attr_index
             rng = intersect(eachindex(x), segment.range)

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -411,7 +411,7 @@ function _inspectdr_setupsubplot(sp::Subplot{InspectDRBackend})
         _inspectdr_mapptsize(xaxis[:tickfontsize]),
         color = _inspectdr_mapcolor(xaxis[:tickfontcolor]),
     )
-    l.enable_legend = (sp[:legend_position] != :none)
+    l.enable_legend = (sp[:legend_position] !== :none)
     #l.halloc_legend = 150 #TODO: compute???
     l.font_legend = InspectDR.Font(
         sp[:legend_font_family],

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -19,7 +19,7 @@ is_marker_supported(::InspectDRBackend, shape::Shape) = true
 
 #Do we avoid Map to avoid possible pre-comile issues?
 function _inspectdr_mapglyph(s::Symbol)
-    s == :rect && return :square
+    s === :rect && return :square
     return s
 end
 
@@ -88,9 +88,9 @@ function _inspectdr_getaxisticks(ticks, gridlines, xfrm)
     _xfrm(coord) = InspectDR.axis2aloc(Float64(coord), xfrm.spec) #Ensure Float64 - in case
 
     ttype = ticksType(ticks)
-    if ticks == :native
+    if ticks === :native
         #keep current
-    elseif ttype == :ticks_and_labels
+    elseif ttype === :ticks_and_labels
         pos = ticks[1]
         labels = ticks[2]
         nticks = length(ticks[1])
@@ -99,7 +99,7 @@ function _inspectdr_getaxisticks(ticks, gridlines, xfrm)
         gridlines.major = newticks
         gridlines.minor = []
         gridlines.displayminor = false
-    elseif ttype == :ticks
+    elseif ttype === :ticks
         nticks = length(ticks)
         gridlines.major = Float64[_xfrm(t) for t in ticks]
         gridlines.minor = []
@@ -107,7 +107,7 @@ function _inspectdr_getaxisticks(ticks, gridlines, xfrm)
     elseif isnothing(ticks)
         gridlines.major = []
         gridlines.minor = []
-    else #Assume ticks == :native
+    else #Assume ticks === :native
         #keep current
     end
 
@@ -234,7 +234,7 @@ function _series_added(plt::Plot{InspectDRBackend}, series::Series)
     end
 
     _vectorize(v) = isa(v, Vector) ? v : collect(v) #InspectDR only supports vectors
-    x, y = if st == :straightline
+    x, y = if st === :straightline
         straightline_data(series)
     else
         _vectorize(series[:x]), _vectorize(series[:y])

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -74,7 +74,7 @@ surface_to_vecs(x::AVec, y::AVec, z::AVec) = x, y, z
 Base.push!(pgfx_plot::PGFPlotsXPlot, item) = push!(pgfx_plot.the_plot, item)
 
 pgfx_split_extra_opts(extra) =
-    (get(extra, :add, nothing), filter(x -> first(x) != :add, extra))
+    (get(extra, :add, nothing), filter(x -> first(x) !== :add, extra))
 
 function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
     if !pgfx_plot.is_created || pgfx_plot.was_shown
@@ -163,7 +163,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
             sp_width > 0 * mm ? push!(axis_opt, "width" => string(axis_width)) : nothing
             sp_height > 0 * mm ? push!(axis_opt, "height" => string(axis_height)) : nothing
             for letter in (:x, :y, :z)
-                if letter != :z || RecipesPipeline.is3d(sp)
+                if letter !== :z || RecipesPipeline.is3d(sp)
                     pgfx_axis!(axis_opt, sp, letter)
                 end
             end
@@ -347,7 +347,7 @@ function pgfx_add_series!(::Val{:path}, axis, series_opt, series, series_func, o
         i, rng = segment.attr_index, segment.range
         segment_opt = PGFPlotsX.Options()
         segment_opt = merge(segment_opt, pgfx_linestyle(opt, i))
-        if opt[:markershape] != :none
+        if opt[:markershape] !== :none
             marker = _cycle(opt[:markershape], i)
             if marker isa Shape
                 x = marker.x
@@ -389,7 +389,7 @@ function pgfx_add_series!(::Val{:path}, axis, series_opt, series, series_func, o
                 end
             end
             if i == 1 &&
-               series[:subplot][:legend_position] != :none &&
+               series[:subplot][:legend_position] !== :none &&
                pgfx_should_add_to_legend(series)
                 pgfx_filllegend!(series_opt, opt)
             end
@@ -662,7 +662,7 @@ function pgfx_add_series!(::Val{:xsticks}, axis, series_opt, args...)
 end
 
 function pgfx_add_legend!(axis, series, opt, i = 1)
-    if series[:subplot][:legend_position] != :none
+    if series[:subplot][:legend_position] !== :none
         leg_entry = if opt[:label] isa AVec
             get(opt[:label], i, "")
         elseif opt[:label] isa AbstractString
@@ -1314,7 +1314,7 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
     # grid on or off
     push!(
         opt,
-        "$(letter)majorgrids" => axis[:grid] && framestyle != :none ? "true" : "false",
+        "$(letter)majorgrids" => axis[:grid] && framestyle !== :none ? "true" : "false",
     )
 
     # limits
@@ -1323,7 +1323,7 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
         axis_limits(sp, letter)
     push!(opt, string(letter, :min) => lims[1], string(letter, :max) => lims[2])
 
-    if !(axis[:ticks] in (nothing, false, :none, :native)) && framestyle != :none
+    if !(axis[:ticks] in (nothing, false, :none, :native)) && framestyle !== :none
         # ticks
         ticks = get_ticks(sp, axis)
         # pgf plot ignores ticks with angle below 90 when xmin = 90 so shift values

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -87,7 +87,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
             push!(the_plot, extra_plot...)
         end
         bgc =
-            plt.attr[:background_color_outside] == :match ? plt.attr[:background_color] :
+            plt.attr[:background_color_outside] === :match ? plt.attr[:background_color] :
             plt.attr[:background_color_outside]
         if bgc isa Colors.Colorant
             cstr = plot_color(bgc)
@@ -239,7 +239,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 azim, elev = sp[:camera]
                 push!(axis_opt, "view" => (azim, elev))
             end
-            axisf = if sp[:projection] == :polar
+            axisf = if sp[:projection] === :polar
                 # push!(axis_opt, "xmin" => 90)
                 # push!(axis_opt, "xmax" => 450)
                 PGFPlotsX.PolarAxis
@@ -285,7 +285,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 if (
                     RecipesPipeline.is3d(series) ||
                     st in (:heatmap, :contour) ||
-                    (st == :quiver && opt[:z] !== nothing)
+                    (st === :quiver && opt[:z] !== nothing)
                 )
                     series_func = PGFPlotsX.Plot3
                 else
@@ -410,17 +410,17 @@ function pgfx_add_series!(::Val{:path}, axis, series_opt, series, series_func, o
             if opt[:label] == ""
                 push!(arrow_opt, "forget plot" => nothing)
             end
-            if arrow.side == :head
+            if arrow.side === :head
                 x_arrow = opt[:x][rng][(end - 1):end]
                 y_arrow = opt[:y][rng][(end - 1):end]
                 x_path  = opt[:x][rng][1:(end - 1)]
                 y_path  = opt[:y][rng][1:(end - 1)]
-            elseif arrow.side == :tail
+            elseif arrow.side === :tail
                 x_arrow = opt[:x][rng][2:-1:1]
                 y_arrow = opt[:y][rng][2:-1:1]
                 x_path  = opt[:x][rng][2:end]
                 y_path  = opt[:y][rng][2:end]
-            elseif arrow.side == :both
+            elseif arrow.side === :both
                 x_arrow = opt[:x][rng][[2, 1, end - 1, end]]
                 y_arrow = opt[:y][rng][[2, 1, end - 1, end]]
                 x_path  = opt[:x][rng][2:(end - 1)]
@@ -695,9 +695,9 @@ function pgfx_series_arguments(series, opt)
         surface_to_vecs(opt[:x], opt[:y], opt[:z])
     elseif RecipesPipeline.is3d(st)
         opt[:x], opt[:y], opt[:z]
-    elseif st == :straightline
+    elseif st === :straightline
         straightline_data(series)
-    elseif st == :shape
+    elseif st === :shape
         shape_data(series)
     elseif ispolar(series)
         theta, r = opt[:x], opt[:y]
@@ -877,16 +877,16 @@ function pgfx_arrow(arr::Arrow, side = arr.side)
     components = String[]
     head = String[]
     push!(head, "{stealth[length = $(arr.headlength)pt, width = $(arr.headwidth)pt")
-    if arr.style == :open
+    if arr.style === :open
         push!(head, ", open")
     end
     push!(head, "]}")
     head = join(head, "")
-    if side == :both || side == :tail
+    if side === :both || side === :tail
         push!(components, head)
     end
     push!(components, "-")
-    if side == :both || side == :head
+    if side === :both || side === :head
         push!(components, head)
     end
     components = join(components, "")
@@ -954,7 +954,7 @@ function pgfx_linestyle(linewidth::Real, color, α = 1, linestyle = :solid)
     )
 end
 
-pgfx_legend_col(s::Symbol) = s == :horizontal ? -1 : 1
+pgfx_legend_col(s::Symbol) = s === :horizontal ? -1 : 1
 pgfx_legend_col(n) = n
 
 function pgfx_linestyle(plotattributes, i = 1)
@@ -1023,11 +1023,11 @@ function pgfx_marker(plotattributes, i = 1)
                 pgfx_thickness_scaling(plotattributes) *
                 0.75 *
                 _cycle(plotattributes[:markerstrokewidth], i),
-            "rotate" => if shape == :dtriangle
+            "rotate" => if shape === :dtriangle
                 180
-            elseif shape == :rtriangle
+            elseif shape === :rtriangle
                 270
-            elseif shape == :ltriangle
+            elseif shape === :ltriangle
                 90
             else
                 0
@@ -1196,7 +1196,7 @@ function pgfx_sanitize_plot!(plt)
     end
     for subplot in plt.subplots
         for (key, value) in subplot.attr
-            if key == :annotations && subplot.attr[:annotations] !== nothing
+            if key === :annotations && subplot.attr[:annotations] !== nothing
                 old_ann = subplot.attr[key]
                 for i in eachindex(old_ann)
                     subplot.attr[key][i] =
@@ -1215,7 +1215,7 @@ function pgfx_sanitize_plot!(plt)
     end
     for series in plt.series_list
         for (key, value) in series.plotattributes
-            if key == :series_annotations &&
+            if key === :series_annotations &&
                series.plotattributes[:series_annotations] !== nothing
                 old_ann = series.plotattributes[key].strs
                 for i in eachindex(old_ann)
@@ -1267,9 +1267,9 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
 
     # axis label position
     labelpos = ""
-    if letter == :x
+    if letter === :x
         labelpos = pgfx_get_xguide_pos(axis[:guide_position])
-    elseif letter == :y
+    elseif letter === :y
         labelpos = pgfx_get_yguide_pos(axis[:guide_position])
     end
 
@@ -1301,11 +1301,11 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
     is_log_scale = scale in (:ln, :log2, :log10)
     if is_log_scale
         push!(opt, string(letter, :mode) => "log")
-        scale == :ln || push!(opt, "log basis $letter" => "$(scale == :log2 ? 2 : 10)")
+        scale === :ln || push!(opt, "log basis $letter" => "$(scale === :log2 ? 2 : 10)")
     end
 
     # ticks on or off
-    if axis[:ticks] in (nothing, false, :none) || framestyle == :none
+    if axis[:ticks] in (nothing, false, :none) || framestyle === :none
         push!(opt, "$(letter)majorticks" => "false")
     elseif framestyle in (:grid, :zerolines)
         push!(opt, "$letter tick style" => PGFPlotsX.Options("draw" => "none"))
@@ -1319,7 +1319,7 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
 
     # limits
     lims =
-        ispolar(sp) && letter == :x ? rad2deg.(axis_limits(sp, :x)) :
+        ispolar(sp) && letter === :x ? rad2deg.(axis_limits(sp, :x)) :
         axis_limits(sp, letter)
     push!(opt, string(letter, :min) => lims[1], string(letter, :max) => lims[2])
 
@@ -1328,10 +1328,10 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
         ticks = get_ticks(sp, axis)
         # pgf plot ignores ticks with angle below 90 when xmin = 90 so shift values
         tick_values =
-            ispolar(sp) && letter == :x ? [rad2deg.(ticks[1])[3:end]..., 360, 405] :
+            ispolar(sp) && letter === :x ? [rad2deg.(ticks[1])[3:end]..., 360, 405] :
             ticks[1]
         push!(opt, string(letter, "tick") => string("{", join(tick_values, ","), "}"))
-        if axis[:showaxis] && is_log_scale && axis[:ticks] == :auto
+        if axis[:showaxis] && is_log_scale && axis[:ticks] === :auto
             tick_labels = wrap_power_labels(ticks[2])
             if tick_labels isa Vector{String}
                 push!(
@@ -1344,7 +1344,7 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
             end
         elseif axis[:showaxis]
             tick_labels =
-                ispolar(sp) && letter == :x ? [ticks[2][3:end]..., "0", "45"] : ticks[2]
+                ispolar(sp) && letter === :x ? [ticks[2][3:end]..., "0", "45"] : ticks[2]
             is_log_scale && (tick_labels = wrap_power_labels(tick_labels))
             if axis[:formatter] in (:scientific, :auto) && tick_labels isa Vector{String}
                 tick_labels = string.("\$", convert_sci_unicode.(tick_labels), "\$")
@@ -1363,7 +1363,7 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
             push!(
                 opt,
                 string(letter, "tick align") =>
-                    (axis[:tick_direction] == :out ? "outside" : "inside"),
+                    (axis[:tick_direction] === :out ? "outside" : "inside"),
             )
         end
         push!(opt, string(letter, "ticklabel style") => pgfx_get_ticklabel_style(sp, axis))
@@ -1386,7 +1386,7 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
         minor_ticks = get_minor_ticks(sp, axis, ticks)
         if minor_ticks !== nothing
             minor_ticks =
-                ispolar(sp) && letter == :x ? [rad2deg.(minor_ticks)[3:end]..., 360, 405] :
+                ispolar(sp) && letter === :x ? [rad2deg.(minor_ticks)[3:end]..., 360, 405] :
                 minor_ticks
             push!(
                 opt,
@@ -1414,7 +1414,7 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
 
     # framestyle
     if framestyle in (:axes, :origin)
-        axispos = axis[:mirror] ? "right" : framestyle == :axes ? "left" : "middle"
+        axispos = axis[:mirror] ? "right" : framestyle === :axes ? "left" : "middle"
 
         if axis[:draw_arrow]
             push!(opt, string("axis ", letter, " line") => axispos)
@@ -1424,7 +1424,7 @@ function pgfx_axis!(opt::PGFPlotsX.Options, sp::Subplot, letter)
         end
     end
 
-    if framestyle == :zerolines
+    if framestyle === :zerolines
         push!(opt, string("extra ", letter, " ticks") => "0")
         push!(opt, string("extra ", letter, " tick labels") => "")
         push!(

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -47,8 +47,8 @@ function plotly_annotation_dict(x, y, ptxt::PlotText; xref = "paper", yref = "pa
         plotly_annotation_dict(x, y, ptxt.str; xref = xref, yref = yref),
         KW(
             :font => plotly_font(ptxt.font),
-            :xanchor => ptxt.font.halign == :hcenter ? :center : ptxt.font.halign,
-            :yanchor => ptxt.font.valign == :vcenter ? :middle : ptxt.font.valign,
+            :xanchor => ptxt.font.halign === :hcenter ? :center : ptxt.font.halign,
+            :yanchor => ptxt.font.valign === :vcenter ? :middle : ptxt.font.valign,
             :rotation => -ptxt.font.rotation,
         ),
     )
@@ -78,7 +78,7 @@ end
 # end
 
 function plotly_scale(scale::Symbol)
-    if scale == :log10
+    if scale === :log10
         "log"
     else
         "-"
@@ -93,7 +93,7 @@ end
 function plotly_apply_aspect_ratio(sp::Subplot, plotarea, pcts)
     aspect_ratio = get_aspect_ratio(sp)
     if aspect_ratio != :none
-        if aspect_ratio == :equal
+        if aspect_ratio === :equal
             aspect_ratio = 1.0
         end
         xmin, xmax = axis_limits(sp, :x)
@@ -134,14 +134,14 @@ function plotly_axis(axis, sp, anchor = nothing, domain = nothing)
         :gridcolor =>
             rgba_string(plot_color(axis[:foreground_color_grid], axis[:gridalpha])),
         :gridwidth => axis[:gridlinewidth],
-        :zeroline => framestyle == :zerolines,
+        :zeroline => framestyle === :zerolines,
         :zerolinecolor => rgba_string(axis[:foreground_color_axis]),
         :showline => framestyle in (:box, :axes) && axis[:showaxis],
         :linecolor => rgba_string(plot_color(axis[:foreground_color_axis])),
         :ticks =>
             axis[:tick_direction] === :out ? "outside" :
             axis[:tick_direction] === :in ? "inside" : "",
-        :mirror => framestyle == :box,
+        :mirror => framestyle === :box,
         :showticklabels => axis[:showaxis],
     )
     if anchor !== nothing
@@ -171,10 +171,10 @@ function plotly_axis(axis, sp, anchor = nothing, domain = nothing)
         if axis[:ticks] != :native
             ticks = get_ticks(sp, axis)
             ttype = ticksType(ticks)
-            if ttype == :ticks
+            if ttype === :ticks
                 ax[:tickmode] = "array"
                 ax[:tickvals] = ticks
-            elseif ttype == :ticks_and_labels
+            elseif ttype === :ticks_and_labels
                 ax[:tickmode] = "array"
                 ax[:tickvals], ax[:ticktext] = ticks
             end
@@ -195,7 +195,7 @@ end
 function plotly_polaraxis(sp::Subplot, axis::Axis)
     ax = KW(:visible => axis[:showaxis], :showline => axis[:grid])
 
-    if axis[:letter] == :x
+    if axis[:letter] === :x
         ax[:range] = rad2deg.(axis_limits(sp, :x))
     else
         ax[:range] = axis_limits(sp, :y)
@@ -225,9 +225,9 @@ function plotly_layout(plt::Plot)
         if sp[:title] != ""
             bb = plotarea(sp)
             tpos = sp[:titlelocation]
-            xmm = if tpos == :left
+            xmm = if tpos === :left
                 left(bb)
-            elseif tpos == :right
+            elseif tpos === :right
                 right(bb)
             else
                 0.5 * (left(bb) + right(bb))
@@ -502,7 +502,7 @@ end
 function plotly_data(series::Series, letter::Symbol, data)
     axis = series[:subplot][get_attr_symbol(letter, :axis)]
 
-    data = if axis[:ticks] == :native && data !== nothing
+    data = if axis[:ticks] === :native && data !== nothing
         plotly_native_data(axis, data)
     else
         data
@@ -554,7 +554,7 @@ function plotly_series(plt::Plot, series::Series)
     sp = series[:subplot]
     clims = get_clims(sp, series)
 
-    if st == :shape
+    if st === :shape
         return plotly_series_shapes(plt, series, clims)
     end
 
@@ -574,7 +574,7 @@ function plotly_series(plt::Plot, series::Series)
     end
     plotattributes_out[:showlegend] = should_add_to_legend(series)
 
-    if st == :straightline
+    if st === :straightline
         x, y = straightline_data(series, 100)
         z = series[:z]
     else
@@ -605,7 +605,7 @@ function plotly_series(plt::Plot, series::Series)
     if st in (:path, :scatter, :scattergl, :straightline, :path3d, :scatter3d)
         return plotly_series_segments(series, plotattributes_out, x, y, z, clims)
 
-    elseif st == :heatmap
+    elseif st === :heatmap
         x = heatmap_edges(x, sp[:xaxis][:scale])
         y = heatmap_edges(y, sp[:yaxis][:scale])
         plotattributes_out[:type] = "heatmap"
@@ -614,7 +614,7 @@ function plotly_series(plt::Plot, series::Series)
             plotly_colorscale(series[:fillcolor], series[:fillalpha])
         plotattributes_out[:showscale] = hascolorbar(sp)
 
-    elseif st == :contour
+    elseif st === :contour
         filled = isfilledcontour(series)
         plotattributes_out[:type] = "contour"
         plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
@@ -653,7 +653,7 @@ function plotly_series(plt::Plot, series::Series)
     elseif st in (:surface, :wireframe)
         plotattributes_out[:type] = "surface"
         plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
-        if st == :wireframe
+        if st === :wireframe
             plotattributes_out[:hidesurface] = true
             wirelines = KW(
                 :show => true,
@@ -673,7 +673,7 @@ function plotly_series(plt::Plot, series::Series)
             end
             plotattributes_out[:showscale] = hascolorbar(sp)
         end
-    elseif st == :mesh3d
+    elseif st === :mesh3d
         plotattributes_out[:type] = "mesh3d"
         plotattributes_out[:x], plotattributes_out[:y], plotattributes_out[:z] = x, y, z
 
@@ -847,7 +847,7 @@ function plotly_series_segments(series::Series, plotattributes_base::KW, x, y, z
 
         # set the type
         if st in (:path, :scatter, :scattergl, :straightline)
-            plotattributes_out[:type] = st == :scattergl ? "scattergl" : "scatter"
+            plotattributes_out[:type] = st === :scattergl ? "scattergl" : "scatter"
             plotattributes_out[:mode] = if hasmarker
                 hasline ? "lines+markers" : "markers"
             else
@@ -917,11 +917,11 @@ function plotly_series_segments(series::Series, plotattributes_base::KW, x, y, z
                     plot_color(get_linecolor(series, clims, i), get_linealpha(series, i)),
                 ),
                 :width => get_linewidth(series, i),
-                :shape => if st == :steppre
+                :shape => if st === :steppre
                     "vh"
-                elseif st == :stepmid
+                elseif st === :stepmid
                     "hvh"
-                elseif st == :steppost
+                elseif st === :steppost
                     "hv"
                 else
                     "linear"

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -92,7 +92,7 @@ end
 
 function plotly_apply_aspect_ratio(sp::Subplot, plotarea, pcts)
     aspect_ratio = get_aspect_ratio(sp)
-    if aspect_ratio != :none
+    if aspect_ratio !== :none
         if aspect_ratio === :equal
             aspect_ratio = 1.0
         end
@@ -128,7 +128,7 @@ function plotly_axis(axis, sp, anchor = nothing, domain = nothing)
     letter = axis[:letter]
     framestyle = sp[:framestyle]
     ax = KW(
-        :visible => framestyle != :none,
+        :visible => framestyle !== :none,
         :title => axis[:guide],
         :showgrid => axis[:grid],
         :gridcolor =>
@@ -155,7 +155,7 @@ function plotly_axis(axis, sp, anchor = nothing, domain = nothing)
     ax[:type] = plotly_scale(axis[:scale])
     lims = axis_limits(sp, letter)
 
-    if axis[:ticks] != :native || axis[:lims] != :auto
+    if axis[:ticks] !== :native || axis[:lims] !== :auto
         ax[:range] = map(RecipesPipeline.scale_func(axis[:scale]), lims)
     end
 
@@ -168,7 +168,7 @@ function plotly_axis(axis, sp, anchor = nothing, domain = nothing)
         ax[:linecolor] = rgba_string(axis[:foreground_color_axis])
 
         # ticks
-        if axis[:ticks] != :native
+        if axis[:ticks] !== :native
             ticks = get_ticks(sp, axis)
             ttype = ticksType(ticks)
             if ttype === :ticks
@@ -338,9 +338,9 @@ function plotly_layout(plt::Plot)
 end
 
 function plotly_add_legend!(plotattributes_out::KW, sp::Subplot)
-    plotattributes_out[:showlegend] = sp[:legend_position] != :none
+    plotattributes_out[:showlegend] = sp[:legend_position] !== :none
     legend_position = plotly_legend_pos(sp[:legend_position])
-    if sp[:legend_position] != :none
+    if sp[:legend_position] !== :none
         plotattributes_out[:legend_position] = KW(
             :bgcolor => rgba_string(sp[:legend_background_color]),
             :bordercolor => rgba_string(sp[:legend_foreground_color]),
@@ -589,7 +589,7 @@ function plotly_series(plt::Plot, series::Series)
     plotattributes_out[:name] = series[:label]
 
     isscatter = st in (:scatter, :scatter3d, :scattergl)
-    hasmarker = isscatter || series[:markershape] != :none
+    hasmarker = isscatter || series[:markershape] !== :none
     hasline = st in (:path, :path3d, :straightline)
     hasfillrange =
         st in (:path, :scatter, :scattergl, :straightline) &&
@@ -827,7 +827,7 @@ function plotly_series_segments(series::Series, plotattributes_base::KW, x, y, z
     st = series[:seriestype]
     sp = series[:subplot]
     isscatter = st in (:scatter, :scatter3d, :scattergl)
-    hasmarker = isscatter || series[:markershape] != :none
+    hasmarker = isscatter || series[:markershape] !== :none
     hasline = st in (:path, :path3d, :straightline)
     hasfillrange =
         st in (:path, :scatter, :scattergl, :straightline) &&

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -119,11 +119,11 @@ end
 
 # get the style (solid, dashed, etc)
 function py_linestyle(seriestype::Symbol, linestyle::Symbol)
-    seriestype == :none && return " "
-    linestyle == :solid && return "-"
-    linestyle == :dash && return "--"
-    linestyle == :dot && return ":"
-    linestyle == :dashdot && return "-."
+    seriestype === :none && return " "
+    linestyle === :solid && return "-"
+    linestyle === :dash && return "--"
+    linestyle === :dot && return ":"
+    linestyle === :dashdot && return "-."
     @warn("Unknown linestyle $linestyle")
     return "-"
 end
@@ -142,21 +142,21 @@ end
 
 # get the marker shape
 function py_marker(marker::Symbol)
-    marker == :none && return " "
-    marker == :circle && return "o"
-    marker == :rect && return "s"
-    marker == :diamond && return "D"
-    marker == :utriangle && return "^"
-    marker == :dtriangle && return "v"
-    marker == :+ && return "+"
-    marker == :x && return "x"
-    marker == :star5 && return "*"
-    marker == :pentagon && return "p"
-    marker == :hexagon && return "h"
-    marker == :octagon && return "8"
-    marker == :pixel && return ","
-    marker == :hline && return "_"
-    marker == :vline && return "|"
+    marker === :none && return " "
+    marker === :circle && return "o"
+    marker === :rect && return "s"
+    marker === :diamond && return "D"
+    marker === :utriangle && return "^"
+    marker === :dtriangle && return "v"
+    marker === :+ && return "+"
+    marker === :x && return "x"
+    marker === :star5 && return "*"
+    marker === :pentagon && return "p"
+    marker === :hexagon && return "h"
+    marker === :octagon && return "8"
+    marker === :pixel && return ","
+    marker === :hline && return "_"
+    marker === :vline && return "|"
     haskey(_shapes, marker) && return py_marker(_shapes[marker])
 
     @warn("Unknown marker $marker")
@@ -176,16 +176,16 @@ function py_marker(marker::AbstractString)
 end
 
 function py_stepstyle(seriestype::Symbol)
-    seriestype == :steppost && return "steps-post"
-    seriestype == :stepmid && return "steps-mid"
-    seriestype == :steppre && return "steps-pre"
+    seriestype === :steppost && return "steps-post"
+    seriestype === :stepmid && return "steps-mid"
+    seriestype === :steppre && return "steps-pre"
     return "default"
 end
 
 function py_fillstepstyle(seriestype::Symbol)
-    seriestype == :steppost && return "post"
-    seriestype == :stepmid && return "mid"
-    seriestype == :steppre && return "pre"
+    seriestype === :steppost && return "post"
+    seriestype === :stepmid && return "mid"
+    seriestype === :steppre && return "pre"
     return nothing
 end
 
@@ -393,9 +393,9 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
 
     # ax = getAxis(plt, series)
     x, y, z = (py_handle_surface(series[letter]) for letter in (:x, :y, :z))
-    if st == :straightline
+    if st === :straightline
         x, y = straightline_data(series)
-    elseif st == :shape
+    elseif st === :shape
         x, y = shape_data(series)
     end
 
@@ -417,7 +417,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     vmin, vmax = clims = get_clims(sp, series)
 
     # Dict to store extra kwargs
-    if st == :wireframe || st == :hexbin
+    if st === :wireframe || st === :hexbin
         # vmin, vmax cause an error for wireframe plot
         # We are not supporting clims for hexbin as calculation of bins is not trivial
         extrakw = KW()
@@ -532,7 +532,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
        st in (:path, :scatter, :path3d, :scatter3d, :steppre, :stepmid, :steppost, :bar)
         for segment in series_segments(series, :scatter)
             i, rng = segment.attr_index, segment.range
-            xyargs = if st == :bar && !isvertical(series)
+            xyargs = if st === :bar && !isvertical(series)
                 if RecipesPipeline.is3d(sp)
                     y[rng], x[rng], z[rng]
                 else
@@ -567,7 +567,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         end
     end
 
-    if st == :hexbin
+    if st === :hexbin
         extrakw[:mincnt] = get(series[:extra_kwargs], :mincnt, nothing)
         extrakw[:edgecolors] =
             get(series[:extra_kwargs], :edgecolors, py_color(get_linecolor(series)))
@@ -576,7 +576,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             y;
             label = series[:label],
             C = series[:weights],
-            gridsize = series[:bins] == :auto ? 100 : series[:bins],  # 100 is the default value
+            gridsize = series[:bins] === :auto ? 100 : series[:bins],  # 100 is the default value
             linewidths = py_thickness_scale(plt, series[:linewidth]),
             alpha = series[:fillalpha],
             cmap = py_fillcolormap(series),  # applies to the pcolorfast object
@@ -587,7 +587,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     end
 
     if st in (:contour, :contour3d)
-        if st == :contour3d
+        if st === :contour3d
             extrakw[:extend3d] = true
             if !ismatrix(x) || !ismatrix(y)
                 x, y = repeat(x', length(y), 1), repeat(y, 1, length(x))
@@ -638,7 +638,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
             if !ismatrix(x) || !ismatrix(y)
                 x, y = repeat(x', length(y), 1), repeat(y, 1, length(x))
             end
-            if st == :surface
+            if st === :surface
                 if series[:fill_z] !== nothing
                     # the surface colors are different than z-value
                     extrakw[:facecolors] =
@@ -648,7 +648,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
                     extrakw[:cmap] = py_fillcolormap(series)
                 end
             end
-            handle = getproperty(ax, st == :surface ? :plot_surface : :plot_wireframe)(
+            handle = getproperty(ax, st === :surface ? :plot_surface : :plot_wireframe)(
                 x,
                 y,
                 z;
@@ -698,7 +698,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         end
     end
 
-    if st == :mesh3d
+    if st === :mesh3d
         polygons = if series[:connections] isa AbstractVector{<:AbstractVector{Int}}
             # Combination of any polygon types
             broadcast(inds -> broadcast(i -> [x[i], y[i], z[i]], inds), series[:connections])
@@ -742,7 +742,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         push!(handles, handle)
     end
 
-    if st == :image
+    if st === :image
         xmin, xmax = ignorenan_extrema(series[:x])
         ymin, ymax = ignorenan_extrema(series[:y])
         dx = (xmax - xmin) / (length(series[:x]) - 1) / 2
@@ -770,7 +770,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         # sp[:yaxis].series[:flip] = true
     end
 
-    if st == :heatmap
+    if st === :heatmap
         x, y = heatmap_edges(x, sp[:xaxis][:scale], y, sp[:yaxis][:scale], size(z))
 
         expand_extrema!(sp[:xaxis], x)
@@ -794,7 +794,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
         push!(handles, handle)
     end
 
-    if st == :shape
+    if st === :shape
         handle = []
         for segment in series_segments(series)
             i, rng = segment.attr_index, segment.range
@@ -904,9 +904,9 @@ function py_set_lims(ax, sp::Subplot, axis::Axis)
 end
 
 function py_set_ticks(sp, ax, ticks, letter)
-    ticks == :auto && return
+    ticks === :auto && return
     axis = getproperty(ax, get_attr_symbol(letter, :axis))
-    if ticks == :none || ticks === nothing || ticks == false
+    if ticks === :none || ticks === nothing || ticks == false
         kw = KW()
         for dir in (:top, :bottom, :left, :right)
             kw[dir] = kw[get_attr_symbol(:label, dir)] = false
@@ -916,9 +916,9 @@ function py_set_ticks(sp, ax, ticks, letter)
     end
 
     ttype = ticksType(ticks)
-    if ttype == :ticks
+    if ttype === :ticks
         axis."set_ticks"(ticks)
-    elseif ttype == :ticks_and_labels
+    elseif ttype === :ticks_and_labels
         axis."set_ticks"(ticks[1])
         axis."set_ticklabels"(ticks[2])
     else
@@ -955,14 +955,14 @@ function py_set_scale(ax, sp::Subplot, scale::Symbol, letter::Symbol)
         pyletter = letter
     end
     kw = KW()
-    arg = if scale == :identity
+    arg = if scale === :identity
         "linear"
     else
-        kw[get_attr_symbol(:base, pyletter)] = if scale == :ln
+        kw[get_attr_symbol(:base, pyletter)] = if scale === :ln
             ℯ
-        elseif scale == :log2
+        elseif scale === :log2
             2
-        elseif scale == :log10
+        elseif scale === :log10
             10
         end
         axis = sp[get_attr_symbol(letter, :axis)]
@@ -1076,7 +1076,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             handle = colorbar_series[:serieshandle][end]
             kw = KW()
             if !isempty(sp[:zaxis][:discrete_values]) &&
-               colorbar_series[:seriestype] == :heatmap
+               colorbar_series[:seriestype] === :heatmap
                 locator, formatter = get_locator_and_formatter(sp[:zaxis][:discrete_values])
                 # kw[:values] = eachindex(sp[:zaxis][:discrete_values])
                 kw[:values] = sp[:zaxis][:continuous_values]
@@ -1117,14 +1117,14 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 colorbar_pad = "2.5%"
                 colorbar_orientation = "vertical"
 
-                if sp[:colorbar] == :left
+                if sp[:colorbar] === :left
                     colorbar_position = string(sp[:colorbar])
                     colorbar_pad = "5%"
-                elseif sp[:colorbar] == :top
+                elseif sp[:colorbar] === :top
                     colorbar_position = string(sp[:colorbar])
                     colorbar_pad = "2.5%"
                     colorbar_orientation = "horizontal"
-                elseif sp[:colorbar] == :bottom
+                elseif sp[:colorbar] === :bottom
                     colorbar_position = string(sp[:colorbar])
                     colorbar_pad = "5%"
                     colorbar_orientation = "horizontal"
@@ -1143,11 +1143,11 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                     kw...,
                 )
 
-                if sp[:colorbar] == :left
+                if sp[:colorbar] === :left
                     cbax.yaxis.set_ticks_position("left")
-                elseif sp[:colorbar] == :top
+                elseif sp[:colorbar] === :top
                     cbax.xaxis.set_ticks_position("top")
-                elseif sp[:colorbar] == :bottom
+                elseif sp[:colorbar] === :bottom
                     cbax.xaxis.set_ticks_position("bottom")
                 end
             end
@@ -1175,7 +1175,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 ticks_letter = :y
             end
             py_set_scale(cb.ax, sp, sp[:colorbar_scale], ticks_letter)
-            sp[:colorbar_ticks] == :native ? nothing :
+            sp[:colorbar_ticks] === :native ? nothing :
             py_set_ticks(sp, cb.ax, ticks, ticks_letter)
 
             for lab in cbar_axis."get_ticklabels"()
@@ -1190,9 +1190,9 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             # Adjust thickness of the cbar ticks
             intensity = 0.5
             cbar_axis."set_tick_params"(
-                direction = axis[:tick_direction] == :out ? "out" : "in",
+                direction = axis[:tick_direction] === :out ? "out" : "in",
                 width = py_thickness_scale(plt, intensity),
-                length = axis[:tick_direction] == :none ? 0 :
+                length = axis[:tick_direction] === :none ? 0 :
                          5 * py_thickness_scale(plt, intensity),
             )
 
@@ -1210,7 +1210,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             end
 
             # Then set visible some of them
-            if sp[:framestyle] == :semi
+            if sp[:framestyle] === :semi
                 intensity = 0.5
 
                 spine = sp[:yaxis][:mirror] ? "left" : "right"
@@ -1224,7 +1224,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                     py_thickness_scale(plt, intensity),
                 )
                 getproperty(ax.spines, spine)."set_alpha"(intensity)
-            elseif sp[:framestyle] == :box
+            elseif sp[:framestyle] === :box
                 ax.tick_params(top = true)   # Add ticks too
                 ax.tick_params(right = true) # Add ticks too
             elseif sp[:framestyle] in (:axes, :origin)
@@ -1232,7 +1232,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 ax.spines."top"."set_visible"(false)
                 sp[:yaxis][:mirror] ? ax.spines."left"."set_visible"(false) :
                 ax.spines."right"."set_visible"(false)
-                if sp[:framestyle] == :origin
+                if sp[:framestyle] === :origin
                     ax.spines."bottom"."set_position"("zero")
                     ax.spines."left"."set_position"("zero")
                 end
@@ -1246,7 +1246,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                         spine."set_visible"(false)
                     end
                 end
-                if sp[:framestyle] == :zerolines
+                if sp[:framestyle] === :zerolines
                     ax."axhline"(
                         y = 0,
                         color = py_color(sp[:xaxis][:foreground_color_axis]),
@@ -1262,12 +1262,12 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 
             if sp[:xaxis][:mirror]
                 ax.xaxis."set_label_position"("top")     # the guides
-                sp[:framestyle] == :box ? nothing : ax.xaxis."tick_top"()
+                sp[:framestyle] === :box ? nothing : ax.xaxis."tick_top"()
             end
 
             if sp[:yaxis][:mirror]
                 ax.yaxis."set_label_position"("right")     # the guides
-                sp[:framestyle] == :box ? nothing : ax.yaxis."tick_right"()
+                sp[:framestyle] === :box ? nothing : ax.yaxis."tick_right"()
             end
         end
 
@@ -1284,12 +1284,12 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 
             py_set_scale(ax, sp, axis)
             py_set_lims(ax, sp, axis)
-            if ispolar(sp) && letter == :y
+            if ispolar(sp) && letter === :y
                 ax."set_rlabel_position"(90)
             end
-            ticks = sp[:framestyle] == :none ? nothing : get_ticks(sp, axis)
+            ticks = sp[:framestyle] === :none ? nothing : get_ticks(sp, axis)
             # don't show the 0 tick label for the origin framestyle
-            if sp[:framestyle] == :origin && length(ticks) > 1
+            if sp[:framestyle] === :origin && length(ticks) > 1
                 ticks[2][ticks[1] .== 0] .= ""
             end
 
@@ -1320,7 +1320,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 
             py_set_ticks(sp, ax, ticks, letter)
 
-            if axis[:ticks] == :native # It is easier to reset than to account for this
+            if axis[:ticks] === :native # It is easier to reset than to account for this
                 py_set_lims(ax, sp, axis)
                 pyaxis.set_major_locator(pyticker.AutoLocator())
                 pyaxis.set_major_formatter(pyticker.ScalarFormatter())
@@ -1329,9 +1329,9 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             # Tick marks
             intensity = 0.5  # This value corresponds to scaling of other grid elements
             pyaxis."set_tick_params"(
-                direction = axis[:tick_direction] == :out ? "out" : "in",
+                direction = axis[:tick_direction] === :out ? "out" : "in",
                 width = py_thickness_scale(plt, intensity),
-                length = axis[:tick_direction] == :none ? 0 :
+                length = axis[:tick_direction] === :none ? 0 :
                          5 * py_thickness_scale(plt, intensity),
             )
 
@@ -1349,7 +1349,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 pyaxis."set_rotate_label"(false)
             end
 
-            if (letter == :y && !RecipesPipeline.is3d(sp))
+            if (letter === :y && !RecipesPipeline.is3d(sp))
                 pyaxis."label"."set_rotation"(axis[:guidefontrotation] + 90)
             else
                 pyaxis."label"."set_rotation"(axis[:guidefontrotation])
@@ -1376,8 +1376,8 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 )
                 pyaxis."set_tick_params"(
                     which = "minor",
-                    direction = axis[:tick_direction] == :out ? "out" : "in",
-                    length = axis[:tick_direction] == :none ? 0 :
+                    direction = axis[:tick_direction] === :out ? "out" : "in",
+                    length = axis[:tick_direction] === :none ? 0 :
                              py_thickness_scale(plt, intensity),
                 )
             end
@@ -1388,8 +1388,8 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                 end
                 pyaxis."set_tick_params"(
                     which = "minor",
-                    direction = axis[:tick_direction] == :out ? "out" : "in",
-                    length = axis[:tick_direction] == :none ? 0 :
+                    direction = axis[:tick_direction] === :out ? "out" : "in",
+                    length = axis[:tick_direction] === :none ? 0 :
                              py_thickness_scale(plt, intensity),
                 )
 
@@ -1530,9 +1530,9 @@ function py_add_annotations(sp::Subplot{PyPlotBackend}, x, y, val::PlotText)
         xy = (x, y),
         family = val.font.family,
         color = py_color(val.font.color),
-        horizontalalignment = val.font.halign == :hcenter ? "center" :
+        horizontalalignment = val.font.halign === :hcenter ? "center" :
                               string(val.font.halign),
-        verticalalignment = val.font.valign == :vcenter ? "center" :
+        verticalalignment = val.font.valign === :vcenter ? "center" :
                             string(val.font.valign),
         rotation = val.font.rotation,
         size = py_thickness_scale(sp.plt, val.font.pointsize),
@@ -1575,7 +1575,7 @@ function py_add_legend(plt::Plot, sp::Subplot, ax)
             if should_add_to_legend(series)
                 clims = get_clims(sp, series)
                 # add a line/marker and a label
-                if series[:seriestype] == :shape || series[:fillrange] !== nothing
+                if series[:seriestype] === :shape || series[:fillrange] !== nothing
                     lc = get_linecolor(series, clims)
                     la = get_linealpha(series)
                     ls = get_linestyle(series)

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -528,7 +528,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
     end
 
     # add markers?
-    if series[:markershape] != :none &&
+    if series[:markershape] !== :none &&
        st in (:path, :scatter, :path3d, :scatter3d, :steppre, :stepmid, :steppost, :bar)
         for segment in series_segments(series, :scatter)
             i, rng = segment.attr_index, segment.range
@@ -850,7 +850,7 @@ function py_add_series(plt::Plot{PyPlotBackend}, series::Series)
 
     # handle area filling
     fillrange = series[:fillrange]
-    if fillrange !== nothing && st != :contour
+    if fillrange !== nothing && st !== :contour
         for segment in series_segments(series)
             i, rng = segment.attr_index, segment.range
             f, dim1, dim2 = if isvertical(series)
@@ -1278,7 +1278,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
             axis = sp[axissym]
             pyaxis = getproperty(ax, axissym)
 
-            if axis[:guide_position] != :auto && letter != :z
+            if axis[:guide_position] !== :auto && letter !== :z
                 pyaxis."set_label_position"(axis[:guide_position])
             end
 
@@ -1433,7 +1433,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
 
         # aspect ratio
         aratio = get_aspect_ratio(sp)
-        if aratio != :none
+        if aratio !== :none
             ax."set_aspect"(isa(aratio, Symbol) ? string(aratio) : aratio, anchor = "C")
         end
 
@@ -1567,7 +1567,7 @@ py_legend_bbox(pos) = pos
 
 function py_add_legend(plt::Plot, sp::Subplot, ax)
     leg = sp[:legend_position]
-    if leg != :none
+    if leg !== :none
         # gotta do this to ensure both axes are included
         labels = []
         handles = []

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -92,7 +92,7 @@ function colorbar_style(series::Series)
     elseif iscontour(series)
         cbar_lines
     elseif series[:seriestype] ∈ (:heatmap, :surface) ||
-           any(series[z] !== nothing for z in [:marker_z, :line_z, :fill_z])
+           any(series[z] !== nothing for z in (:marker_z, :line_z, :fill_z))
         cbar_gradient
     else
         nothing
@@ -101,7 +101,7 @@ end
 
 hascolorbar(series::Series) = colorbar_style(series) !== nothing
 hascolorbar(sp::Subplot) =
-    sp[:colorbar] != :none && any(hascolorbar(s) for s in series_list(sp))
+    sp[:colorbar] !== :none && any(hascolorbar(s) for s in series_list(sp))
 
 function get_colorbar_ticks(sp::Subplot; update = true)
     if update || !haskey(sp.attr, :colorbar_optimized_ticks)

--- a/src/components.jl
+++ b/src/components.jl
@@ -252,7 +252,7 @@ function font(args...; kw...)
             valign = arg.valign
             rotation = arg.rotation
             color = arg.color
-        elseif arg == :center
+        elseif arg === :center
             halign = :hcenter
             valign = :vcenter
         elseif arg ∈ _haligns
@@ -277,21 +277,21 @@ function font(args...; kw...)
     end
 
     for sym in keys(kw)
-        if sym == :family
+        if sym === :family
             family = string(kw[sym])
-        elseif sym == :pointsize
+        elseif sym === :pointsize
             pointsize = kw[sym]
-        elseif sym == :halign
+        elseif sym === :halign
             halign = kw[sym]
-            halign == :center && (halign = :hcenter)
+            halign === :center && (halign = :hcenter)
             @assert halign ∈ _haligns
-        elseif sym == :valign
+        elseif sym === :valign
             valign = kw[sym]
-            valign == :center && (valign = :vcenter)
+            valign === :center && (valign = :vcenter)
             @assert valign ∈ _valigns
-        elseif sym == :rotation
+        elseif sym === :rotation
             rotation = kw[sym]
-        elseif sym == :color
+        elseif sym === :color
             color = parse(Colorant, kw[sym])
         else
             @warn "Unused font kwarg: $sym"
@@ -606,7 +606,7 @@ _annotationfont(sp::Subplot) = Plots.font(;
 
 _annotation(sp::Subplot, font, lab, pos...; alphabet = "abcdefghijklmnopqrstuvwxyz") = (
     pos...,
-    lab == :auto ? text("($(alphabet[sp[:subplot_index]]))", font) : _text_label(lab, font),
+    lab === :auto ? text("($(alphabet[sp[:subplot_index]]))", font) : _text_label(lab, font),
 )
 
 # Expand arrays of coordinates, positions and labels into individual annotations

--- a/src/components.jl
+++ b/src/components.jl
@@ -606,7 +606,8 @@ _annotationfont(sp::Subplot) = Plots.font(;
 
 _annotation(sp::Subplot, font, lab, pos...; alphabet = "abcdefghijklmnopqrstuvwxyz") = (
     pos...,
-    lab === :auto ? text("($(alphabet[sp[:subplot_index]]))", font) : _text_label(lab, font),
+    lab === :auto ? text("($(alphabet[sp[:subplot_index]]))", font) :
+    _text_label(lab, font),
 )
 
 # Expand arrays of coordinates, positions and labels into individual annotations

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1194,9 +1194,9 @@ const _examples = PlotExample[
                             wireframe(
                                 args...,
                                 title = "wire-flip-$ax",
-                                xflip = ax == :x,
-                                yflip = ax == :y,
-                                zflip = ax == :z;
+                                xflip = ax === :x,
+                                yflip = ax === :y,
+                                zflip = ax === :z;
                                 kwargs...,
                             ),
                         )
@@ -1208,9 +1208,9 @@ const _examples = PlotExample[
                             wireframe(
                                 args...,
                                 title = "wire-mirror-$ax",
-                                xmirror = ax == :x,
-                                ymirror = ax == :y,
-                                zmirror = ax == :z;
+                                xmirror = ax === :x,
+                                ymirror = ax === :y,
+                                zmirror = ax === :z;
                                 kwargs...,
                             ),
                         )

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -913,7 +913,7 @@ const _examples = PlotExample[
                         m::T,
                     ) where {T<:AbstractArray{<:Measurement}}
                         if !(
-                            get(plotattributes, :seriestype, :path) in [
+                            get(plotattributes, :seriestype, :path) in (
                                 :contour,
                                 :contourf,
                                 :contour3d,
@@ -921,7 +921,7 @@ const _examples = PlotExample[
                                 :surface,
                                 :wireframe,
                                 :image,
-                            ]
+                            )
                         )
                             error_sym = Symbol(plotattributes[:letter], :error)
                             plotattributes[error_sym] = uncertainty.(m)

--- a/src/ijulia.jl
+++ b/src/ijulia.jl
@@ -32,24 +32,24 @@ end
 
 function _ijulia_display_dict(plt::Plot)
     output_type = Symbol(plt.attr[:html_output_format])
-    if output_type == :auto
+    if output_type === :auto
         output_type = get(_best_html_output_type, backend_name(plt.backend), :svg)
     end
     out = Dict()
-    if output_type == :txt
+    if output_type === :txt
         mime = "text/plain"
         out[mime] = sprint(show, MIME(mime), plt)
-    elseif output_type == :png
+    elseif output_type === :png
         mime = "image/png"
         out[mime] = base64encode(show, MIME(mime), plt)
-    elseif output_type == :svg
+    elseif output_type === :svg
         mime = "image/svg+xml"
         out[mime] = sprint(show, MIME(mime), plt)
-    elseif output_type == :html
+    elseif output_type === :html
         mime = "text/html"
         out[mime] = sprint(show, MIME(mime), plt)
         _ijulia__extra_mime_info!(plt, out)
-    elseif output_type == :pdf
+    elseif output_type === :pdf
         mime = "application/pdf"
         out[mime] = base64encode(show, MIME(mime), plt)
     else

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -551,19 +551,19 @@ function build_layout(layout::GridLayout, n::Integer, plts::AVec{Plot})
                 merge!(spmap, plt.spmap)
                 inc = length(plt.subplots)
             end
-            if get(l.attr, :width, :auto) != :auto
+            if get(l.attr, :width, :auto) !== :auto
                 layout.widths[c] = attr(l, :width)
             end
-            if get(l.attr, :height, :auto) != :auto
+            if get(l.attr, :height, :auto) !== :auto
                 layout.heights[r] = attr(l, :height)
             end
             i += inc
         elseif isa(l, GridLayout)
             # sub-grid
-            if get(l.attr, :width, :auto) != :auto
+            if get(l.attr, :width, :auto) !== :auto
                 layout.widths[c] = attr(l, :width)
             end
-            if get(l.attr, :height, :auto) != :auto
+            if get(l.attr, :height, :auto) !== :auto
                 layout.heights[r] = attr(l, :height)
             end
             l, sps, m = build_layout(l, n - i, plts)

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -80,7 +80,7 @@ function resolve_mixed(mix::MixedMeasures, sp::Subplot, letter::Symbol)
     xy = mix.xy
     pct = mix.pct
     if mix.len != 0mm
-        f = (letter == :x ? width : height)
+        f = (letter === :x ? width : height)
         totlen = f(plotarea(sp))
         pct += mix.len / totlen
     end
@@ -113,7 +113,7 @@ function bbox(x, y, w, h, oarg1::Symbol, originargs::Symbol...)
     orighor = :left
     origver = :top
     for oarg in oargs
-        if oarg == :center
+        if oarg === :center
             orighor = origver = oarg
         elseif oarg in (:left, :right, :hcenter)
             orighor = oarg
@@ -132,14 +132,14 @@ function bbox(x, y, width, height; h_anchor = :left, v_anchor = :top)
     y = make_measure_vert(y)
     width = make_measure_hor(width)
     height = make_measure_vert(height)
-    left = if h_anchor == :left
+    left = if h_anchor === :left
         x
     elseif h_anchor in (:center, :hcenter)
         0.5w - 0.5width + x
     else
         1w - x - width
     end
-    top = if v_anchor == :top
+    top = if v_anchor === :top
         y
     elseif v_anchor in (:center, :vcenter)
         0.5h - 0.5height + y
@@ -639,7 +639,7 @@ function link_axes!(layout::GridLayout, link::Symbol)
             link_axes!(layout.grid[r, :], :yaxis)
         end
     end
-    if link == :square
+    if link === :square
         sps = filter(l -> isa(l, Subplot), layout.grid)
         if !isempty(sps)
             base_axis = sps[1][:xaxis]
@@ -649,7 +649,7 @@ function link_axes!(layout::GridLayout, link::Symbol)
             end
         end
     end
-    if link == :all
+    if link === :all
         link_axes!(layout.grid, :xaxis)
         link_axes!(layout.grid, :yaxis)
     end

--- a/src/output.jl
+++ b/src/output.jl
@@ -142,7 +142,7 @@ end
 
 _do_plot_show(plt, showval::Bool) = showval && gui(plt)
 function _do_plot_show(plt, showval::Symbol)
-    showval == :gui && gui(plt)
+    showval === :gui && gui(plt)
     showval in (:inline, :ijulia) && inline(plt)
 end
 
@@ -154,10 +154,10 @@ const _best_html_output_type =
 # a backup for html... passes to svg or png depending on the html_output_format arg
 function _show(io::IO, ::MIME"text/html", plt::Plot)
     output_type = Symbol(plt.attr[:html_output_format])
-    if output_type == :auto
+    if output_type === :auto
         output_type = get(_best_html_output_type, backend_name(plt.backend), :svg)
     end
-    if output_type == :png
+    if output_type === :png
         # @info("writing png to html output")
         print(
             io,
@@ -165,10 +165,10 @@ function _show(io::IO, ::MIME"text/html", plt::Plot)
             base64encode(show, MIME("image/png"), plt),
             "\" />",
         )
-    elseif output_type == :svg
+    elseif output_type === :svg
         # @info("writing svg to html output")
         show(io, MIME("image/svg+xml"), plt)
-    elseif output_type == :txt
+    elseif output_type === :txt
         show(io, MIME("text/plain"), plt)
     else
         error("only png or svg allowed. got: $(repr(output_type))")

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -37,7 +37,7 @@ RecipesPipeline.split_attribute(plt::Plot, key, val::SeriesAnnotations, indices)
 function RecipesPipeline.preprocess_axis_args!(plt::Plot, plotattributes, letter)
     # Fix letter for seriestypes that are x only but data gets passed as y
     if treats_y_as_x(get(plotattributes, :seriestype, :path)) &&
-       get(plotattributes, :orientation, :vertical) == :vertical
+       get(plotattributes, :orientation, :vertical) === :vertical
         letter = :x
     end
 
@@ -157,7 +157,7 @@ function RecipesPipeline.process_sliced_series_attributes!(plt::Plots.Plot, kw_l
     err_inds =
         findall(kw -> get(kw, :seriestype, :path) in (:xerror, :yerror, :zerror), kw_list)
     for ind in err_inds
-        if get(kw_list[ind - 1], :seriestype, :path) == :scatter
+        if get(kw_list[ind - 1], :seriestype, :path) === :scatter
             tmp = copy(kw_list[ind])
             kw_list[ind] = copy(kw_list[ind - 1])
             kw_list[ind - 1] = tmp
@@ -243,7 +243,7 @@ function _subplot_setup(plt::Plot, plotattributes::AKW, kw_list::Vector{KW})
         sp = get_subplot(
             plt,
             _cycle(
-                sps == :auto ? plt.subplots : plt.subplots[sps],
+                sps === :auto ? plt.subplots : plt.subplots[sps],
                 series_idx(kw_list, kw),
             ),
         )
@@ -352,10 +352,10 @@ function RecipesPipeline.add_series!(plt::Plot, plotattributes)
     sp = _prepare_subplot(plt, plotattributes)
     if plotattributes[:permute] != :none
         letter1, letter2 = plotattributes[:permute]
-        if plotattributes[:markershape] == :hline &&
+        if plotattributes[:markershape] === :hline &&
            (plotattributes[:permute] == (:x, :y) || plotattributes[:permute] == (:y, :x))
             plotattributes[:markershape] = :vline
-        elseif plotattributes[:markershape] == :vline && (
+        elseif plotattributes[:markershape] === :vline && (
             plotattributes[:permute] == (:x, :y) || plotattributes[:permute] == (:y, :x)
         )
             plotattributes[:markershape] = :hline
@@ -381,7 +381,7 @@ function _prepare_subplot(plt::Plot{T}, plotattributes::AKW) where {T}
     # change to a 3d projection for this subplot?
     if (
         RecipesPipeline.needs_3d_axes(st) ||
-        (st == :quiver && plotattributes[:z] !== nothing)
+        (st === :quiver && plotattributes[:z] !== nothing)
     )
         sp.attr[:projection] = "3d"
     end
@@ -402,7 +402,7 @@ function _override_seriestype_check(plotattributes::AKW, st::Symbol)
             z !== nothing &&
             (size(plotattributes[:x]) == size(plotattributes[:y]) == size(z))
         )
-            st = (st == :scatter ? :scatter3d : :path3d)
+            st = (st === :scatter ? :scatter3d : :path3d)
             plotattributes[:seriestype] = st
         end
     end
@@ -417,7 +417,7 @@ needs_any_3d_axes(sp::Subplot) = any(
 
 function _expand_subplot_extrema(sp::Subplot, plotattributes::AKW, st::Symbol)
     # adjust extrema and discrete info
-    if st == :image
+    if st === :image
         xmin, xmax = ignorenan_extrema(plotattributes[:x])
         ymin, ymax = ignorenan_extrema(plotattributes[:y])
         expand_extrema!(sp[:xaxis], (xmin, xmax))
@@ -438,11 +438,11 @@ function _add_the_series(plt, sp, plotattributes)
         plt[:extra_plot_kwargs] = get(kw, :plot, KW())
         sp[:extra_kwargs] = get(kw, :subplot, KW())
         plotattributes[:extra_kwargs] = get(kw, :series, KW())
-    elseif plt[:extra_kwargs] == :plot
+    elseif plt[:extra_kwargs] === :plot
         plt[:extra_plot_kwargs] = extra_kwargs
-    elseif plt[:extra_kwargs] == :subplot
+    elseif plt[:extra_kwargs] === :subplot
         sp[:extra_kwargs] = extra_kwargs
-    elseif plt[:extra_kwargs] == :series
+    elseif plt[:extra_kwargs] === :series
         plotattributes[:extra_kwargs] = extra_kwargs
     else
         ArgumentError("Unsupported type for extra keyword arguments")
@@ -451,9 +451,9 @@ function _add_the_series(plt, sp, plotattributes)
     series = Series(plotattributes)
     push!(plt.series_list, series)
     z_order = plotattributes[:z_order]
-    if z_order == :front
+    if z_order === :front
         push!(sp.series_list, series)
-    elseif z_order == :back
+    elseif z_order === :back
         pushfirst!(sp.series_list, series)
     elseif z_order isa Integer
         insert!(sp.series_list, z_order, series)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -70,7 +70,7 @@ end
 function _preprocess_userrecipe(kw::AKW)
     _add_markershape(kw)
 
-    if get(kw, :permute, default(:permute)) != :none
+    if get(kw, :permute, default(:permute)) !== :none
         l1, l2 = kw[:permute]
         for k in _axis_args
             k1 = _attrsymbolcache[l1][k]
@@ -350,7 +350,7 @@ RecipesPipeline.is_seriestype_supported(plt::Plot, st) = is_seriestype_supported
 
 function RecipesPipeline.add_series!(plt::Plot, plotattributes)
     sp = _prepare_subplot(plt, plotattributes)
-    if plotattributes[:permute] != :none
+    if plotattributes[:permute] !== :none
         letter1, letter2 = plotattributes[:permute]
         if plotattributes[:markershape] === :hline &&
            (plotattributes[:permute] == (:x, :y) || plotattributes[:permute] == (:y, :x))

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -231,7 +231,7 @@ make_steps(t::Tuple, st, even) = Tuple(make_steps(ti, st, even) for ti in t)
     plotattributes[:fillrange] = make_steps(plotattributes[:fillrange], :pre, false)
 
     # create a secondary series for the markers
-    if plotattributes[:markershape] != :none
+    if plotattributes[:markershape] !== :none
         @series begin
             seriestype := :scatter
             x := x
@@ -256,7 +256,7 @@ end
     plotattributes[:fillrange] = make_steps(plotattributes[:fillrange], :post, true)
 
     # create a secondary series for the markers
-    if plotattributes[:markershape] != :none
+    if plotattributes[:markershape] !== :none
         @series begin
             seriestype := :scatter
             x := x
@@ -281,7 +281,7 @@ end
     plotattributes[:fillrange] = make_steps(plotattributes[:fillrange], :post, false)
 
     # create a secondary series for the markers
-    if plotattributes[:markershape] != :none
+    if plotattributes[:markershape] !== :none
         @series begin
             seriestype := :scatter
             x := x
@@ -340,7 +340,7 @@ end
     end
 
     # create a primary series for the markers
-    if plotattributes[:markershape] != :none
+    if plotattributes[:markershape] !== :none
         primary := false
         @series begin
             seriestype := :scatter
@@ -724,7 +724,7 @@ end
     end
 
     # create a secondary series for the markers
-    if plotattributes[:markershape] != :none
+    if plotattributes[:markershape] !== :none
         @series begin
             seriestype := :scatter
             x := _bin_centers(edge)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -14,7 +14,7 @@ function seriestype_supported(pkg::AbstractBackend, st::Symbol)
 
     supported = true
     for dep in _series_recipe_deps[st]
-        if seriestype_supported(pkg, dep) == :no
+        if seriestype_supported(pkg, dep) === :no
             supported = false
         end
     end
@@ -207,11 +207,11 @@ function make_steps(x::AbstractArray, st, even)
     newx[1] = x[1]
     for i in 2:n
         idx = 2i - 1
-        if st == :mid
+        if st === :mid
             newx[idx] = newx[idx - 1] = (x[i] + x[i - 1]) / 2
         else
             newx[idx] = x[i]
-            newx[idx - 1] = x[st == :pre ? i : i - 1]
+            newx[idx - 1] = x[st === :pre ? i : i - 1]
         end
     end
     even && (newx[end] = x[end])
@@ -306,7 +306,7 @@ end
     if fr === nothing
         sp = plotattributes[:subplot]
         yaxis = sp[:yaxis]
-        fr = if yaxis[:scale] == :identity
+        fr = if yaxis[:scale] === :identity
             0.0
         else
             NaNMath.min(axis_limits(sp, :y)[1], ignorenan_minimum(y))
@@ -332,7 +332,7 @@ end
     fillrange := nothing
     seriestype := :path
     if (
-        plotattributes[:linecolor] == :auto &&
+        plotattributes[:linecolor] === :auto &&
         plotattributes[:marker_z] !== nothing &&
         plotattributes[:line_z] === nothing
     )
@@ -774,21 +774,21 @@ function _auto_binning_nbins(
 
     v = vs[dim]
 
-    if mode == :auto
+    if mode === :auto
         mode = :fd
     end
 
-    if mode == :sqrt  # Square-root choice
+    if mode === :sqrt  # Square-root choice
         _cl(sqrt(n_samples))
-    elseif mode == :sturges  # Sturges' formula
+    elseif mode === :sturges  # Sturges' formula
         _cl(log2(n_samples) + 1)
-    elseif mode == :rice  # Rice Rule
+    elseif mode === :rice  # Rice Rule
         _cl(2 * nd)
-    elseif mode == :scott  # Scott's normal reference rule
+    elseif mode === :scott  # Scott's normal reference rule
         _cl(_span(v) / (3.5 * std(v) / nd))
-    elseif mode == :fd  # Freedman–Diaconis rule
+    elseif mode === :fd  # Freedman–Diaconis rule
         _cl(_span(v) / (2 * _iqr(v) / nd))
-    elseif mode == :wand
+    elseif mode === :wand
         wand_edges(v)  # this makes this function not type stable, but the type instability does not propagate
     else
         error("Unknown auto-binning mode $mode")
@@ -903,7 +903,7 @@ end
     )
     seriestype := get(st_map, plotattributes[:seriestype], plotattributes[:seriestype])
 
-    if plotattributes[:seriestype] == :scatterbins
+    if plotattributes[:seriestype] === :scatterbins
         # Workaround, error bars currently not set correctly by scatterbins
         edge, weights, xscale, yscale, baseline =
             _preprocess_binlike(plotattributes, h.edges[1], h.weights)
@@ -1013,7 +1013,7 @@ end
 
 @recipe function f(::Type{Val{:scatter3d}}, x, y, z)
     seriestype := :path3d
-    if plotattributes[:markershape] == :none
+    if plotattributes[:markershape] === :none
         markershape := :circle
     end
     linewidth := 0
@@ -1203,7 +1203,7 @@ clamp_to_eps!(ary) = (replace!(x -> x <= 0.0 ? Base.eps(Float64) : x, ary); noth
         plotattributes[:x], plotattributes[:y], plotattributes[:z] =
             error_coords(xerr, x, y, z)
     end
-    if :xscale ∈ keys(plotattributes) && plotattributes[:xscale] == :log10
+    if :xscale ∈ keys(plotattributes) && plotattributes[:xscale] === :log10
         clamp_to_eps!(plotattributes[:x])
     end
     ()
@@ -1220,7 +1220,7 @@ end
         plotattributes[:y], plotattributes[:x], plotattributes[:z] =
             error_coords(yerr, y, x, z)
     end
-    if :yscale ∈ keys(plotattributes) && plotattributes[:yscale] == :log10
+    if :yscale ∈ keys(plotattributes) && plotattributes[:yscale] === :log10
         clamp_to_eps!(plotattributes[:y])
     end
     ()
@@ -1235,7 +1235,7 @@ end
         plotattributes[:z], plotattributes[:x], plotattributes[:y] =
             error_coords(zerr, z, x, y)
     end
-    if :zscale ∈ keys(plotattributes) && plotattributes[:zscale] == :log10
+    if :zscale ∈ keys(plotattributes) && plotattributes[:zscale] === :log10
         clamp_to_eps!(plotattributes[:z])
     end
     ()
@@ -1480,7 +1480,7 @@ end
 
 # Special case for 4-tuples in :ohlc series
 @recipe f(xyuv::AVec{<:Tuple{R1,R2,R3,R4}}) where {R1,R2,R3,R4} =
-    get(plotattributes, :seriestype, :path) == :ohlc ? OHLC[OHLC(t...) for t in xyuv] :
+    get(plotattributes, :seriestype, :path) === :ohlc ? OHLC[OHLC(t...) for t in xyuv] :
     RecipesPipeline.unzip(xyuv)
 
 @specialize

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -99,7 +99,7 @@ function series_segments(series::Series, seriestype::Symbol = :path; check = fal
 
     segments = if has_attribute_segments(series)
         Iterators.flatten(map(nan_segments) do r
-                if seriestype == :shape
+                if seriestype === :shape
                     warn_on_inconsistent_shape_attr(series, x, y, z, r)
                     (SeriesSegment(r, first(r)),)
                 elseif seriestype in (:scatter, :scatter3d)
@@ -355,7 +355,7 @@ ticksType(ticks::Tuple{T,S}) where {T<:Union{AVec,Tuple},S<:Union{AVec,Tuple}} =
 ticksType(ticks) = :invalid
 
 limsType(lims::Tuple{T,S}) where {T<:Real,S<:Real} = :limits
-limsType(lims::Symbol) = lims == :auto ? :auto : :invalid
+limsType(lims::Symbol) = lims === :auto ? :auto : :invalid
 limsType(lims) = :invalid
 
 # recursively merge kw-dicts, e.g. for merging extra_kwargs / extra_plot_kwargs in plotly)
@@ -653,7 +653,7 @@ function with(f::Function, args...; kw...)
     end
 
     # save the backend
-    if CURRENT_BACKEND.sym == :none
+    if CURRENT_BACKEND.sym === :none
         _pick_default_backend()
     end
     oldbackend = CURRENT_BACKEND.sym

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -57,7 +57,7 @@
         @test coords(myshapes) isa Tuple{Vector{Vector{S}},Vector{Vector{T}}} where {T,S}
         local p
         @test_nowarn p = plot(myshapes)
-        @test p[1][1][:seriestype] == :shape
+        @test p[1][1][:seriestype] === :shape
     end
 
     @testset "Misc" begin

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -92,7 +92,7 @@ end
     end
     @testset "Alpha" begin
         @test brush(0.4).alpha == 0.4
-        @test brush(20).alpha == nothing
+        @test brush(20).alpha === nothing
     end
     @testset "Bad Argument" begin
         # using test_logs because test_warn seems to not work anymore

--- a/test/test_contours.jl
+++ b/test/test_contours.jl
@@ -44,7 +44,7 @@ end
         @testset "$n contours" for n in (2, 5, 100)
             p = contour(x, y, z, levels = n)
             attr = p[1][1].plotattributes
-            @test attr[:seriestype] == :contour
+            @test attr[:seriestype] === :contour
             @test attr[:levels] == n
         end
     end

--- a/test/test_defaults.jl
+++ b/test/test_defaults.jl
@@ -24,16 +24,16 @@ end
     p = plot()
     @test p[1][:legend_font_family] == "sans-serif"
     @test p[1][:legend_font_pointsize] == 8
-    @test p[1][:legend_font_halign] == :hcenter
-    @test p[1][:legend_font_valign] == :vcenter
+    @test p[1][:legend_font_halign] === :hcenter
+    @test p[1][:legend_font_valign] === :vcenter
     @test p[1][:legend_font_rotation] == 0.0
     @test p[1][:legend_font_color] == RGB{Colors.N0f8}(0.0, 0.0, 0.0)
-    @test p[1][:legend_position] == :best
+    @test p[1][:legend_position] === :best
     @test p[1][:legend_title] == nothing
     @test p[1][:legend_title_font_family] == "sans-serif"
     @test p[1][:legend_title_font_pointsize] == 11
-    @test p[1][:legend_title_font_halign] == :hcenter
-    @test p[1][:legend_title_font_valign] == :vcenter
+    @test p[1][:legend_title_font_halign] === :hcenter
+    @test p[1][:legend_title_font_valign] === :vcenter
     @test p[1][:legend_title_font_rotation] == 0.0
     @test p[1][:legend_title_font_color] == RGB{Colors.N0f8}(0.0, 0.0, 0.0)
     @test p[1][:legend_background_color] == RGBA{Float64}(1.0, 1.0, 1.0, 1.0)
@@ -61,18 +61,18 @@ end
     )
     @test p[1][:legend_font_family] == "serif"
     @test p[1][:legend_font_pointsize] == 12
-    @test p[1][:legend_font_halign] == :left
-    @test p[1][:legend_font_valign] == :top
+    @test p[1][:legend_font_halign] === :left
+    @test p[1][:legend_font_valign] === :top
     @test p[1][:legend_font_rotation] == 1.0
-    @test p[1][:legend_font_color] == :red
-    @test p[1][:legend_position] == :outertopleft
+    @test p[1][:legend_font_color] === :red
+    @test p[1][:legend_position] === :outertopleft
     @test p[1][:legend_title] == "The legend"
     @test p[1][:legend_title_font_family] == "helvetica"
     @test p[1][:legend_title_font_pointsize] == 3
-    @test p[1][:legend_title_font_halign] == :right
-    @test p[1][:legend_title_font_valign] == :bottom
+    @test p[1][:legend_title_font_halign] === :right
+    @test p[1][:legend_title_font_valign] === :bottom
     @test p[1][:legend_title_font_rotation] == -5.2
-    @test p[1][:legend_title_font_color] == :blue
+    @test p[1][:legend_title_font_color] === :blue
     @test p[1][:legend_background_color] == RGBA{Float64}(0.0, 1.0, 1.0, 1.0)
     @test p[1][:legend_foreground_color] == RGBA{Float64}(0.0, 0.5019607843137255, 0.0, 1.0)
 
@@ -89,7 +89,7 @@ end
         foreground_color_subplot = :red,
     )[1]
     @test Plots.legendfont(sp).pointsize == 12
-    @test Plots.legendfont(sp).halign == :left
+    @test Plots.legendfont(sp).halign === :left
     # match mechanism
     @test sp[:legend_font_color] == sp[:foreground_color_subplot]
     @test Plots.legendfont(sp).color == sp[:foreground_color_subplot]

--- a/test/test_defaults.jl
+++ b/test/test_defaults.jl
@@ -29,7 +29,7 @@ end
     @test p[1][:legend_font_rotation] == 0.0
     @test p[1][:legend_font_color] == RGB{Colors.N0f8}(0.0, 0.0, 0.0)
     @test p[1][:legend_position] === :best
-    @test p[1][:legend_title] == nothing
+    @test p[1][:legend_title] === nothing
     @test p[1][:legend_title_font_family] == "sans-serif"
     @test p[1][:legend_title_font_pointsize] == 11
     @test p[1][:legend_title_font_halign] === :hcenter

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -4,10 +4,10 @@
         layout = 4,
         yscale = [:identity :identity :log10 :log10],
     )
-    @test pl[1][:yaxis][:scale] == :identity
-    @test pl[2][:yaxis][:scale] == :identity
-    @test pl[3][:yaxis][:scale] == :log10
-    @test pl[4][:yaxis][:scale] == :log10
+    @test pl[1][:yaxis][:scale] === :identity
+    @test pl[2][:yaxis][:scale] === :identity
+    @test pl[3][:yaxis][:scale] === :log10
+    @test pl[4][:yaxis][:scale] === :log10
 end
 
 @testset "Plot title" begin

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -116,7 +116,7 @@ end
     @testset "orientation" begin
         for f in (histogram, barhist, stephist, scatterhist), o in (:vertical, :horizontal)
             @test f(data, orientation = o).subplots[1].attr[:title] ==
-                  (o == :vertical ? "x" : "y")
+                  (o === :vertical ? "x" : "y")
         end
     end
 

--- a/test/test_pgfplotsx.jl
+++ b/test/test_pgfplotsx.jl
@@ -407,7 +407,7 @@ with(:pgfplotsx) do
         pl = plot(1:5, title = "Test me", titlefont = (2, :left))
         @test pl[1][:title] == "Test me"
         @test pl[1][:titlefontsize] == 2
-        @test pl[1][:titlefonthalign] == :left
+        @test pl[1][:titlefonthalign] === :left
         Plots._update_plot_object(pl)
         ax_opt = Plots.pgfx_axes(pl.o)[1].options
         @test ax_opt["title"] == "Test me"
@@ -415,7 +415,7 @@ with(:pgfplotsx) do
         pl = plot(1:5, plot_title = "Test me", plot_titlefont = (2, :left))
         @test pl[:plot_title] == "Test me"
         @test pl[:plot_titlefontsize] == 2
-        @test pl[:plot_titlefonthalign] == :left
+        @test pl[:plot_titlefonthalign] === :left
         pl = heatmap(
             rand(3, 3),
             colorbar_title = "Test me",
@@ -423,6 +423,6 @@ with(:pgfplotsx) do
         )
         @test pl[1][:colorbar_title] == "Test me"
         @test pl[1][:colorbar_titlefontsize] == 12
-        @test pl[1][:colorbar_titlefonthalign] == :right
+        @test pl[1][:colorbar_titlefonthalign] === :right
     end
 end

--- a/test/test_recipes.jl
+++ b/test/test_recipes.jl
@@ -7,16 +7,16 @@ using OffsetArrays
         (1:3, 1:3)
     end
     pl = plot(LegendPlot(); legend = :right)
-    @test pl[1][:legend_position] == :right
+    @test pl[1][:legend_position] === :right
     pl = plot(LegendPlot())
-    @test pl[1][:legend_position] == :topleft
+    @test pl[1][:legend_position] === :topleft
 end
 
 @testset "lens!" begin
     pl = plot(1:5)
     lens!(pl, [1, 2], [1, 2], inset = (1, bbox(0.0, 0.0, 0.2, 0.2)), colorbar = false)
     @test length(pl.series_list) == 4
-    @test pl[2][:colorbar] == :none
+    @test pl[2][:colorbar] === :none
 end
 
 @testset "vline, vspan" begin

--- a/test/test_shorthands.jl
+++ b/test/test_shorthands.jl
@@ -83,7 +83,7 @@ end
 
     p = plot3d([1, 2], [1, 2], [1, 2])
     plot3d!(p, [3, 4], [3, 4], [3, 4])
-    @test Plots.series_list(p[1])[1][:seriestype] == :path3d
+    @test Plots.series_list(p[1])[1][:seriestype] === :path3d
 end
 
 @testset "Set Ticks" begin


### PR DESCRIPTION
This mostly changes `==` to `===` for comparisons with symbols and nothing. It also converts a few arrays to tuples where applicable. This can help improve inference time, which I see locally in precompilation from ~60s -> 50s. I notice some trade-off in load/execution time, so I suspect re-generating precompilation statements may help this end.

before:
```
julia> @timev using Plots
  6.196723 seconds (8.99 M allocations: 603.026 MiB, 3.87% gc time, 20.50% compilation time)
elapsed time (ns): 6196722714
gc time (ns):      240113203
bytes allocated:   632318994
pool allocs:       8988395
non-pool GC allocs:2091
malloc() calls:    200
realloc() calls:   4
GC pauses:         4
full collections:  1

julia> @timev scatter(rand(500))
  3.914092 seconds (3.80 M allocations: 209.930 MiB, 1.69% gc time, 99.81% compilation time)
elapsed time (ns): 3914092369
gc time (ns):      66005571
bytes allocated:   220127748
pool allocs:       3795989
non-pool GC allocs:1446
GC pauses:         5
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
```

PR:
```
julia> @timev using Plots
  6.333818 seconds (8.99 M allocations: 603.106 MiB, 3.84% gc time, 21.04% compilation time)
elapsed time (ns): 6333817635
gc time (ns):      243223589
bytes allocated:   632402690
pool allocs:       8988292
non-pool GC allocs:2092
malloc() calls:    200
realloc() calls:   4
GC pauses:         5
full collections:  1

julia> @timev scatter(rand(500))
  3.749349 seconds (3.78 M allocations: 209.149 MiB, 1.71% gc time, 99.82% compilation time)
elapsed time (ns): 3749349010
gc time (ns):      64252052
bytes allocated:   219308520
pool allocs:       3782670
non-pool GC allocs:1421
GC pauses:         5
```