### PR TITLE
Allow user to specify series type for line of `areaplot`

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1663,20 +1663,9 @@ end
 
 @userplot AreaPlot
 
-@recipe function f(a::AreaPlot; steptype = :none)
+@recipe function f(a::AreaPlot; seriestype = :line)
     data = cumsum(a.args[end], dims = 2)
     x = length(a.args) == 1 ? (axes(data, 1)) : a.args[1]
-    if steptype === :none
-        seriestype := :line
-    elseif steptype === :pre
-        seriestype := :steppre
-    elseif steptype === :mid
-        seriestype := :stepmid
-    elseif steptype === :post
-        seriestype := :steppost
-    else
-        throw(ArgumentError("steptype must be one of :none, :pre, :mid, :post"))
-    end
     for i in axes(data, 2)
         @series begin
             fillrange := i > 1 ? data[:, i - 1] : 0

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1663,10 +1663,20 @@ end
 
 @userplot AreaPlot
 
-@recipe function f(a::AreaPlot)
+@recipe function f(a::AreaPlot; steptype = :none)
     data = cumsum(a.args[end], dims = 2)
     x = length(a.args) == 1 ? (axes(data, 1)) : a.args[1]
-    seriestype := :line
+    if steptype === :none
+        seriestype := :line
+    elseif steptype === :pre
+        seriestype := :steppre
+    elseif steptype === :mid
+        seriestype := :stepmid
+    elseif steptype === :post
+        seriestype := :steppost
+    else
+        throw(ArgumentError("steptype must be one of :none, :pre, :mid, :post"))
+    end
     for i in axes(data, 2)
         @series begin
             fillrange := i > 1 ? data[:, i - 1] : 0


### PR DESCRIPTION
In partial fulfilment of #4290, ~this PR adds a `steptype` property to `areaplot`, which can take on values of `:none` (default, linear), `:pre` => `steppre`, `mid` => `stepmid`, `:post` => `steppost`.~ allows a different `seriestype` to be specified instead of `line`.

```
areaplot([1 11; 2 12; 3 13; 4 14; 3 13; 2 12; 1 11], seriestype = :steppost)
```
![image](https://user-images.githubusercontent.com/1438610/181427869-250bb50f-43c7-4ae8-85b0-b83fa585b2c9.png)
