### PR TITLE
1.34.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Plots"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 author = ["Tom Breloff (@tbreloff)"]
-version = "1.33.0"
+version = "1.34.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Needed for https://github.com/JuliaPlots/PlotDocs.jl/pull/302.

Bump minor regarding precompilation and `GR@0.68` changes.