### PR TITLE
RB: remove debug support (macro instead)

### DIFF
--- a/RecipesBase/README.md
+++ b/RecipesBase/README.md
@@ -120,9 +120,6 @@ For the example above, the following code is generated.  In it, you can see the 
 
 ```julia
 function RecipesBase.apply_recipe(d::Dict{Symbol,Any},::T,n=1)
-    if RecipesBase._debug_recipes[1]
-        println("apply_recipe args: ",Any[:(::T),:(n=1)])
-    end
     begin
         customcolor = get!(d,:customcolor,:green)
     end
@@ -134,7 +131,7 @@ function RecipesBase.apply_recipe(d::Dict{Symbol,Any},::T,n=1)
             get!(d,:zrotation,90)
             rand(10,n)
         end
-    if func_return != nothing
+    if func_return !== nothing
         push!(series_list,RecipesBase.RecipeData(d,RecipesBase.wrap_tuple(func_return)))
     end
     begin

--- a/RecipesBase/src/RecipesBase.jl
+++ b/RecipesBase/src/RecipesBase.jl
@@ -52,9 +52,6 @@ apply_recipe(plotattributes::AbstractDict{Symbol,Any}) = ()
 is_explicit(d::AbstractDict{Symbol,Any}, k) = haskey(d, k)
 function is_default end
 
-const _debug_recipes = Ref(false)
-debug(v::Bool = true) = _debug_recipes[] = v
-
 # --------------------------------------------------------------------------
 
 # this holds the data and attributes of one series, and is returned from apply_recipe
@@ -296,7 +293,6 @@ macro recipe(funcexpr::Expr)
         func,
         quote
             @nospecialize
-            RecipesBase._debug_recipes[] && println("apply_recipe args: ", $args)
             $kw_body
             $cleanup_body
             series_list = RecipesBase.RecipeData[]

--- a/RecipesBase/test/runtests.jl
+++ b/RecipesBase/test/runtests.jl
@@ -8,7 +8,6 @@ using Test
 const KW = Dict{Symbol,Any}
 
 RecipesBase.is_key_supported(k::Symbol) = true
-RecipesBase.debug(false)
 
 for t in map(i -> Symbol(:T, i), 1:5)
     @eval struct $t end


### PR DESCRIPTION
From https://discourse.julialang.org/t/building-a-pc-optimized-for-time-to-first-plot/88801/53, when inspecting flamegraphs, debug statements are causing un-necessary allocations.

The alternative is to use `ENV["JULIA_DEBUG"] = "RecipesBase"`.

**PR**
```julia
julia> using Plots; @time plot(rand(5, 2));
  1.909939 seconds (111.02 k allocations: 5.712 MiB, 99.74% compilation time)
```
**master**
```julia
julia> using Plots; @time plot(rand(5, 2));
  1.895801 seconds (112.04 k allocations: 5.768 MiB, 99.76% compilation time)
```
