### PR TITLE
Faster extrema calculations for large series

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -416,7 +416,7 @@ expand_extrema!(axis::Axis, ::Nothing) = axis[:extrema]
 expand_extrema!(axis::Axis, ::Bool) = axis[:extrema]
 
 function expand_extrema!(axis::Axis, v::Tuple{MIN,MAX}) where {MIN<:Number,MAX<:Number}
-    ex = axis[:extrema]
+    ex = axis[:extrema]::Extrema
     ex.emin = isfinite(v[1]) ? min(v[1], ex.emin) : ex.emin
     ex.emax = isfinite(v[2]) ? max(v[2], ex.emax) : ex.emax
     ex

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -422,7 +422,7 @@ function expand_extrema!(axis::Axis, v::Tuple{MIN,MAX}) where {MIN<:Number,MAX<:
     ex
 end
 function expand_extrema!(axis::Axis, v::AVec{N}) where {N<:Number}
-    ex = axis[:extrema]
+    ex = axis[:extrema]::Extrema
     for vi in v
         expand_extrema!(ex, vi)
     end

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -425,6 +425,7 @@ function _expand_subplot_extrema(sp::Subplot, plotattributes::AKW, st::Symbol)
         expand_extrema!(sp[:xaxis], 0.0)
         expand_extrema!(sp[:yaxis], 0.0)
     end
+    return nothing
 end
 
 function _add_the_series(plt, sp, plotattributes)


### PR DESCRIPTION
Due to type instability, the `expand_extrema` methods were very slow. Adding a type assert fixes that and greatly improves the performance of plotting large series.

Test example:
```
const x6 = rand(1000000, 10) # several large series
plot(x6);
```

Before: `1.004 s (19999416 allocations: 457.95 MiB)`

After: `209.896 ms (4526 allocations: 152.85 MiB)`

(Numbers both include the effect of an unmerged RecipesPipeline PR, but the impact is the same)