### PR TITLE
add plot-to-png-within-IOBuffer method

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -17,12 +17,16 @@ svg(plt::Plot, fn::AbstractString) =
 
 svg(fn::AbstractString) = svg(current(), fn)
 
+svg(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("image/svg"), plt); seekstart(io))
+
 pdf(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "pdf"), "w") do io
         show(io, MIME("application/pdf"), plt)
     end
 
 pdf(fn::AbstractString) = pdf(current(), fn)
+
+pdf(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("application/pdf"), plt); seekstart(io))
 
 ps(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "ps"), "w") do io
@@ -31,12 +35,16 @@ ps(plt::Plot, fn::AbstractString) =
 
 ps(fn::AbstractString) = ps(current(), fn)
 
+ps(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("application/postscript"), plt); seekstart(io))
+
 eps(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "eps"), "w") do io
         show(io, MIME("image/eps"), plt)
     end
 
 eps(fn::AbstractString) = eps(current(), fn)
+
+eps(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("image/eps"), plt); seekstart(io))
 
 tex(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "tex"), "w") do io

--- a/src/output.jl
+++ b/src/output.jl
@@ -8,6 +8,8 @@ png(plt::Plot, fn::AbstractString) =
 
 png(fn::AbstractString) = png(current(), fn)
 
+png(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("image/png"), plt); seekstart(io))
+
 svg(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "svg"), "w") do io
         show(io, MIME("image/svg+xml"), plt)

--- a/src/output.jl
+++ b/src/output.jl
@@ -8,7 +8,7 @@ png(plt::Plot, fn::AbstractString) =
 
 png(fn::AbstractString) = png(current(), fn)
 
-png(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("image/png"), plt); seekstart(io))
+png(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("image/png"), plt); seekstart(io))
 
 svg(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "svg"), "w") do io
@@ -17,7 +17,7 @@ svg(plt::Plot, fn::AbstractString) =
 
 svg(fn::AbstractString) = svg(current(), fn)
 
-svg(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("image/svg"), plt); seekstart(io))
+svg(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("image/svg"), plt); seekstart(io))
 
 pdf(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "pdf"), "w") do io
@@ -26,7 +26,7 @@ pdf(plt::Plot, fn::AbstractString) =
 
 pdf(fn::AbstractString) = pdf(current(), fn)
 
-pdf(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("application/pdf"), plt); seekstart(io))
+pdf(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("application/pdf"), plt); seekstart(io))
 
 ps(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "ps"), "w") do io
@@ -35,7 +35,7 @@ ps(plt::Plot, fn::AbstractString) =
 
 ps(fn::AbstractString) = ps(current(), fn)
 
-ps(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("application/postscript"), plt); seekstart(io))
+ps(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("application/postscript"), plt); seekstart(io))
 
 eps(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "eps"), "w") do io
@@ -44,7 +44,7 @@ eps(plt::Plot, fn::AbstractString) =
 
 eps(fn::AbstractString) = eps(current(), fn)
 
-eps(plt::Plot, io::IOBuffer) = (seekstart(io); show(io, MIME("image/eps"), plt); seekstart(io))
+eps(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("image/eps"), plt); seekstart(io))
 
 tex(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "tex"), "w") do io
@@ -52,6 +52,8 @@ tex(plt::Plot, fn::AbstractString) =
     end
 
 tex(fn::AbstractString) = tex(current(), fn)
+
+tex(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("application/x-tex"), plt); seekstart(io))
 
 json(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "json"), "w") do io
@@ -67,12 +69,16 @@ html(plt::Plot, fn::AbstractString) =
 
 html(fn::AbstractString) = html(current(), fn)
 
+html(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("text/html"), plt); seekstart(io))
+
 txt(plt::Plot, fn::AbstractString; color::Bool = true) =
     open(addExtension(fn, "txt"), "w") do io
         show(IOContext(io, :color => color), MIME("text/plain"), plt)
     end
 
 txt(fn::AbstractString) = txt(current(), fn)
+
+txt(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("text/plain"), plt); seekstart(io))
 
 # ----------------------------------------------------------------
 

--- a/src/output.jl
+++ b/src/output.jl
@@ -9,6 +9,7 @@ png(plt::Plot, fn::AbstractString) =
 png(fn::AbstractString) = png(current(), fn)
 
 png(plt::Plot, io::IO) = show(io, MIME("image/png"), plt)
+png(io::IO) = png(current(), io)
 
 svg(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "svg"), "w") do io
@@ -16,6 +17,7 @@ svg(plt::Plot, fn::AbstractString) =
     end
 
 svg(fn::AbstractString) = svg(current(), fn)
+svg(io::IO) = svg(current(), io)
 
 svg(plt::Plot, io::IO) = show(io, MIME("image/svg"), plt)
 
@@ -27,6 +29,7 @@ pdf(plt::Plot, fn::AbstractString) =
 pdf(fn::AbstractString) = pdf(current(), fn)
 
 pdf(plt::Plot, io::IO) = show(io, MIME("application/pdf"), plt)
+pdf(io::IO) = pdf(current(), io)
 
 ps(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "ps"), "w") do io
@@ -36,6 +39,7 @@ ps(plt::Plot, fn::AbstractString) =
 ps(fn::AbstractString) = ps(current(), fn)
 
 ps(plt::Plot, io::IO) = show(io, MIME("application/postscript"), plt)
+ps(io::IO) = ps(current(), io)
 
 eps(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "eps"), "w") do io
@@ -43,6 +47,7 @@ eps(plt::Plot, fn::AbstractString) =
     end
 
 eps(fn::AbstractString) = eps(current(), fn)
+eps(io::IO) = eps(current(), io)
 
 eps(plt::Plot, io::IO) = show(io, MIME("image/eps"), plt)
 
@@ -54,6 +59,7 @@ tex(plt::Plot, fn::AbstractString) =
 tex(fn::AbstractString) = tex(current(), fn)
 
 tex(plt::Plot, io::IO) = show(io, MIME("application/x-tex"), plt)
+tex(io::IO) = tex(current(), io)
 
 json(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "json"), "w") do io
@@ -70,6 +76,7 @@ html(plt::Plot, fn::AbstractString) =
 html(fn::AbstractString) = html(current(), fn)
 
 html(plt::Plot, io::IO) = show(io, MIME("text/html"), plt)
+html(io::IO) = html(current(), io)
 
 txt(plt::Plot, fn::AbstractString; color::Bool = true) =
     open(addExtension(fn, "txt"), "w") do io
@@ -79,7 +86,7 @@ txt(plt::Plot, fn::AbstractString; color::Bool = true) =
 txt(fn::AbstractString) = txt(current(), fn)
 
 txt(plt::Plot, io::IO) = show(io, MIME("text/plain"), plt)
-
+txt(io::IO) = txt(current(), io)
 # ----------------------------------------------------------------
 
 const _savemap = Dict(

--- a/src/output.jl
+++ b/src/output.jl
@@ -8,7 +8,7 @@ png(plt::Plot, fn::AbstractString) =
 
 png(fn::AbstractString) = png(current(), fn)
 
-png(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("image/png"), plt); seekstart(io))
+png(plt::Plot, io::IO) = show(io, MIME("image/png"), plt)
 
 svg(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "svg"), "w") do io
@@ -17,7 +17,7 @@ svg(plt::Plot, fn::AbstractString) =
 
 svg(fn::AbstractString) = svg(current(), fn)
 
-svg(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("image/svg"), plt); seekstart(io))
+svg(plt::Plot, io::IO) = show(io, MIME("image/svg"), plt)
 
 pdf(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "pdf"), "w") do io
@@ -26,7 +26,7 @@ pdf(plt::Plot, fn::AbstractString) =
 
 pdf(fn::AbstractString) = pdf(current(), fn)
 
-pdf(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("application/pdf"), plt); seekstart(io))
+pdf(plt::Plot, io::IO) = show(io, MIME("application/pdf"), plt)
 
 ps(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "ps"), "w") do io
@@ -35,7 +35,7 @@ ps(plt::Plot, fn::AbstractString) =
 
 ps(fn::AbstractString) = ps(current(), fn)
 
-ps(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("application/postscript"), plt); seekstart(io))
+ps(plt::Plot, io::IO) = show(io, MIME("application/postscript"), plt)
 
 eps(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "eps"), "w") do io
@@ -44,7 +44,7 @@ eps(plt::Plot, fn::AbstractString) =
 
 eps(fn::AbstractString) = eps(current(), fn)
 
-eps(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("image/eps"), plt); seekstart(io))
+eps(plt::Plot, io::IO) = show(io, MIME("image/eps"), plt)
 
 tex(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "tex"), "w") do io
@@ -53,7 +53,7 @@ tex(plt::Plot, fn::AbstractString) =
 
 tex(fn::AbstractString) = tex(current(), fn)
 
-tex(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("application/x-tex"), plt); seekstart(io))
+tex(plt::Plot, io::IO) = show(io, MIME("application/x-tex"), plt)
 
 json(plt::Plot, fn::AbstractString) =
     open(addExtension(fn, "json"), "w") do io
@@ -69,7 +69,7 @@ html(plt::Plot, fn::AbstractString) =
 
 html(fn::AbstractString) = html(current(), fn)
 
-html(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("text/html"), plt); seekstart(io))
+html(plt::Plot, io::IO) = show(io, MIME("text/html"), plt)
 
 txt(plt::Plot, fn::AbstractString; color::Bool = true) =
     open(addExtension(fn, "txt"), "w") do io
@@ -78,7 +78,7 @@ txt(plt::Plot, fn::AbstractString; color::Bool = true) =
 
 txt(fn::AbstractString) = txt(current(), fn)
 
-txt(plt::Plot, io::IO) = (seekstart(io); show(io, MIME("text/plain"), plt); seekstart(io))
+txt(plt::Plot, io::IO) = show(io, MIME("text/plain"), plt)
 
 # ----------------------------------------------------------------
 


### PR DESCRIPTION
This patch is for situations where it is desired to share a plot image to another function, such as:
```julia
using Cairo
using Gtk
using Plots

const io = IOBuffer()

function plotincanvas(h = 900, w = 800)
    win = GtkWindow("Normal Histogram Widget", h, w) |> (vbox = GtkBox(:v) |> (slide = GtkScale(false, 1:500)))
    Gtk.G_.value(slide, 250.0)
    can = GtkCanvas()
    push!(vbox, can)
    set_gtk_property!(vbox, :expand, can, true)
    @guarded draw(can) do widget
        ctx = getgc(can)
        n = Int(Gtk.GAccessor.value(slide))
        png(histogram(randn(n)), io)
        img = read_from_png(io)
        set_source_surface(ctx, img, 0, 0)
        paint(ctx)
    end
    id = signal_connect((w) -> draw(can), slide, "value-changed")
    showall(win)
    show(can)
end

plotincanvas()
```