### PR TITLE
Adds extra_kwarg legend_wfactor to control the width of legend with gr.

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1324,6 +1324,7 @@ function gr_get_legend_geometry(viewport_plotarea, sp)
     end
 
     legend_width_factor = (viewport_plotarea[2] - viewport_plotarea[1]) / 45 # Determines the width of legend box
+    legend_width_factor *= get(sp[:extra_kwargs], :legend_wfactor, 1)
     legend_textw = legendw
     legend_rightw = legend_width_factor
     legend_leftw = legend_width_factor * 4


### PR DESCRIPTION
This PR adds an extra_kwarg `legend_wfactor` for GR backend.
This extra_kwarg is multiplied with `legend_width_factor` and effectively controls the width of the legend.

The reason for this PR is the following. I have been trying to create a common legend for a grid of subplots, which consists of several columns. For that, I created empty subplots with only the legend displayed.
The problem was that the default legend width was so small, that it was hard to discern the linestyles.