### PR TITLE
Unitful ticks and lims

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -138,6 +138,7 @@
         {
             "affiliation": "Lund University",
             "name": "David Gustavsson",
+            "orcid": "0000-0002-0195-475X",
             "type": "Other"
         },
         {

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Plots"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 author = ["Tom Breloff (@tbreloff)"]
-version = "1.35.0"
+version = "1.35.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Plots"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 author = ["Tom Breloff (@tbreloff)"]
-version = "1.35.1"
+version = "1.35.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -335,7 +335,8 @@ get_ticks(ticks::Bool, args...) =
 get_ticks(::T, args...) where {T} = error("Unknown ticks type in get_ticks: $T")
 
 _transform_ticks(ticks, axis) = ticks
-_transform_ticks(ticks::AbstractArray{T}, axis) where {T<:Dates.TimeType} = Dates.value.(ticks)
+_transform_ticks(ticks::AbstractArray{T}, axis) where {T<:Dates.TimeType} =
+    Dates.value.(ticks)
 _transform_ticks(ticks::NTuple{2,Any}, axis) = (_transform_ticks(ticks[1], axis), ticks[2])
 
 function get_minor_ticks(sp, axis, ticks)

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -105,7 +105,7 @@ hascolorbar(sp::Subplot) =
 
 function get_colorbar_ticks(sp::Subplot; update = true, formatter = sp[:colorbar_formatter])
     if update || !haskey(sp.attr, :colorbar_optimized_ticks)
-        ticks = _transform_ticks(sp[:colorbar_ticks])
+        ticks = _transform_ticks(sp[:colorbar_ticks], sp[:colorbar_title])
         cvals = sp[:colorbar_continuous_values]
         dvals = sp[:colorbar_discrete_values]
         clims = get_clims(sp)

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -7,7 +7,8 @@ using ..Unitful: Quantity, unit, ustrip, Unitful, dimension, Units, NoUnits
 using ..RecipesBase
 export @P_str
 
-import ..locate_annotation, ..PlotText, ..Subplot, ..AVec, ..AMat, ..Axis, .._transform_ticks, ..process_limits
+import ..locate_annotation,
+    ..PlotText, ..Subplot, ..AVec, ..AMat, ..Axis, .._transform_ticks, ..process_limits
 
 const MissingOrQuantity = Union{Missing,<:Quantity}
 
@@ -293,8 +294,11 @@ locate_annotation(sp::Subplot, rel::NTuple{N,<:MissingOrQuantity}, label) where 
 #==================#
 # ticks and limits #
 #==================#
-_transform_ticks(ticks::AbstractArray{T}, axis) where {T<:Quantity} = ustrip.(getaxisunit(axis), ticks)
-process_limits(lims::AbstractArray{T}, axis) where {T<:Quantity} = ustrip.(getaxisunit(axis), lims)
-process_limits(lims::Tuple{S, T}, axis) where {S<:Quantity, T<:Quantity} = ustrip.(getaxisunit(axis), lims)
+_transform_ticks(ticks::AbstractArray{T}, axis) where {T<:Quantity} =
+    ustrip.(getaxisunit(axis), ticks)
+process_limits(lims::AbstractArray{T}, axis) where {T<:Quantity} =
+    ustrip.(getaxisunit(axis), lims)
+process_limits(lims::Tuple{S,T}, axis) where {S<:Quantity,T<:Quantity} =
+    ustrip.(getaxisunit(axis), lims)
 
 end

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -3,11 +3,11 @@
 
 module UnitfulRecipes
 
-using ..Unitful: Quantity, unit, ustrip, Unitful, dimension, Units
+using ..Unitful: Quantity, unit, ustrip, Unitful, dimension, Units, NoUnits
 using ..RecipesBase
 export @P_str
 
-import ..locate_annotation, ..PlotText, ..Subplot, ..AVec, ..AMat
+import ..locate_annotation, ..PlotText, ..Subplot, ..AVec, ..AMat, ..Axis, .._transform_ticks, ..process_limits
 
 const MissingOrQuantity = Union{Missing,<:Quantity}
 
@@ -40,16 +40,12 @@ function fixaxis!(attr, x, axisletter)
     sp = get(attr, :subplot, 1)
     if sp ≤ length(attr[:plot_object]) && attr[:plot_object].n > 0
         label = attr[:plot_object][sp][axis][:guide]
-        if label isa UnitfulString
-            u = label.unit
-        end
+        u = getaxisunit(label)
         # If label was not given as an argument, reuse
         get!(attr, axislabel, label)
     end
     # Fix the attributes: labels, lims, ticks, marker/line stuff, etc.
     append_unit_if_needed!(attr, axislabel, u)
-    ustripattribute!(attr, axislims, u)
-    ustripattribute!(attr, axisticks, u)
     ustripattribute!(attr, err, u)
     if axisletter === :y
         ustripattribute!(attr, :ribbon, u)
@@ -271,6 +267,10 @@ const UNIT_FORMATS = Dict(
 
 format_unit_label(l, u, f::Symbol) = format_unit_label(l, u, UNIT_FORMATS[f])
 
+getaxisunit(::AbstractString) = NoUnits
+getaxisunit(s::UnitfulString) = s.unit
+getaxisunit(a::Axis) = getaxisunit(a[:guide])
+
 #==============
 Fix annotations
 ===============#
@@ -289,5 +289,12 @@ locate_annotation(
 ) = (ustrip(x), ustrip(y), ustrip(z), label)
 locate_annotation(sp::Subplot, rel::NTuple{N,<:MissingOrQuantity}, label) where {N} =
     locate_annotation(sp, ustrip.(rel), label)
+
+#==================#
+# ticks and limits #
+#==================#
+_transform_ticks(ticks::AbstractArray{T}, axis) where {T<:Quantity} = ustrip.(getaxisunit(axis), ticks)
+process_limits(lims::AbstractArray{T}, axis) where {T<:Quantity} = ustrip.(getaxisunit(axis), lims)
+process_limits(lims::Tuple{S, T}, axis) where {S<:Quantity, T<:Quantity} = ustrip.(getaxisunit(axis), lims)
 
 end

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -60,8 +60,14 @@ end
         compare_yticks(pl, expected_ticks) = all(first(first(yticks(pl))) .≈ expected_ticks)
         encompassing_ylims = (-1m, 6m)
         @test compare_yticks(plot(y; ylims = encompassing_ylims, yticks = (1:5)m), 1:5)
-        @test compare_yticks(plot(y; ylims = encompassing_ylims, yticks = [1cm, 3cm]), [0.01, 0.03])
-        @test compare_yticks(plot!(; ylims = encompassing_ylims, yticks = [-1cm, 4cm]), [-0.01, 0.04])
+        @test compare_yticks(
+            plot(y; ylims = encompassing_ylims, yticks = [1cm, 3cm]),
+            [0.01, 0.03],
+        )
+        @test compare_yticks(
+            plot!(; ylims = encompassing_ylims, yticks = [-1cm, 4cm]),
+            [-0.01, 0.04],
+        )
         @test_throws DimensionError begin
             pl = plot(y)
             plot!(pl; yticks = (1:5)s)


### PR DESCRIPTION
Solves an issue from UnitfulRecipes: https://github.com/jw3126/UnitfulRecipes.jl/issues/82#issuecomment-1264380067

```julia
plot(randn(5)u"m")
plot!(; ylims=(0u"cm", 5u"cm"), yticks=[1u"cm", 2u"cm", 3u"cm"])
```