### PR TITLE
Set default theme by default

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -23,11 +23,7 @@ _plots_defaults() =
 
 function _plots_theme_defaults()
     user_defaults = _plots_defaults()
-    if haskey(user_defaults, :theme)
-        theme(pop!(user_defaults, :theme); user_defaults...)
-    else
-        default(; user_defaults...)
-    end
+    theme(pop!(user_defaults, :theme, :default); user_defaults...)
 end
 
 function _plots_plotly_defaults()


### PR DESCRIPTION
Solves #4398 

I'm not entirely sure why #4398 happens, I can't track down any of the awkward settings to any setting in Plots, PlotsThemes or anywhere else I could think of. But if you supply a theme it doesn't happen, and giving `:default` if no other theme is supplied should be pretty uncontroversial.