### PR TITLE
test 1.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         version:
           - '1.6' # LTS (minimal declared julia compat in `Project.toml`)
-          - '1.8' # latest stable
+          - '1.8.1' # latest stable
         os: [ubuntu-latest, windows-latest, macos-latest]
         arch:
           - x64


### PR DESCRIPTION
Dummy PR to test julia `1.8.1` ci, vs `1.8.2` in https://github.com/JuliaPlots/Plots.jl/pull/4403.