### PR TITLE
Adjust workaround for Windows precompilation on Julia 1.8.2+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       # surface errors during precompilation
       # auto-precompile in build step suppresses errors currently.
       - name: Precompile
+        env:
+          JULIA_DEBUG: Plots
         shell: julia --project=@. --color=yes {0}
         run: |
           using Pkg; Pkg.precompile()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
       - uses: julia-actions/cache@v1
 
       - uses: julia-actions/julia-buildpkg@latest
-        env: JULIA_PKG_PRECOMPILE_AUTO: 0
+        env:
+          JULIA_PKG_PRECOMPILE_AUTO: 0
       
       # surface errors during precompilation
       # auto-precompile in build step suppresses errors currently.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,16 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v1
+
       - uses: julia-actions/julia-buildpkg@latest
+        env: JULIA_PKG_PRECOMPILE_AUTO: 0
+      
+      # surface errors during precompilation
+      # auto-precompile in build step suppresses errors currently.
+      - name: Precompile
+        shell: julia --project=@. --color=yes {0}
+        run: |
+          using Pkg; Pkg.precompile()
 
       - name: Test upstream RecipesBase
         shell: julia --project=@. --color=yes {0}

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -9,28 +9,30 @@ if get(ENV, "PLOTS_PRECOMPILE", "true") == "true"
             _examples[i].external && continue
             (imp = _examples[i].imports) === nothing || push!(imports, imp)
             func = gensym(string(i))
-            push!(examples, quote
-                $func() = begin  # evaluate each example in a local scope
-                    # @show $i  # debug
-                    $(_examples[i].exprs)
-                    if $i == 1  # only for one example
-                        fn = tempname()
-                        pl = current()
-                        gui(pl)
-                        savefig(pl, "$fn.png")
-                        savefig(pl, "$fn.pdf")
+            push!(
+                examples,
+                quote
+                    $func() = begin  # evaluate each example in a local scope
+                        # @show $i  # debug
+                        $(_examples[i].exprs)
+                        if $i == 1  # only for one example
+                            fn = tempname()
+                            pl = current()
+                            gui(pl)
+                            savefig(pl, "$fn.png")
+                            savefig(pl, "$fn.pdf")
+                        end
+                        nothing
                     end
-                    nothing
-                end
-                try
-                    # During precompilation on the Windows GitHub CI in Julia 1.8.2+,
-                    # can fail here due to GR potentially failing to write out the
-                    # temporary file. Pending a fix, swallow the error and continue.
-                    $func()
-                catch
-                    @warn "Plots: Failed a trial save during precompilation"
-                end
-            end)
+                    try
+                        # During precompilation on the Windows GitHub CI in Julia 1.8.2+,
+                        # can fail here due to GR potentially failing to write out the
+                        # temporary file. Pending a fix, swallow the error and continue.
+                        $func()
+                    catch
+                        @warn "Plots: Failed a trial save during precompilation"
+                    end
+                end)
         end
         withenv("GKSwstype" => "nul") do
             @precompile_all_calls begin

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -32,7 +32,8 @@ if get(ENV, "PLOTS_PRECOMPILE", "true") == "true"
                     catch
                         @warn "Plots: Failed a trial save during precompilation"
                     end
-                end)
+                end,
+            )
         end
         withenv("GKSwstype" => "nul") do
             @precompile_all_calls begin

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -17,19 +17,19 @@ if get(ENV, "PLOTS_PRECOMPILE", "true") == "true"
                         fn = tempname()
                         pl = current()
                         gui(pl)
-                        try
-                            # During precompilation on the Windows GitHub CI in Julia 1.8.2+,
-                            # can fail here due to GR potentially failing to write out the
-                            # temporary file. Pending a fix, swallow the error and continue.
-                            savefig(pl, "$fn.png")
-                            savefig(pl, "$fn.pdf")
-                        catch
-                            @warn "Plots: Failed a trial save during precompilation"
-                        end
+                        savefig(pl, "$fn.png")
+                        savefig(pl, "$fn.pdf")
                     end
                     nothing
                 end
-                $func()
+                try
+                    # During precompilation on the Windows GitHub CI in Julia 1.8.2+,
+                    # can fail here due to GR potentially failing to write out the
+                    # temporary file. Pending a fix, swallow the error and continue.
+                    $func()
+                catch
+                    @warn "Plots: Failed a trial save during precompilation"
+                end
             end)
         end
         withenv("GKSwstype" => "nul") do

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -30,7 +30,7 @@ if get(ENV, "PLOTS_PRECOMPILE", "true") == "true"
                         # temporary file. Pending a fix, swallow the error and continue.
                         $func()
                     catch
-                        @warn "Plots: Failed a trial save during precompilation"
+                        @debug "Plots: Failed a trial save during precompilation"
                     end
                 end,
             )


### PR DESCRIPTION
My goal here is to still precompile on normal computers, but only skip it if there's a problem in CI

Providing a warning will also allow the issue to be monitored, and if someone ever encounters it outside of the CI system, maybe we can learn more about the issue.

Adjustment to #4406, based on work in #4445