### PR TITLE
Fix `apng` extension versatility

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -22,7 +22,7 @@ giffn() = (isijulia() ? "tmp.gif" : tempname() * ".gif")
 movfn() = (isijulia() ? "tmp.mov" : tempname() * ".mov")
 mp4fn() = (isijulia() ? "tmp.mp4" : tempname() * ".mp4")
 webmfn() = (isijulia() ? "tmp.webm" : tempname() * ".webm")
-apngfn() = (isijulia() ? "tmp.apng" : tempname() * ".apng")
+apngfn() = (isijulia() ? "tmp.png" : tempname() * ".png")
 
 mutable struct FrameIterator
     itr
@@ -123,7 +123,7 @@ function buildanimation(
                 `-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -i "$(animdir)/palette.bmp" -lavfi "paletteuse=dither=sierra2_4a" -loop $loop -y $fn`,
             )
         end
-    elseif file_extension(fn) == "apng"
+    elseif file_extension(fn) == "png"
         # FFMPEG specific command for APNG (Animated PNG) animations
         ffmpeg_exe(
             `-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -plays $loop -f apng  -y $fn`,

--- a/src/animation.jl
+++ b/src/animation.jl
@@ -123,7 +123,7 @@ function buildanimation(
                 `-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -i "$(animdir)/palette.bmp" -lavfi "paletteuse=dither=sierra2_4a" -loop $loop -y $fn`,
             )
         end
-    elseif file_extension(fn) == "png"
+    elseif file_extension(fn) in ["png", "apng"]
         # FFMPEG specific command for APNG (Animated PNG) animations
         ffmpeg_exe(
             `-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -plays $loop -f apng  -y $fn`,

--- a/src/animation.jl
+++ b/src/animation.jl
@@ -123,7 +123,7 @@ function buildanimation(
                 `-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -i "$(animdir)/palette.bmp" -lavfi "paletteuse=dither=sierra2_4a" -loop $loop -y $fn`,
             )
         end
-    elseif file_extension(fn) in ["png", "apng"]
+    elseif file_extension(fn) in ("png", "apng")
         # FFMPEG specific command for APNG (Animated PNG) animations
         ffmpeg_exe(
             `-v $verbose_level -framerate $framerate -i $(animdir)/%06d.png -plays $loop -f apng  -y $fn`,


### PR DESCRIPTION
Fix #4316 

We decided to use `png` extension for APNG files but i forgot to update these extension changes in the code during the last iteration before the pull request of the new feature. (ref #4295, #4293)

* **It is corrected now and tests are passing ✅**
* The code now outputs `.png` files by default and `.apng` if precised in the filename

We did not see this during tests because they dont check for file extensions.


## Example

```julia
using Plots

x = 1:0.1:30
y = sin.(x)
df = 2

anim = Plots.@animate for i = 1:df:length(x)
    plot(x[1:i], y[1:i], legend=false)
end

Plots.apng(anim, "tutorial_anim_fps30.png", fps = 30) # previously an error, now outputs a .png file

Plots.apng(anim, "tutorial_anim_fps30.apng", fps = 30) # previously correct, outputs a .apng file

Plots.apng(anim, fps = 30) # outputs a .png file when no filename is passed as argument
```
