### PR TITLE
safer clone

### DIFF
--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -18,10 +18,18 @@ reference_path(backend, version) = reference_dir("Plots", string(backend), strin
 
 if !isdir(reference_dir())
     mkpath(reference_dir())
-    LibGit2.clone(
-        "https://github.com/JuliaPlots/PlotReferenceImages.jl.git",
-        reference_dir(),
-    )
+    for i ∈ 1:6
+        try
+            LibGit2.clone(
+                "https://github.com/JuliaPlots/PlotReferenceImages.jl.git",
+                reference_dir(),
+            )
+            break
+        catch err
+            @warn err
+            sleep(20i)
+        end
+    end
 end
 
 function reference_file(backend, i, version)

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -18,7 +18,7 @@ reference_path(backend, version) = reference_dir("Plots", string(backend), strin
 
 if !isdir(reference_dir())
     mkpath(reference_dir())
-    for i ∈ 1:6
+    for i in 1:6
         try
             LibGit2.clone(
                 "https://github.com/JuliaPlots/PlotReferenceImages.jl.git",


### PR DESCRIPTION
Nearly all CI failures on `MacOS` are related to spurious clone issues (no network access, e.g. https://github.com/JuliaPlots/Plots.jl/actions/runs/3129812922/jobs/5079349965).

Try to be more failsafe.