### PR TITLE
handle fractional and NaN epochs

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -720,6 +720,10 @@
         {
             "name": "Nick OBrien",
             "type": "Other"
+        },
+        {
+            "name": "Henning Labuhn",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -534,7 +534,7 @@ function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
     if formatter == datetimeformatter
         map(xi -> isfinite(xi) ? replace(formatter(xi), "T" => " ") : missing, x)
     elseif formatter == dateformatter
-        map(xi -> isfinite(xi) ? replace(dateformatter(xi), "T" => " ") : missing, x)
+        map(xi -> isfinite(xi) ? replace(formatter(xi), "T" => " ") : missing, x)
     elseif formatter == timeformatter
         map(xi -> isfinite(xi) ? string(Dates.today(), " ", formatter(xi)) : missing, x)
     else

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -550,7 +550,7 @@ function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
                 : missing, x)
         end
     elseif formatter == timeformatter
-        map(xi -> isfinite(xi) ? string(Dates.now(), " ", formatter(xi)) : missing, x)
+        map(xi -> isfinite(xi) ? string(Dates.today(), " ", formatter(xi)) : missing, x)
     else
         error(
             "Invalid DateTime formatter. Expected Plots.datetime/date/time formatter but got $formatter",

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -537,6 +537,8 @@ function epochdays2datetime(fractionaldays::Real)::DateTime
     DateTime(Dates.epochdays2date(days)) + missing_ms
 end
 
+epochdays2epochms(x) = Dates.datetime2epochms(epochdays2datetime(x))
+
 function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
     if formatter == datetimeformatter
         map(xi -> isfinite(xi) ? replace(formatter(xi), "T" => " ") : missing, x)
@@ -544,10 +546,13 @@ function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
         if all(isinteger, x)
             map(xi -> string(formatter(xi), " 00:00:00"), x)
         else
-            # deal with "fractional" epochdays (e.g. from `seriestype = :step` and `bar()`)
-            map(xi -> isfinite(xi)
-                ? replace(string(datetimeformatter(Dates.datetime2epochms(epochdays2datetime(xi)))), "T" => " ")
-                : missing, x)
+            # deal with "fractional" epochdays (e.g. for xticks in `seriestype = :step` and `bar()`)
+            map(
+                xi ->
+                    isfinite(xi) ?
+                    replace(string(datetimeformatter(epochdays2epochms(x))), "T" => " ") : missing,
+                x,
+            )
         end
     elseif formatter == timeformatter
         map(xi -> isfinite(xi) ? string(Dates.today(), " ", formatter(xi)) : missing, x)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -531,10 +531,10 @@ end
 plotly_native_data(axis::Axis, a::Surface) = Surface(plotly_native_data(axis, a.surf))
 
 function epochdays2datetime(fractionaldays::Real)::DateTime
-	days = floor(fractionaldays)
-	dayfraction = fractionaldays - days
-	missing_ms = Millisecond(round(Millisecond(Day(1)).value * dayfraction))
-	DateTime(Dates.epochdays2date(days)) + missing_ms
+    days = floor(fractionaldays)
+    dayfraction = fractionaldays - days
+    missing_ms = Millisecond(round(Millisecond(Day(1)).value * dayfraction))
+    DateTime(Dates.epochdays2date(days)) + missing_ms
 end
 
 function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
@@ -550,7 +550,7 @@ function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
                 : missing, x)
         end
     elseif formatter == timeformatter
-        map(xi -> isfinite(xi) ?  string(Dates.Date(Dates.now()), " ", formatter(xi)) : missing, x)
+        map(xi -> isfinite(xi) ? string(Dates.now(), " ", formatter(xi)) : missing, x)
     else
         error(
             "Invalid DateTime formatter. Expected Plots.datetime/date/time formatter but got $formatter",

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -544,8 +544,10 @@ function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
         if all(isinteger, x)
             map(xi -> string(formatter(xi), " 00:00:00"), x)
         else
-            # deal with "fracional" epochdays (e.g. from `seriestype = :step`` and `bar()``)
-            map(xi -> isfinite(xi) ? replace(string(datetimeformatter(Dates.datetime2epochms(epochdays2datetime(xi)))), "T" => " ") : missing, x)
+            # deal with "fractional" epochdays (e.g. from `seriestype = :step` and `bar()`)
+            map(xi -> isfinite(xi)
+                ? replace(string(datetimeformatter(Dates.datetime2epochms(epochdays2datetime(xi)))), "T" => " ")
+                : missing, x)
         end
     elseif formatter == timeformatter
         map(xi -> isfinite(xi) ?  string(Dates.Date(Dates.now()), " ", formatter(xi)) : missing, x)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -530,30 +530,11 @@ function plotly_native_data(axis::Axis, data::AbstractArray)
 end
 plotly_native_data(axis::Axis, a::Surface) = Surface(plotly_native_data(axis, a.surf))
 
-function epochdays2datetime(fractionaldays::Real)::DateTime
-    days = floor(fractionaldays)
-    dayfraction = fractionaldays - days
-    missing_ms = Millisecond(round(Millisecond(Day(1)).value * dayfraction))
-    DateTime(Dates.epochdays2date(days)) + missing_ms
-end
-
-epochdays2epochms(x) = Dates.datetime2epochms(epochdays2datetime(x))
-
 function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
     if formatter == datetimeformatter
         map(xi -> isfinite(xi) ? replace(formatter(xi), "T" => " ") : missing, x)
     elseif formatter == dateformatter
-        if all(isinteger, x)
-            map(xi -> string(formatter(xi), " 00:00:00"), x)
-        else
-            # deal with "fractional" epochdays (e.g. for xticks in `seriestype = :step` and `bar()`)
-            map(
-                xi ->
-                    isfinite(xi) ? replace(datetimeformatter(epochdays2epochms(x)), "T" => " ") :
-                    missing,
-                x,
-            )
-        end
+        map(xi -> isfinite(xi) ? replace(dateformatter(xi), "T" => " ") : missing, x)
     elseif formatter == timeformatter
         map(xi -> isfinite(xi) ? string(Dates.today(), " ", formatter(xi)) : missing, x)
     else

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -549,8 +549,8 @@ function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
             # deal with "fractional" epochdays (e.g. for xticks in `seriestype = :step` and `bar()`)
             map(
                 xi ->
-                    isfinite(xi) ?
-                    replace(string(datetimeformatter(epochdays2epochms(x))), "T" => " ") : missing,
+                    isfinite(xi) ? replace(datetimeformatter(epochdays2epochms(x)), "T" => " ") :
+                    missing,
                 x,
             )
         end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -530,13 +530,25 @@ function plotly_native_data(axis::Axis, data::AbstractArray)
 end
 plotly_native_data(axis::Axis, a::Surface) = Surface(plotly_native_data(axis, a.surf))
 
+function epochdays2datetime(fractionaldays::Real)::DateTime
+	days = floor(fractionaldays)
+	dayfraction = fractionaldays - days
+	missing_ms = Millisecond(round(Millisecond(Day(1)).value * dayfraction))
+	DateTime(Dates.epochdays2date(days)) + missing_ms
+end
+
 function plotly_convert_to_datetime(x::AbstractArray, formatter::Function)
     if formatter == datetimeformatter
-        map(xi -> replace(formatter(xi), "T" => " "), x)
+        map(xi -> isfinite(xi) ? replace(formatter(xi), "T" => " ") : missing, x)
     elseif formatter == dateformatter
-        map(xi -> string(formatter(xi), " 00:00:00"), x)
+        if all(isinteger, x)
+            map(xi -> string(formatter(xi), " 00:00:00"), x)
+        else
+            # deal with "fracional" epochdays (e.g. from `seriestype = :step`` and `bar()``)
+            map(xi -> isfinite(xi) ? replace(string(datetimeformatter(Dates.datetime2epochms(epochdays2datetime(xi)))), "T" => " ") : missing, x)
+        end
     elseif formatter == timeformatter
-        map(xi -> string(Dates.Date(Dates.now()), " ", formatter(xi)), x)
+        map(xi -> isfinite(xi) ?  string(Dates.Date(Dates.now()), " ", formatter(xi)) : missing, x)
     else
         error(
             "Invalid DateTime formatter. Expected Plots.datetime/date/time formatter but got $formatter",


### PR DESCRIPTION
Note: This is my first PR for an OSS project, please forgive me if I missed and contributing guidelines...

fixes #4248

One can now use `ticks = :native` for `DateTime`s in combination with "fractional" Dates (e.g. from `bar()` and `seriestype = :step`.

```julia 
using Plots
using Dates
plotly()

x = [now() + Second(i) for i in 1:20]
y = rand(length(x))
plot(
    x, y,
    seriestype = :stepmid,
    ticks=:native,
)
scatter!(x,y)
```

Full plot:
![plot_11](https://user-images.githubusercontent.com/5331081/181260524-19853099-0afa-4b8e-a575-d8cf0dfdaa29.svg)

Zoomed in:
![plot_12](https://user-images.githubusercontent.com/5331081/181260523-fb68e6c5-5ccd-478d-922d-1b3dfafe5da7.svg)
