### PR TITLE
keep largest size of subplots when plotting plots

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -121,11 +121,12 @@ function plot!(plt1::Plot, plt2::Plot, plts_tail::Plot...; kw...)
     # TODO: build the user_attr dict by creating "Any matrices" for the args of each subplot
 
     # TODO: replace this with proper processing from a merged user_attr KW
-    # update plot args, first with existing plots, then override with plotattributes
+    # update plot args
     for p in plts
         # _update_plot_args(plt, copy(p.attr))
         plt.n += p.n
     end
+    plt[:size] = last(sort(getindex.(plts, :size), by = x -> x[1] * x[2]))
     _update_plot_args(plt, plotattributes)
 
     # pass new plot to the backend

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -1,9 +1,9 @@
 using Plots, Test
 
 @testset "Plotting plots" begin
-    pl = @test_nowarn plot(plot(1:2), plot(1:2, size=(1200,400)))
+    pl = @test_nowarn plot(plot(1:2), plot(1:2, size = (1200, 400)))
     @test pl[:size] == (1200, 400)
-    pl = @test_nowarn plot(plot(1:2), plot(1:2), size=(1200,400))
+    pl = @test_nowarn plot(plot(1:2), plot(1:2), size = (1200, 400))
     @test pl[:size] == (1200, 400)
 end
 

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -1,3 +1,12 @@
+using Plots, Test
+
+@testset "Plotting plots" begin
+    pl = @test_nowarn plot(plot(1:2), plot(1:2, size=(1200,400)))
+    @test pl[:size] == (1200, 400)
+    pl = @test_nowarn plot(plot(1:2), plot(1:2), size=(1200,400))
+    @test pl[:size] == (1200, 400)
+end
+
 @testset "Subplot sclicing" begin
     pl = @test_nowarn plot(
         rand(4, 8),


### PR DESCRIPTION
Another option would be to actually add sizes when plotting plots, but I think thats breaking.

Fix: #4273 