### PR TITLE
Allow 2d coordinates for heatmap plots in PyPlot backend

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -423,7 +423,7 @@ function expand_extrema!(axis::Axis, v::Tuple{MIN,MAX}) where {MIN<:Number,MAX<:
     ex.emax = isfinite(v[2]) ? max(v[2], ex.emax) : ex.emax
     ex
 end
-function expand_extrema!(axis::Axis, v::AVec{N}) where {N<:Number}
+function expand_extrema!(axis::Axis, v::Union{AVec{N},AMat{N}}) where {N<:Number}
     ex = axis[:extrema]
     for vi in v
         expand_extrema!(ex, vi)
@@ -515,6 +515,10 @@ function expand_extrema!(sp::Subplot, plotattributes::AKW)
     if plotattributes[:seriestype] === :heatmap
         for letter in (:x, :y)
             data = plotattributes[letter]
+            if typeof(data) <: Surface
+                # Was given 2d coordinates, need to extract from Surface struct
+                data = data.surf
+            end
             axis = sp[get_attr_symbol(letter, :axis)]
             scale = get(plotattributes, get_attr_symbol(letter, :scale), :identity)
             expand_extrema!(axis, heatmap_edges(data, scale))


### PR DESCRIPTION
Allows plotting on a non-rectangular grid, at least with PyPlot backend. For example:
```julia
using Plots
pyplot()

nx = 10
ny = 11

x = zeros(ny, nx)
y = zeros(ny, nx)

for i ∈ 1:nx, j ∈ 1:ny
    x[j,i] = i
    y[j,i] = 2.0 + j + i
end

z = randn(ny,nx)

heatmap(x,y,z)

savefig("test.png")
```
produces
![test](https://user-images.githubusercontent.com/3958036/182694686-42c1fc03-bfda-4f82-8d7d-b4fdd1abc728.png)

Currently 'Draft' because:
* [ ] `_heatmap_edges()` is fudged for 2d `x` and `y`. PyPlot can handle the cell-centre/cell-edge conversion automatically so the `_heatmap_edges()` functionality is not needed for the case I was trying to get working. It would be nicer to be more general, but the logic is a bit more complicated (I guess an extra argument would need to be passed to say which dimension needs to be converted from centres to edges?) - is it worth doing and does anyone have opinions/suggestions on the best way?
* [ ] I guess a test would be good? I would be very grateful for a pointer on where the test should go and if there is something similar I could copy to start from.
* [ ] What to do about other backends? I tried running the same test case with GR and got an error that seemed to happen due to `z` being transposed. I got lost trying to look for where a special-case for 2d `x` and `y` would be needed though... Should only backends where 2d `x` and `y` are known to work be supported? If so where would be a good place to throw an error for unsupported backends?

Maybe an expert can see a better way to implement this and would find it easier to start from scratch, in which case please consider this just a feature request!