### PR TITLE
Scaling axis limits by manual factor

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -186,8 +186,11 @@ const _arg_desc = KW(
     :tick_direction              => "Symbol.  Direction of the ticks. `:in`, `:out` or `:none`",
     :showaxis                    => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`",
     :widen                       => """
-                                    Bool or :auto. Widen the axis limits by a small factor to avoid cut-off markers and lines at the borders.
-                                    Defaults to `:auto`, which widens unless limits were manually set.
+                                    Bool, Number or :auto. Widen the axis limits by a small factor to avoid cut-off markers and lines at the borders.
+                                    If set to `true`, scale the axis limits by the default factor of 1.06. 
+                                    A different factor may be specified by setting `widen` to a number.
+                                    Defaults to `:auto`, which widens by the default factor unless limits were manually set.
+                                    See also the `scale_limits!` function for scaling axis limits in an existing plot.
                                     """,
     :draw_arrow                  => "Bool. Draw arrow at the end of the axis.",
 )

--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -187,7 +187,7 @@ const _arg_desc = KW(
     :showaxis                    => "Bool, Symbol or String.  Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`",
     :widen                       => """
                                     Bool, Number or :auto. Widen the axis limits by a small factor to avoid cut-off markers and lines at the borders.
-                                    If set to `true`, scale the axis limits by the default factor of 1.06. 
+                                    If set to `true`, scale the axis limits by the default factor of $(default_widen_factor). 
                                     A different factor may be specified by setting `widen` to a number.
                                     Defaults to `:auto`, which widens by the default factor unless limits were manually set.
                                     See also the `scale_limits!` function for scaling axis limits in an existing plot.

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -592,9 +592,9 @@ const _widen_seriestypes = (
 const default_widen_factor = 1.06
 
 # facor to widen axis limits by, or `nothing` if axis widening should be skipped
-function widen_factor(axis::Axis)
+function widen_factor(axis::Axis; factor = default_widen_factor)
     widen = axis[:widen]
-    widen isa Bool   && return widen ? default_widen_factor : nothing
+    widen isa Bool   && return widen ? factor : nothing
     widen isa Number && return widen
     widen == :auto   || @warn "Invalid value specified for `widen`: $widen"
 
@@ -604,7 +604,7 @@ function widen_factor(axis::Axis)
     for sp in axis.sps
         for series in series_list(sp)
             if series.plotattributes[:seriestype] in _widen_seriestypes
-                return default_widen_factor
+                return factor
             end
         end
     end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -594,9 +594,9 @@ const default_widen_factor = 1.06
 # facor to widen axis limits by, or `nothing` if axis widening should be skipped
 function widen_factor(axis::Axis; factor = default_widen_factor)
     widen = axis[:widen]
-    widen isa Bool   && return widen ? factor : nothing
+    widen isa Bool && return widen ? factor : nothing
     widen isa Number && return widen
-    widen == :auto   || @warn "Invalid value specified for `widen`: $widen"
+    widen == :auto || @warn "Invalid value specified for `widen`: $widen"
 
     # automatic behavior: widen if limits aren't specified and series type is appropriate
     lims = process_limits(axis[:lims])

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -527,14 +527,43 @@ end
 
 # -------------------------------------------------------------------------
 
-# push the limits out slightly
-function widen(lmin, lmax, scale = :identity)
-    f, invf = RecipesPipeline.scale_func(scale), RecipesPipeline.inverse_scale_func(scale)
-    span = f(lmax) - f(lmin)
-    # eps = NaNMath.max(1e-16, min(1e-2span, 1e-10))
-    eps = NaNMath.max(1e-16, 0.03span)
-    invf(f(lmin) - eps), invf(f(lmax) + eps)
+function scale_lims(from, to, factor)
+    mid, span = (from + to) / 2, (to - from) / 2
+    mid .+ (-span, span) .* factor
 end
+
+function scale_lims(from, to, factor, scale)
+    f, invf = RecipesPipeline.scale_func(scale), RecipesPipeline.inverse_scale_func(scale)
+    invf.(scale_lims(f(from), f(to), factor))
+end
+
+"""
+    scale_lims!([plt], [letter], factor)
+
+Scale the limits of the axis specified by `letter` (one of `:x`, `:y`, `:z`) by the
+given `factor` around the limits' middle point. 
+If `letter` is omitted, all axes are affected.
+"""
+function scale_lims!(sp::Subplot, letter, factor)
+    axis = Plots.get_axis(sp, letter)
+    scale = axis[:scale]
+    from, to = Plots.get_sp_lims(sp, letter)
+    axis[:lims] = scale_lims(from, to, factor, scale)
+end
+function scale_lims!(plt::Plot, letter, factor)
+    for subplot in plt.subplots
+        scale_lims!(subplot, letter, factor)
+    end
+    plt
+end
+scale_lims!(letter::Symbol, factor) = scale_lims!(current(), letter, factor)
+function scale_lims!(plt::Union{Plot,Subplot}, factor)
+    for letter in (:x, :y, :z)
+        scale_lims!(plt, letter, factor)
+    end
+    plt
+end
+scale_lims!(factor::Number) = scale_lims!(current(), factor)
 
 # figure out if widening is a good idea.
 const _widen_seriestypes = (
@@ -560,21 +589,26 @@ const _widen_seriestypes = (
     :scatter3d,
 )
 
-function default_should_widen(axis::Axis)
-    if axis[:widen] isa Bool
-        return axis[:widen]
-    end
+const default_widen_factor = 1.06
+
+# facor to widen axis limits by, or `nothing` if axis widening should be skipped
+function widen_factor(axis::Axis)
+    widen = axis[:widen]
+    widen isa Bool   && return widen ? default_widen_factor : nothing
+    widen isa Number && return widen
+    widen == :auto   || @warn "Invalid value specified for `widen`: $widen"
+
     # automatic behavior: widen if limits aren't specified and series type is appropriate
     lims = process_limits(axis[:lims])
-    (lims isa Tuple || lims == :round) && return false
+    (lims isa Tuple || lims == :round) && return nothing
     for sp in axis.sps
         for series in series_list(sp)
             if series.plotattributes[:seriestype] in _widen_seriestypes
-                return true
+                return default_widen_factor
             end
         end
     end
-    false
+    nothing
 end
 
 function round_limits(amin, amax, scale)
@@ -600,10 +634,10 @@ warn_invalid_limits(lims, letter) = @warn """
 function axis_limits(
     sp,
     letter,
-    should_widen = default_should_widen(sp[get_attr_symbol(letter, :axis)]),
+    lims_factor = widen_factor(get_axis(sp, letter)),
     consider_aspect = true,
 )
-    axis = sp[get_attr_symbol(letter, :axis)]
+    axis = get_axis(sp, letter)
     ex = axis[:extrema]
     amin, amax = ex.emin, ex.emax
     lims = process_limits(axis[:lims])
@@ -640,8 +674,8 @@ function axis_limits(
         else
             amin, amax
         end
-    elseif should_widen
-        widen(amin, amax, axis[:scale])
+    elseif lims_factor !== nothing
+        scale_lims(amin, amax, lims_factor, axis[:scale])
     elseif lims === :round
         round_limits(amin, amax, axis[:scale])
     else
@@ -659,12 +693,12 @@ function axis_limits(
         dist = amax - amin
 
         if letter === :x
-            yamin, yamax = axis_limits(sp, :y, default_should_widen(sp[:yaxis]), false)
+            yamin, yamax = axis_limits(sp, :y, widen_factor(sp[:yaxis]), false)
             ydist = yamax - yamin
             axis_ratio = aspect_ratio * ydist / dist
             factor = axis_ratio / plot_ratio
         else
-            xamin, xamax = axis_limits(sp, :x, default_should_widen(sp[:xaxis]), false)
+            xamin, xamax = axis_limits(sp, :x, widen_factor(sp[:xaxis]), false)
             xdist = xamax - xamin
             axis_ratio = aspect_ratio * dist / xdist
             factor = plot_ratio / axis_ratio

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -138,7 +138,7 @@ function _add_smooth_kw(kw_list::Vector{KW}, kw::AKW)
     end
 end
 
-RecipesPipeline.get_axis_limits(plt::Plot, letter) = axis_limits(plt[1], letter, false)
+RecipesPipeline.get_axis_limits(plt::Plot, letter) = axis_limits(plt[1], letter, nothing)
 
 ## Plot recipes
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -484,7 +484,7 @@ end
     end
 
     # widen limits out a bit
-    expand_extrema!(axis, widen(ignorenan_extrema(xseg.pts)...))
+    expand_extrema!(axis, scale_lims(ignorenan_extrema(xseg.pts)..., default_widen_factor))
 
     # switch back
     if !isvertical(plotattributes)
@@ -1568,8 +1568,10 @@ end
     yflip := true
     aspect_ratio := 1
     rs, cs, zs = Plots.findnz(z.surf)
-    xlims := widen(ignorenan_extrema(cs)..., get(plotattributes, :xscale, :identity))
-    ylims := widen(ignorenan_extrema(rs)..., get(plotattributes, :yscale, :identity))
+    xlims := ignorenan_extrema(cs)
+    ylims := ignorenan_extrema(rs)
+    widen --> true
+
     markershape --> :circle
     markersize --> 1
     markerstrokewidth := 0

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -45,11 +45,13 @@ end
 end
 
 @testset "Axis limits" begin
+    default_widen(from, to) = Plots.scale_lims(from, to, Plots.default_widen_factor)
+
     pl = plot(1:5, xlims = :symmetric, widen = false)
     @test Plots.xlims(pl) == (-5, 5)
 
     pl = plot(1:3)
-    @test Plots.xlims(pl) == Plots.widen(1, 3)
+    @test Plots.xlims(pl) == default_widen(1, 3)
 
     pl = plot([1.05, 2.0, 2.95], ylims = :round)
     @test Plots.ylims(pl) == (1, 3)
@@ -58,7 +60,7 @@ end
         pl = plot(x; xlims)
         @test Plots.xlims(pl) == (1, 5)
         pl = plot(x; xlims, widen = true)
-        @test Plots.xlims(pl) == Plots.widen(1, 5)
+        @test Plots.xlims(pl) == default_widen(1, 5)
     end
 
     pl = plot(1:5, lims = :symmetric, widen = false)
@@ -70,7 +72,7 @@ end
             @test_logs (:warn, r"Invalid limits for x axis") match_mode = :any Plots.xlims(
                 pl,
             )
-        @test plims == Plots.widen(1, 5)
+        @test plims == default_widen(1, 5)
     end
 end
 


### PR DESCRIPTION
Adds official API for specifying scaling factor in `widen`, or scaling axis limits in existing plots, which I've often found myself doing with various hacks.