### PR TITLE
Make `savefig` filepath-type agnostic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -70,6 +70,7 @@ julia = "1.6"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 Gaston = "4b11ee91-296f-5714-9832-002c20994614"
 Gtk = "4c0ca9eb-093a-5379-98c5-f87ac0bbbf44"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
@@ -92,4 +93,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 
 [targets]
-test = ["Colors", "Distributions", "FileIO", "Gaston", "Gtk", "ImageMagick", "Images", "InspectDR", "LibGit2", "OffsetArrays", "PGFPlotsX", "PlotlyJS", "PlotlyBase", "PyPlot", "HDF5", "RDatasets", "StableRNGs", "StaticArrays", "StatsPlots", "Test", "TestImages", "UnicodePlots", "VisualRegressionTests"]
+test = ["Colors", "Distributions", "FilePathsBase", "FileIO", "Gaston", "Gtk", "ImageMagick", "Images", "InspectDR", "LibGit2", "OffsetArrays", "PGFPlotsX", "PlotlyJS", "PlotlyBase", "PyPlot", "HDF5", "RDatasets", "StableRNGs", "StaticArrays", "StatsPlots", "Test", "TestImages", "UnicodePlots", "VisualRegressionTests"]

--- a/src/output.jl
+++ b/src/output.jl
@@ -112,11 +112,10 @@ const _extension_map = Dict("tikz" => "tex")
 Change filepath extension according to the extension map
 """
 function addExtension(fp, ext::AbstractString)
-    parent = dirname(fp)
-    fn = basename(fp)
-    oldfn, oldext = splitext(fn)
+    dn, fn = splitdir(fp)
+    _, oldext = splitext(fn)
     oldext = chop(oldext, head = 1, tail = 0)
-    get(_extension_map, oldext, oldext) == ext ? fp : joinpath(parent, string(fn, ".", ext))
+    get(_extension_map, oldext, oldext) == ext ? fp : joinpath(dn, string(fn, ".", ext))
 end
 
 """
@@ -126,7 +125,7 @@ Save a Plot (the current plot if `plot` is not passed) to file. The file
 type is inferred from the file extension. All backends support png and pdf
 file types, some also support svg, ps, eps, html and tex.
 """
-function savefig(plt::Plot, fn)
+function savefig(plt::Plot, fn) # fn might be an `AbstractString` or an `AbstractPath` from `FilePaths.jl`
     fn = abspath(expanduser(fn))
 
     # get the extension

--- a/src/output.jl
+++ b/src/output.jl
@@ -1,83 +1,83 @@
 
 defaultOutputFormat(plt::Plot) = "png"
 
-png(plt::Plot, fn::AbstractString) =
+png(plt::Plot, fn) =
     open(addExtension(fn, "png"), "w") do io
         show(io, MIME("image/png"), plt)
     end
-png(fn::AbstractString) = png(current(), fn)
+png(fn) = png(current(), fn)
 
 png(plt::Plot, io::IO) = show(io, MIME("image/png"), plt)
 png(io::IO) = png(current(), io)
 
-svg(plt::Plot, fn::AbstractString) =
+svg(plt::Plot, fn) =
     open(addExtension(fn, "svg"), "w") do io
         show(io, MIME("image/svg+xml"), plt)
     end
-svg(fn::AbstractString) = svg(current(), fn)
+svg(fn) = svg(current(), fn)
 
 svg(plt::Plot, io::IO) = show(io, MIME("image/svg+xml"), plt)
 svg(io::IO) = svg(current(), io)
 
-pdf(plt::Plot, fn::AbstractString) =
+pdf(plt::Plot, fn) =
     open(addExtension(fn, "pdf"), "w") do io
         show(io, MIME("application/pdf"), plt)
     end
-pdf(fn::AbstractString) = pdf(current(), fn)
+pdf(fn) = pdf(current(), fn)
 
 pdf(plt::Plot, io::IO) = show(io, MIME("application/pdf"), plt)
 pdf(io::IO) = pdf(current(), io)
 
-ps(plt::Plot, fn::AbstractString) =
+ps(plt::Plot, fn) =
     open(addExtension(fn, "ps"), "w") do io
         show(io, MIME("application/postscript"), plt)
     end
-ps(fn::AbstractString) = ps(current(), fn)
+ps(fn) = ps(current(), fn)
 
 ps(plt::Plot, io::IO) = show(io, MIME("application/postscript"), plt)
 ps(io::IO) = ps(current(), io)
 
-eps(plt::Plot, fn::AbstractString) =
+eps(plt::Plot, fn) =
     open(addExtension(fn, "eps"), "w") do io
         show(io, MIME("image/eps"), plt)
     end
-eps(fn::AbstractString) = eps(current(), fn)
+eps(fn) = eps(current(), fn)
 
 eps(plt::Plot, io::IO) = show(io, MIME("image/eps"), plt)
 eps(io::IO) = eps(current(), io)
 
-tex(plt::Plot, fn::AbstractString) =
+tex(plt::Plot, fn) =
     open(addExtension(fn, "tex"), "w") do io
         show(io, MIME("application/x-tex"), plt)
     end
-tex(fn::AbstractString) = tex(current(), fn)
+tex(fn) = tex(current(), fn)
 
 tex(plt::Plot, io::IO) = show(io, MIME("application/x-tex"), plt)
 tex(io::IO) = tex(current(), io)
 
-json(plt::Plot, fn::AbstractString) =
+json(plt::Plot, fn) =
     open(addExtension(fn, "json"), "w") do io
         show(io, MIME("application/vnd.plotly.v1+json"), plt)
     end
-json(fn::AbstractString) = json(current(), fn)
+json(fn) = json(current(), fn)
 
 json(plt::Plot, io::IO) = show(io, MIME("application/vnd.plotly.v1+json"), plt)
 json(io::IO) = json(current(), io)
 
-html(plt::Plot, fn::AbstractString) =
+html(plt::Plot, fn) =
     open(addExtension(fn, "html"), "w") do io
         show(io, MIME("text/html"), plt)
     end
-html(fn::AbstractString) = html(current(), fn)
+html(fn) = html(current(), fn)
 
 html(plt::Plot, io::IO) = show(io, MIME("text/html"), plt)
 html(io::IO) = html(current(), io)
 
-txt(plt::Plot, fn::AbstractString; color::Bool = true) =
+txt(plt::Plot, fn; color::Bool = true) =
     open(addExtension(fn, "txt"), "w") do io
         show(IOContext(io, :color => color), MIME("text/plain"), plt)
     end
-txt(fn::AbstractString) = txt(current(), fn)
+txt(fn) = txt(current(), fn)
 
 txt(plt::Plot, io::IO) = show(io, MIME("text/plain"), plt)
 txt(io::IO) = txt(current(), io)
@@ -106,10 +106,17 @@ end
 
 const _extension_map = Dict("tikz" => "tex")
 
-function addExtension(fn::AbstractString, ext::AbstractString)
+"""
+    addExtension(filepath, extension)
+
+Change filepath extension according to the extension map
+"""
+function addExtension(fp, ext::AbstractString)
+    parent = dirname(fp)
+    fn = basename(fp)
     oldfn, oldext = splitext(fn)
     oldext = chop(oldext, head = 1, tail = 0)
-    get(_extension_map, oldext, oldext) == ext ? fn : string(fn, ".", ext)
+    get(_extension_map, oldext, oldext) == ext ? fp : joinpath(parent, string(fn, ".", ext))
 end
 
 """
@@ -119,7 +126,7 @@ Save a Plot (the current plot if `plot` is not passed) to file. The file
 type is inferred from the file extension. All backends support png and pdf
 file types, some also support svg, ps, eps, html and tex.
 """
-function savefig(plt::Plot, fn::AbstractString)
+function savefig(plt::Plot, fn)
     fn = abspath(expanduser(fn))
 
     # get the extension
@@ -135,7 +142,7 @@ function savefig(plt::Plot, fn::AbstractString)
         error("Invalid file extension: ", fn)
     end
 end
-savefig(fn::AbstractString) = savefig(current(), fn)
+savefig(fn) = savefig(current(), fn)
 
 # ---------------------------------------------------------
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using LaTeXStrings
 using RecipesBase
 using TestImages
 using FileIO
+using FilePathsBase
 using Plots
 using Dates
 using Test

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -1,8 +1,10 @@
 macro test_save(fmt)
     quote
-        let pl = plot(1:10), fn = tmpname() # fn is an AbstractPath from FilePathsBase.jl
+        let pl = plot(1:10), fn = tempname(), fp = tmpname() # fp is an AbstractPath from FilePathsBase.jl
             getfield(Plots, $fmt)(pl, fn)
             getfield(Plots, $fmt)(fn)
+            getfield(Plots, $fmt)(fp)
+            # ...
             fn_ext = string(fn, '.', $fmt)
             savefig(pl, fn_ext)
             savefig(fn_ext)

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -17,7 +17,6 @@ macro test_save(fmt)
             @test isfile(fn_ext)
             @test isfile(fp_ext)
 
-
             @test_throws ErrorException savefig(string(fn, ".foo"))
             @test_throws ErrorException savefig(string(fp, ".foo"))
         end

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -4,12 +4,22 @@ macro test_save(fmt)
             getfield(Plots, $fmt)(pl, fn)
             getfield(Plots, $fmt)(fn)
             getfield(Plots, $fmt)(fp)
-            # ...
+
             fn_ext = string(fn, '.', $fmt)
-            savefig(pl, fn_ext)
+            fp_ext = string(fp, '.', $fmt)
+
             savefig(fn_ext)
+            savefig(fp_ext)
+
+            savefig(pl, fn_ext)
+            savefig(pl, fp_ext)
+
             @test isfile(fn_ext)
+            @test isfile(fp_ext)
+
+
             @test_throws ErrorException savefig(string(fn, ".foo"))
+            @test_throws ErrorException savefig(string(fp, ".foo"))
         end
 
         let pl = plot(1:10), io = PipeBuffer()

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -1,6 +1,6 @@
 macro test_save(fmt)
     quote
-        let pl = plot(1:10), fn = tempname()
+        let pl = plot(1:10), fn = tmpname() # fn is an AbstractPath from FilePathsBase.jl
             getfield(Plots, $fmt)(pl, fn)
             getfield(Plots, $fmt)(fn)
             fn_ext = string(fn, '.', $fmt)


### PR DESCRIPTION
~~This PR may close this issue :~~ Fix #4279 .

I changed the save functions (html, png, pdf ...) and `savefig` in `output.jl` so that the filepath is type agnostic.
The `addExtension` has been changed too according to #4279.

```julia
function addExtension(fp, ext::AbstractString)
     parent = dirname(fp)
     fn = basename(fp)
     oldfn, oldext = splitext(fn) 
     oldext = chop(oldext, head = 1, tail = 0) 
     get(_extension_map, oldext, oldext) == ext ? fp : joinpath(parent, string(fn, ".", ext)) 
 end 

```
Output tests are passing ✅ 

---

Example :
```julia
using Plots
using FilePathsBase

fn = p"C:/Users/someone/image.png" # WindowsPath type

x = 0:0.1:2pi
y = sin.(x).
p = plot(x,y)

# Writing directly plot output in fn
open(fn, "w") do io
    show(io, MIME("image/png"), p)
end


savefig(fn) # Same result despite the fact that filepath is not of type AbstractString
```