### PR TITLE
annotate! relative position independant from the axis scale

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -648,11 +648,11 @@ function _relative_position(xmin, xmax, pos::Length{:pct}, scale::Symbol)
 
     # !TODO Add more scales in the future (asinh, sqrt) ?
     if scale === :log || scale === :ln
-        exp(log(xmin) + pos.value * (log(xmax) - log(xmin)))
+        exp(log(xmin) + pos.value * (log(xmax / xmin)))
     elseif scale === :log10
-        exp10(log10(xmin) + pos.value * (log10(xmax) - log10(xmin)))
+        exp10(log10(xmin) + pos.value * (log10(xmax / xmin)))
     elseif scale === :log2
-        exp2(log2(xmin) + pos.value * (log2(xmax) - log2(xmin)))
+        exp2(log2(xmin) + pos.value * (log2(xmax / xmin)))
     else # :identity (linear scale)
         xmin + pos.value * (xmax - xmin)
     end
@@ -674,8 +674,16 @@ function locate_annotation(
 )
     x, y = position_multiplier[pos]
     (
-        _relative_position(axis_limits(sp, :x)..., x, sp[get_attr_symbol(:x, :axis)][:scale]),
-        _relative_position(axis_limits(sp, :y)..., y, sp[get_attr_symbol(:y, :axis)][:scale]),
+        _relative_position(
+            axis_limits(sp, :x)...,
+            x,
+            sp[get_attr_symbol(:x, :axis)][:scale],
+        ),
+        _relative_position(
+            axis_limits(sp, :y)...,
+            y,
+            sp[get_attr_symbol(:y, :axis)][:scale],
+        ),
         label,
     )
 end
@@ -683,15 +691,34 @@ locate_annotation(sp::Subplot, x, y, label::PlotText) = (x, y, label)
 locate_annotation(sp::Subplot, x, y, z, label::PlotText) = (x, y, z, label)
 
 locate_annotation(sp::Subplot, rel::NTuple{2,<:Number}, label::PlotText) = (
-    _relative_position(axis_limits(sp, :x)..., rel[1] * Plots.pct, sp[get_attr_symbol(:x, :axis)][:scale]),
-    _relative_position(axis_limits(sp, :y)..., rel[2] * Plots.pct, sp[get_attr_symbol(:y, :axis)][:scale]),
+    _relative_position(
+        axis_limits(sp, :x)...,
+        rel[1] * Plots.pct,
+        sp[get_attr_symbol(:x, :axis)][:scale],
+    ),
+    _relative_position(
+        axis_limits(sp, :y)...,
+        rel[2] * Plots.pct,
+        sp[get_attr_symbol(:y, :axis)][:scale],
+    ),
     label,
 )
 locate_annotation(sp::Subplot, rel::NTuple{3,<:Number}, label::PlotText) = (
-
-    _relative_position(axis_limits(sp, :x)..., rel[1] * Plots.pct, sp[get_attr_symbol(:x, :axis)][:scale]),
-    _relative_position(axis_limits(sp, :y)..., rel[2] * Plots.pct, sp[get_attr_symbol(:y, :axis)][:scale]),
-    _relative_position(axis_limits(sp, :z)..., rel[3] * Plots.pct, sp[get_attr_symbol(:z, :axis)][:scale]),
+    _relative_position(
+        axis_limits(sp, :x)...,
+        rel[1] * Plots.pct,
+        sp[get_attr_symbol(:x, :axis)][:scale],
+    ),
+    _relative_position(
+        axis_limits(sp, :y)...,
+        rel[2] * Plots.pct,
+        sp[get_attr_symbol(:y, :axis)][:scale],
+    ),
+    _relative_position(
+        axis_limits(sp, :z)...,
+        rel[3] * Plots.pct,
+        sp[get_attr_symbol(:z, :axis)][:scale],
+    ),
     label,
 )
 # -----------------------------------------------------------------------

--- a/src/components.jl
+++ b/src/components.jl
@@ -648,11 +648,11 @@ function _relative_position(xmin, xmax, pos::Length{:pct}, scale::Symbol)
 
     # !TODO Add more scales in the future (asinh, sqrt) ?
     if scale === :log || scale === :ln
-        exp(log(xmin) + pos.value * (log(xmax / xmin)))
+        exp(log(xmin) + pos.value * log(xmax / xmin))
     elseif scale === :log10
-        exp10(log10(xmin) + pos.value * (log10(xmax / xmin)))
+        exp10(log10(xmin) + pos.value * log10(xmax / xmin))
     elseif scale === :log2
-        exp2(log2(xmin) + pos.value * (log2(xmax / xmin)))
+        exp2(log2(xmin) + pos.value * log2(xmax / xmin))
     else # :identity (linear scale)
         xmin + pos.value * (xmax - xmin)
     end

--- a/src/components.jl
+++ b/src/components.jl
@@ -644,7 +644,19 @@ function process_annotation(
     anns
 end
 
-_relative_position(xmin, xmax, pos::Length{:pct}) = xmin + pos.value * (xmax - xmin)
+function _relative_position(xmin, xmax, pos::Length{:pct}, scale::Symbol)
+
+    # !TODO Add more scales in the future (asinh, sqrt) ?
+    if scale === :log || scale === :ln
+        exp(log(xmin) + pos.value * (log(xmax) - log(xmin)))
+    elseif scale === :log10
+        exp10(log10(xmin) + pos.value * (log10(xmax) - log10(xmin)))
+    elseif scale === :log2
+        exp2(log2(xmin) + pos.value * (log2(xmax) - log2(xmin)))
+    else # :identity (linear scale)
+        xmin + pos.value * (xmax - xmin)
+    end
+end
 
 # Give each annotation coordinates based on specified position
 function locate_annotation(
@@ -662,8 +674,8 @@ function locate_annotation(
 )
     x, y = position_multiplier[pos]
     (
-        _relative_position(axis_limits(sp, :x)..., x),
-        _relative_position(axis_limits(sp, :y)..., y),
+        _relative_position(axis_limits(sp, :x)..., x, sp[get_attr_symbol(:x, :axis)][:scale]),
+        _relative_position(axis_limits(sp, :y)..., y, sp[get_attr_symbol(:y, :axis)][:scale]),
         label,
     )
 end
@@ -671,14 +683,15 @@ locate_annotation(sp::Subplot, x, y, label::PlotText) = (x, y, label)
 locate_annotation(sp::Subplot, x, y, z, label::PlotText) = (x, y, z, label)
 
 locate_annotation(sp::Subplot, rel::NTuple{2,<:Number}, label::PlotText) = (
-    _relative_position(axis_limits(sp, :x)..., rel[1] * Plots.pct),
-    _relative_position(axis_limits(sp, :y)..., rel[2] * Plots.pct),
+    _relative_position(axis_limits(sp, :x)..., rel[1] * Plots.pct, sp[get_attr_symbol(:x, :axis)][:scale]),
+    _relative_position(axis_limits(sp, :y)..., rel[2] * Plots.pct, sp[get_attr_symbol(:y, :axis)][:scale]),
     label,
 )
 locate_annotation(sp::Subplot, rel::NTuple{3,<:Number}, label::PlotText) = (
-    _relative_position(axis_limits(sp, :x)..., rel[1] * Plots.pct),
-    _relative_position(axis_limits(sp, :y)..., rel[2] * Plots.pct),
-    _relative_position(axis_limits(sp, :z)..., rel[3] * Plots.pct),
+
+    _relative_position(axis_limits(sp, :x)..., rel[1] * Plots.pct, sp[get_attr_symbol(:x, :axis)][:scale]),
+    _relative_position(axis_limits(sp, :y)..., rel[2] * Plots.pct, sp[get_attr_symbol(:y, :axis)][:scale]),
+    _relative_position(axis_limits(sp, :z)..., rel[3] * Plots.pct, sp[get_attr_symbol(:z, :axis)][:scale]),
     label,
 )
 # -----------------------------------------------------------------------


### PR DESCRIPTION
This PR may close #4233

The relative (percentage) position of annotations is now independant from the following axis scales : 
* `ln`,`log`
* `log10`
* `log2`
* `identity (linear)`

Example :
```julia
using Plots

x_percentage = 0.25 # <--- write text into top-left quadrant
y_percentage = 0.5

plot(xaxis=:log10,xlim=(xmin,xmax))
annotate!((x_percentage,y_percentage),"Hi issue #4233")
```

As scales are defined in each backend (GR, PyPlot...), this PR should be revisited in the future if new are proposed