### PR TITLE
revert `benchmark` changes

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,9 +2,9 @@ using BenchmarkTools
 using Plots
 
 const SUITE = BenchmarkGroup()
-julia_cmd = split(get(ENV, "TESTCMD", unsafe_string(Base.JLOptions().julia_bin)))
+julia_cmd = split(get(ENV, "TESTCMD", Base.JLOptions().julia_bin))
 
-SUITE["load_plot_display"] = @benchmarkable run(`$julia_cmd --startup-file=no --project=$(Base.active_project()) -e 'using Plots; display(plot(1:0.1:10, sin.(1:0.1:10)))'`)
-SUITE["load"] = @benchmarkable run(`$julia_cmd --startup-file=no --project=$(Base.active_project()) -e 'using Plots'`)
+SUITE["load_plot_display"] = @benchmarkable run(`$julia_cmd --startup-file=no --project -e 'using Plots; display(plot(1:0.1:10, sin.(1:0.1:10)))'`)
+SUITE["load"] = @benchmarkable run(`$julia_cmd --startup-file=no --project -e 'using Plots'`)
 SUITE["plot"] = @benchmarkable p = plot(1:0.1:10, sin.(1:0.1:10)) samples=1 evals=1
 SUITE["display"] = @benchmarkable display(p) setup=(p = plot(1:0.1:10, sin.(1:0.1:10))) samples=1 evals=1


### PR DESCRIPTION
Not intended to get merged, but since https://github.com/JuliaPlots/Plots.jl/commit/c8f4ff33079d3f1ccb5f17e5409c73a277d99d9a was merged without CI check I need to be certain that this commit was not involved in CI break.

Dependencies diff between working and failing ci:

```diff
--- deps_a	2022-09-01 18:27:55.669085748 +0200
+++ deps_b	2022-09-01 18:28:20.717800624 +0200
@@ -28,7 +28,7 @@
   [3da002f7] + ColorTypes v0.11.4
   [c3611d14] + ColorVectorSpace v0.9.9
   [5ae59095] + Colors v0.12.8
-  [34da2185] + Compat v4.1.0
+  [34da2185] + Compat v4.2.0
   [d38c429a] + Contour v0.6.2
   [9a962f9c] + DataAPI v1.10.0
   [864edb3b] + DataStructures v0.18.13
@@ -42,7 +42,7 @@
   [cf35fbd7] + GeoInterface v1.0.1
   [5c1252a2] + GeometryBasics v0.4.3
   [42e2da0e] + Grisu v1.0.2
-  [cd3eb016] + HTTP v1.2.1
+  [cd3eb016] + HTTP v1.3.0
   [83e8ac13] + IniFile v0.5.1
   [3587e190] + InverseFunctions v0.1.7
   [92d709cd] + IrrationalConstants v0.1.1
@@ -52,7 +52,7 @@
   [682c06a0] + JSON v0.21.3
   [b964fa9f] + LaTeXStrings v1.3.0
   [23fbe1c1] + Latexify v0.15.16
-  [2ab3a3ac] + LogExpFunctions v0.3.17
+  [2ab3a3ac] + LogExpFunctions v0.3.18
   [e6f89c97] + LoggingExtras v0.4.9
   [1914dd2f] + MacroTools v0.5.9
   [739be429] + MbedTLS v1.1.3
@@ -74,15 +74,15 @@
   [777ac1f9] + SimpleBufferStream v1.1.0
   [a2af1166] + SortingAlgorithms v1.0.1
   [276daf66] + SpecialFunctions v2.1.7
-  [90137ffa] + StaticArrays v1.5.5
-  [1e83bf80] + StaticArraysCore v1.1.0
+  [90137ffa] + StaticArrays v1.5.6
+  [1e83bf80] + StaticArraysCore v1.3.0
   [82ae8749] + StatsAPI v1.5.0
   [2913bbd2] + StatsBase v0.33.21
   [09ab397b] + StructArrays v0.6.12
   [3783bdb8] + TableTraits v1.0.1
   [bd369af6] + Tables v1.7.0
   [62fd8b95] + TensorCore v0.1.1
-  [3bb67fe8] + TranscodingStreams v0.9.7
+  [3bb67fe8] + TranscodingStreams v0.9.8
   [5c2747f8] + URIs v1.4.0
   [1cfade01] + UnicodeFun v0.4.1
   [41fe7b60] + Unzip v0.1.2
```

It seems `Compat` is involved.