### PR TITLE
gr: support `:pixel`

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -431,7 +431,7 @@ const _gr_seriestype = [
     :shape,
 ]
 const _gr_style = [:auto, :solid, :dash, :dot, :dashdot, :dashdotdot]
-const _gr_marker = _allMarkers
+const _gr_marker = vcat(_allMarkers, :pixel)
 const _gr_scale = [:identity, :log10]
 is_marker_supported(::GRBackend, shape::Shape) = true
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -18,6 +18,7 @@ gr_linetype(k) = (auto = 1, solid = 1, dash = 2, dot = 3, dashdot = 4, dashdotdo
 
 gr_markertype(k) = (
     auto = 1,
+    pixel = 1,
     none = -1,
     circle = -1,
     rect = -7,


### PR DESCRIPTION
`gr` actually supports the `:pixel` marker (`MARKERTYPE_DOT`): https://gr-framework.org/markertypes.html.