### PR TITLE
use `circshift` instead of `axes_shift`

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -1049,5 +1049,3 @@ end
 
 reverse_if(x, cond) = cond ? reverse(x) : x
 axis_tuple(x, y, letter) = reverse_if((x, y), letter === :y)
-
-axes_shift(t, i) = i % 3 == 0 ? t : i % 3 == 1 ? (t[3], t[1], t[2]) : (t[2], t[3], t[1])

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1664,8 +1664,7 @@ function gr_label_ticks_3d(sp, letter, ticks)
     famin, famax = axis_limits(sp, far_letter)
     n0, n1 = isy ? (namax, namin) : (namin, namax)
 
-    i = isx ? 1 : (isy ? 2 : 3)
-    letters = axes_shift((:x, :y, :z), 1 - i)
+    letters = circshift([:x, :y, :z], isx ? 0 : (isy ? -1 : -2))
     asyms = get_attr_symbol.(letters, :axis)
 
     # get axis objects, ticks and minor ticks


### PR DESCRIPTION
I'm tired of things reinventing the wheel.
We should be able to use `circshift` from stdlib, instead of defining `axes_shift` in a cryptic non tested way.