### PR TITLE
fix single `:auto` in `xlims` or `ylims`

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -588,7 +588,7 @@ end
 process_limits(lims::Tuple{<:Union{Symbol,Real},<:Union{Symbol,Real}}) = lims
 process_limits(lims::Symbol) = lims
 process_limits(lims::AVec) =
-    length(lims) == 2 && all(x isa Real for x in lims) ? Tuple(lims) : nothing
+    length(lims) == 2 && all(map(x -> x isa Union{Symbol,Real}, lims)) ? Tuple(lims) : nothing
 process_limits(lims) = nothing
 
 warn_invalid_limits(lims, letter) = @warn """
@@ -611,17 +611,15 @@ function axis_limits(
     has_user_lims = lims isa Tuple
     if has_user_lims
         lmin, lmax = lims
-        if lmin === :auto
-        elseif lmax isa Symbol
-            @warn "Invalid min limit" lmin
-        elseif isfinite(lmin)
+        if lmin isa Number && isfinite(lmin)
             amin = lmin
+        else
+            lmin === :auto || @warn "Invalid min limit" lmin
         end
-        if lmax === :auto
-        elseif lmax isa Symbol
-            @warn "Invalid max limit" lmax
-        elseif isfinite(lmax)
+        if lmax isa Number && isfinite(lmax)
             amax = lmax
+        else
+            lmax === :auto || @warn "Invalid max $(letter)limit" lmax
         end
     end
     if lims === :symmetric

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -588,7 +588,8 @@ end
 process_limits(lims::Tuple{<:Union{Symbol,Real},<:Union{Symbol,Real}}) = lims
 process_limits(lims::Symbol) = lims
 process_limits(lims::AVec) =
-    length(lims) == 2 && all(map(x -> x isa Union{Symbol,Real}, lims)) ? Tuple(lims) : nothing
+    length(lims) == 2 && all(map(x -> x isa Union{Symbol,Real}, lims)) ? Tuple(lims) :
+    nothing
 process_limits(lims) = nothing
 
 warn_invalid_limits(lims, letter) = @warn """

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -585,7 +585,7 @@ function round_limits(amin, amax, scale)
     amin, amax
 end
 
-process_limits(lims::Tuple{<:Real,<:Real}) = lims
+process_limits(lims::Tuple{<:Union{Symbol,Real},<:Union{Symbol,Real}}) = lims
 process_limits(lims::Symbol) = lims
 process_limits(lims::AVec) =
     length(lims) == 2 && all(x isa Real for x in lims) ? Tuple(lims) : nothing
@@ -612,10 +612,14 @@ function axis_limits(
     if has_user_lims
         lmin, lmax = lims
         if lmin === :auto
+        elseif lmax isa Symbol
+            @warn "Invalid min limit" lmin
         elseif isfinite(lmin)
             amin = lmin
         end
         if lmax === :auto
+        elseif lmax isa Symbol
+            @warn "Invalid max limit" lmax
         elseif isfinite(lmax)
             amax = lmax
         end

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -74,17 +74,23 @@ end
     end
 
     @testset "JuliaPlots/Plots.jl/issues/4379" begin
-        pl = plot([-2, 3], ylims = (-5, :auto), widen = false)
-        @test Plots.ylims(pl) == (-5, 3)
+        for ylims ∈ ((-5, :auto), [-5, :auto])
+            pl = plot([-2, 3], ylims = ylims, widen = false)
+            @test Plots.ylims(pl) == (-5.0, 3.0)
+        end
+        for ylims ∈ ((:auto, 4), [:auto, 4])
+            pl = plot([-2, 3], ylims = ylims, widen = false)
+            @test Plots.ylims(pl) == (-2.0, 4.0)
+        end
 
-        pl = plot([-2, 3], ylims = (:auto, 4), widen = false)
-        @test Plots.ylims(pl) == (-2, 4)
-
-        pl = plot([-2, 3], [-1, 1], xlims = (-3, :auto), widen = false)
-        @test Plots.xlims(pl) == (-3, 3)
-
-        pl = plot([-2, 3], [-1, 1], xlims = (:auto, 4), widen = false)
-        @test Plots.xlims(pl) == (-2, 4)
+        for xlims ∈ ((-3, :auto), [-3, :auto])
+            pl = plot([-2, 3], [-1, 1], xlims = xlims, widen = false)
+            @test Plots.xlims(pl) == (-3.0, 3.0)
+        end
+        for xlims ∈ ((:auto, 4), [:auto, 4])
+            pl = plot([-2, 3], [-1, 1], xlims = xlims, widen = false)
+            @test Plots.xlims(pl) == (-2.0, 4.0)
+        end
     end
 end
 

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -73,17 +73,19 @@ end
         @test plims == Plots.widen(1, 5)
     end
 
-    pl = plot([-2, 3], ylims = (-5, :auto), widen = false)
-    @test Plots.ylims(pl) == (-5, 3)
+    @testset "JuliaPlots/Plots.jl/issues/4379" begin
+        pl = plot([-2, 3], ylims = (-5, :auto), widen = false)
+        @test Plots.ylims(pl) == (-5, 3)
 
-    pl = plot([-2, 3], ylims = (:auto, 4), widen = false)
-    @test Plots.ylims(pl) == (-2, 4)
+        pl = plot([-2, 3], ylims = (:auto, 4), widen = false)
+        @test Plots.ylims(pl) == (-2, 4)
 
-    pl = plot([-2, 3], [-1, 1], xlims = (-3, :auto), widen = false)
-    @test Plots.xlims(pl) == (-3, 3)
+        pl = plot([-2, 3], [-1, 1], xlims = (-3, :auto), widen = false)
+        @test Plots.xlims(pl) == (-3, 3)
 
-    pl = plot([-2, 3], [-1, 1], xlims = (:auto, 4), widen = false)
-    @test Plots.xlims(pl) == (-2, 4)
+        pl = plot([-2, 3], [-1, 1], xlims = (:auto, 4), widen = false)
+        @test Plots.xlims(pl) == (-2, 4)
+    end
 end
 
 @testset "3D Axis" begin

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -74,20 +74,20 @@ end
     end
 
     @testset "JuliaPlots/Plots.jl/issues/4379" begin
-        for ylims ∈ ((-5, :auto), [-5, :auto])
+        for ylims in ((-5, :auto), [-5, :auto])
             pl = plot([-2, 3], ylims = ylims, widen = false)
             @test Plots.ylims(pl) == (-5.0, 3.0)
         end
-        for ylims ∈ ((:auto, 4), [:auto, 4])
+        for ylims in ((:auto, 4), [:auto, 4])
             pl = plot([-2, 3], ylims = ylims, widen = false)
             @test Plots.ylims(pl) == (-2.0, 4.0)
         end
 
-        for xlims ∈ ((-3, :auto), [-3, :auto])
+        for xlims in ((-3, :auto), [-3, :auto])
             pl = plot([-2, 3], [-1, 1], xlims = xlims, widen = false)
             @test Plots.xlims(pl) == (-3.0, 3.0)
         end
-        for xlims ∈ ((:auto, 4), [:auto, 4])
+        for xlims in ((:auto, 4), [:auto, 4])
             pl = plot([-2, 3], [-1, 1], xlims = xlims, widen = false)
             @test Plots.xlims(pl) == (-2.0, 4.0)
         end

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -72,6 +72,18 @@ end
             )
         @test plims == Plots.widen(1, 5)
     end
+
+    pl = plot([-2, 3], ylims = (-5, :auto), widen = false)
+    @test Plots.ylims(pl) == (-5, 3)
+
+    pl = plot([-2, 3], ylims = (:auto, 4), widen = false)
+    @test Plots.ylims(pl) == (-2, 4)
+
+    pl = plot([-2, 3], [-1, 1], xlims = (-3, :auto), widen = false)
+    @test Plots.xlims(pl) == (-3, 3)
+
+    pl = plot([-2, 3], [-1, 1], xlims = (:auto, 4), widen = false)
+    @test Plots.xlims(pl) == (-2, 4)
 end
 
 @testset "3D Axis" begin


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/4379.

```julia
julia> using Plots
julia> plot(rand(100), ylims=(0, :auto))

Invalid limits for y axis. Limits should be a symbol, or a two-element tuple or vector of numbers.
│ ylims = (0, :auto)
```