### PR TITLE
Truncate markersize in legends to not hide linestyle

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1096,10 +1096,11 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                 if st in (:path, :straightline, :path3d)
                     gr_set_transparency(lc, get_linealpha(series))
                     # This is to prevent that linestyle is obscured by large markers. 
-                    # We are trying to get markers to not be larger than half the line width. 
-                    # 1 / leg.dy translates width_factor to width units (important in the context of size kwarg)
+                    # We are trying to get markers to not be larger than half the line length. 
+                    # 1 / leg.dy translates width_factor to line length units (important in the context of size kwarg)
                     # 4 is an empirical constant to translate between line length unit and marker size unit
-                    maxmarkersize = (leg.width_factor * 3.5 - leg.width_factor / 2) * 0.5 / leg.dy * 4
+                    maxmarkersize =
+                        (leg.width_factor * 3.5 - leg.width_factor / 2) * 0.5 / leg.dy * 4
                     if series[:fillrange] === nothing || series[:ribbon] !== nothing
                         GR.polyline(
                             [xpos - leg.width_factor * 3.5, xpos - leg.width_factor / 2],
@@ -1116,12 +1117,16 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                 if series[:markershape] !== :none
                     ms = first(series[:markersize])
                     msw = first(series[:markerstrokewidth])
-                    s, sw = min.(maxmarkersize, if ms > 0
-                        0.8 * sp[:legend_font_pointsize],
-                        0.8 * sp[:legend_font_pointsize] * msw / ms
-                    else
-                        0, 0.8 * sp[:legend_font_pointsize] * msw / 8
-                    end)
+                    s, sw =
+                        min.(
+                            maxmarkersize,
+                            if ms > 0
+                                0.8 * sp[:legend_font_pointsize],
+                                0.8 * sp[:legend_font_pointsize] * msw / ms
+                            else
+                                0, 0.8 * sp[:legend_font_pointsize] * msw / 8
+                            end,
+                        )
                     gr_draw_markers(series, xpos - leg.width_factor * 2, ypos, clims, s, sw)
                 end
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1092,8 +1092,14 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                     st === :shape && gr_polyline(x, y)
                 end
 
+                maxmarkersize = Inf
                 if st in (:path, :straightline, :path3d)
                     gr_set_transparency(lc, get_linealpha(series))
+                    # This is to prevent that linestyle is obscured by large markers. 
+                    # We are trying to get markers to not be larger than half the line width. 
+                    # 1 / leg.dy translates width_factor to width units (important in the context of size kwarg)
+                    # 4 is an empirical constant to translate between line length unit and marker size unit
+                    maxmarkersize = (leg.width_factor * 3.5 - leg.width_factor / 2) * 0.5 / leg.dy * 4
                     if series[:fillrange] === nothing || series[:ribbon] !== nothing
                         GR.polyline(
                             [xpos - leg.width_factor * 3.5, xpos - leg.width_factor / 2],
@@ -1110,12 +1116,12 @@ function gr_add_legend(sp, leg, viewport_plotarea)
                 if series[:markershape] !== :none
                     ms = first(series[:markersize])
                     msw = first(series[:markerstrokewidth])
-                    s, sw = if ms > 0
+                    s, sw = min.(maxmarkersize, if ms > 0
                         0.8 * sp[:legend_font_pointsize],
                         0.8 * sp[:legend_font_pointsize] * msw / ms
                     else
                         0, 0.8 * sp[:legend_font_pointsize] * msw / 8
-                    end
+                    end)
                     gr_draw_markers(series, xpos - leg.width_factor * 2, ypos, clims, s, sw)
                 end
 


### PR DESCRIPTION
Fixes #4312

Basic idea is to limit the marker size in legends to approximately half the length of the line in the legend. I'm not sure I managed to do this in a clean way but the rationale is described in a comment.

I have only done this for the GR backend, but should this approach turn out to be acceptable I can verify and implement for the other backends (where needed).

If there is no line then there is also no limit to the markersize.

I think the limitations/drawbacks of this approach are quite well summarized by the visual regressiontest nr 48:
![PlotsMarkerSizePrRef48](https://user-images.githubusercontent.com/36208552/185791882-f8c3a3b0-2a40-4751-b46e-8a79deeb235a.PNG)

Firstly (and this is ofc easy to fix) there is some inconsistency between marker only and marker + line. 

My thinking was that users might want to convey information with marker sizes and then the truncation might destroy that information. Conveying information with both markersize and linestyle however is not something I would expect anyone to do so then truncation should be ok.

An option to trunction is just to scale everything, but then I guess one must first look through the series and find the largest markersize. Users might still get annoyed that their markers are shrinked in the legend though... 

Secondly, when there are four columns the legend tend to be so small that neither linestyles nor markers are very readable. 

Perhaps one should just leave more room for the lines and markers?

Here is the testcode I used to manually verify whether this is an improvment:
```julia
function legsweep(labsuffix="")
    for m in [:none, :circle, :rect, :star5, :diamond, :hexagon, :cross, :xcross, :utriangle, :dtriangle, :rtriangle, :ltriangle, :pentagon, :heptagon, :octagon, :star4, :star6, :star7, :star8, :vline, :hline, :+, :x]
        linestyles = [:solid ;; :dash ;; :dot ;; :dashdot ;; :dashdot ;; :dashdotdot]
        p = plot(map(k -> fill(k, 10), eachindex(linestyles)); c=:blue, linestyle=linestyles, marker=m, label=string.(linestyles).* labsuffix, title=m)
        display(p)
        display(plot(p,p))   
        display(plot(p,p; size=(1200, 400)))
        display(plot(p,p,p,p; layout=(1, 4)))
        display(plot(p,p,p,p; layout=(1, 4), size=(2400, 400)))
    end
end
```
