### PR TITLE
bump cov - more `PyPlot` exs

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -116,9 +116,7 @@ function buildanimation(
     verbose = false,
     show_msg::Bool = true,
 )
-    if length(anim.frames) == 0
-        throw(ArgumentError("Cannot build empty animations"))
-    end
+    length(anim.frames) == 0 && throw(ArgumentError("Cannot build empty animations"))
 
     fn = abspath(expanduser(fn))
     animdir = anim.dir
@@ -198,9 +196,8 @@ Base.show(io::IO, ::MIME"image/png", agif::AnimatedGif) =
 # -----------------------------------------------
 
 function _animate(forloop::Expr, args...; type::Symbol = :none)
-    if forloop.head ∉ (:for, :while)
-        error("@animate macro expects a for- or while-block. got: $(forloop.head)")
-    end
+    forloop.head ∈ (:for, :while) ||
+        error("@animate macro expects a for- or while-block: $(forloop.head)")
 
     # add the call to frame to the end of each iteration
     animsym = gensym("anim")

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -91,10 +91,8 @@ function attr!(axis::Axis, args...; kw...)
         haskey(plotattributes, k) || continue
         if k === :discrete_values
             # add these discrete values to the axis
-            for vi in v
-                discrete_value!(axis, vi)
-            end
-            #could perhaps use TimeType here, as Date and DateTime are both subtypes of TimeType
+            foreach(x -> discrete_value!(axis, x), v)
+            # could perhaps use TimeType here, as Date and DateTime are both subtypes of TimeType
             # or could perhaps check if dateformatter or datetimeformatter is in use
         elseif k === :lims && isa(v, NTuple{2,Date})
             plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
@@ -116,9 +114,6 @@ end
 # -------------------------------------------------------------------------
 
 Base.show(io::IO, axis::Axis) = dumpdict(io, axis.plotattributes, "Axis", true)
-# Base.getindex(axis::Axis, k::Symbol) = getindex(axis.plotattributes, k)
-Base.setindex!(axis::Axis, v, ks::Symbol...) = setindex!(axis.plotattributes, v, ks...)
-Base.haskey(axis::Axis, k::Symbol) = haskey(axis.plotattributes, k)
 ignorenan_extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax))
 
 const _label_func =

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -113,7 +113,7 @@ end
 
 # -------------------------------------------------------------------------
 
-Base.show(io::IO, axis::Axis) = dumpdict(io, axis.plotattributes, "Axis", true)
+Base.show(io::IO, axis::Axis) = dumpdict(io, axis.plotattributes, "Axis")
 ignorenan_extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax))
 
 const _label_func =

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -2087,19 +2087,15 @@ function gr_draw_surface(series, x, y, z, clims)
             # Only triangles - connections have to be 0-based (indexing)
             ci, cj, ck = series[:connections]
             if !(length(ci) == length(cj) == length(ck))
-                throw(
-                    ArgumentError(
-                        "Argument connections must consist of equally sized arrays.",
-                    ),
-                )
+                "Argument connections must consist of equally sized arrays." |>
+                ArgumentError |>
+                throw
             end
             cns = map(i -> ([3, ci[i] + 1, cj[i] + 1, ck[i] + 1]), eachindex(ci))
         else
-            throw(
-                ArgumentError(
-                    "Unsupported `:connections` type $(typeof(series[:connections])) for seriestype=$st",
-                ),
-            )
+            "Unsupported `:connections` type $(typeof(series[:connections])) for seriestype=$st" |>
+            ArgumentError |>
+            throw
         end
         facecolor = if series[:fillcolor] isa AbstractArray
             series[:fillcolor]

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -542,7 +542,7 @@ end
 
 function _cbar_unique(values, propname)
     out = last(values)
-    if any(x != out for x in values)
+    if any(map(x -> x != out, values))
         @warn "Multiple series with different $propname share a colorbar. " *
               "Colorbar may not reflect all series correctly."
     end
@@ -696,9 +696,7 @@ function gr_display(plt::Plot, dpi_factor = 1)
     gr_fill_viewport(viewport_canvas, plt[:background_color_outside])
 
     # subplots:
-    for sp in plt.subplots
-        gr_display(sp, w * px, h * px, viewport_canvas)
-    end
+    foreach(sp -> gr_display(sp, w * px, h * px, viewport_canvas), plt.subplots)
 
     GR.updatews()
 end
@@ -746,7 +744,7 @@ text_box_height(w, h, rot) = abs(sind(rot)) * w + abs(sind(rot + 90)) * h
 
 function gr_get_3d_axis_angle(cvs, nt, ft, letter)
     length(cvs) < 2 && return 0
-    tickpoints = [gr_w3tondc(sort_3d_axes(cv, nt, ft, letter)...) for cv in cvs]
+    tickpoints = map(cv -> gr_w3tondc(sort_3d_axes(cv, nt, ft, letter)...), cvs)
 
     dx = tickpoints[2][1] - tickpoints[1][1]
     dy = tickpoints[2][2] - tickpoints[1][2]
@@ -1045,11 +1043,7 @@ function gr_display(sp::Subplot{GRBackend}, w, h, viewport_canvas)
     # add annotations
     for ann in sp[:annotations]
         x, y, val = locate_annotation(sp, ann...)
-        x, y = if gr_is3d(sp)
-            gr_w3tondc(x, y, z)
-        else
-            GR.wctondc(x, y)
-        end
+        x, y = gr_is3d(sp) ? gr_w3tondc(x, y, z) : GR.wctondc(x, y)
         gr_set_font(val.font, sp)
         gr_text(x, y, val.str)
     end
@@ -1363,7 +1357,7 @@ function gr_update_viewport_legend!(viewport_plotarea, sp, leg)
 
     if s isa Tuple{<:Real,Symbol}
         if s[2] === :outer
-            (x, y) = gr_legend_pos(sp, leg, viewport_plotarea) # Dry run, to figure out
+            x, y = gr_legend_pos(sp, leg, viewport_plotarea) # Dry run, to figure out
             if x < viewport_plotarea[1]
                 viewport_plotarea[1] +=
                     leg.leftw +
@@ -1493,18 +1487,14 @@ function gr_draw_axes(sp, viewport_plotarea)
         x_bg, y_bg = RecipesPipeline.unzip(GR.wc3towc.(area_x, area_y, area_z))
         GR.fillarea(x_bg, y_bg)
 
-        for letter in (:x, :y, :z)
-            gr_draw_axis_3d(sp, letter, viewport_plotarea)
-        end
+        foreach(letter -> gr_draw_axis_3d(sp, letter, viewport_plotarea), (:x, :y, :z))
     elseif ispolar(sp)
         r = gr_set_viewport_polar(viewport_plotarea)
         #rmin, rmax = GR.adjustrange(ignorenan_minimum(r), ignorenan_maximum(r))
         rmin, rmax = axis_limits(sp, :y)
         gr_polaraxes(rmin, rmax, sp)
     elseif sp[:framestyle] !== :none
-        for letter in (:x, :y)
-            gr_draw_axis(sp, letter, viewport_plotarea)
-        end
+        foreach(letter -> gr_draw_axis(sp, letter, viewport_plotarea), (:x, :y))
     end
 end
 
@@ -2078,11 +2068,11 @@ function gr_draw_surface(series, x, y, z, clims)
     elseif st === :mesh3d
         if series[:connections] isa AbstractVector{<:AbstractVector{Int}}
             # Combination of any polygon types
-            cns = [[length(polyinds), polyinds...] for polyinds in series[:connections]]
+            cns = map(cns -> [length(cns), cns...], series[:connections])
         elseif series[:connections] isa AbstractVector{NTuple{N,Int}} where {N}
             # Only N-gons - connections have to be 1-based (indexing)
             N = length(series[:connections][1])
-            cns = [[N, polyinds...] for polyinds in series[:connections]]
+            cns = map(cns -> [N, cns...], series[:connections])
         elseif series[:connections] isa NTuple{3,<:AbstractVector{Int}}
             # Only triangles - connections have to be 0-based (indexing)
             ci, cj, ck = series[:connections]
@@ -2131,9 +2121,10 @@ function gr_draw_heatmap(series, x, y, z, clims)
             z_normalized = get_z_normalized.(z_log, log10.(clims)...)
             plot_color.(map(z -> get(fillgrad, z), z_normalized), series[:fillalpha]), z_log
         end
-        for i in eachindex(colors)
-            isnan(_z[i]) && (colors[i] = set_RGBA_alpha(0, colors[i]))
-        end
+        foreach(
+            i -> isnan(_z[i]) && (colors[i] = set_RGBA_alpha(0, colors[i])),
+            eachindex(colors),
+        )
         GR.drawimage(first(x), last(x), last(y), first(y), w, h, gr_color.(colors))
     else
         if something(series[:fillalpha], 1) < 1
@@ -2147,9 +2138,7 @@ function gr_draw_heatmap(series, x, y, z, clims)
         end
         rgba = Int32[round(Int32, 1000 + _i * 255) for _i in z_normalized]
         bg_rgba = gr_getcolorind(plot_color(series[:subplot][:background_color_inside]))
-        for i in eachindex(rgba)
-            isnan(_z[i]) && (rgba[i] = bg_rgba)
-        end
+        foreach(i -> isnan(_z[i]) && (rgba[i] = bg_rgba), eachindex(rgba))
         if ispolar(series)
             y[1] < 0 && @warn "'y[1] < 0' (rmin) is not yet supported."
             dist = min(gr_x_axislims(sp)[2], gr_y_axislims(sp)[2])
@@ -2177,17 +2166,17 @@ for (mime, fmt) in (
     "image/svg+xml" => "svg",
 )
     @eval function _show(io::IO, ::MIME{Symbol($mime)}, plt::Plot{GRBackend})
-        GR.emergencyclosegks()
         dpi_factor = $fmt == "png" ? plt[:dpi] / Plots.DPI : 1
         filepath = tempname() * "." * $fmt
+        GR.emergencyclosegks()
         withenv(
             "GKS_FILEPATH" => filepath,
             "GKS_ENCODING" => "utf8",
             "GKSwstype" => $fmt,
         ) do
             gr_display(plt, dpi_factor)
-            GR.emergencyclosegks()
         end
+        GR.emergencyclosegks()
         write(io, read(filepath, String))
         rm(filepath)
     end
@@ -2195,16 +2184,16 @@ end
 
 function _display(plt::Plot{GRBackend})
     if plt[:display_type] === :inline
-        GR.emergencyclosegks()
         filepath = tempname() * ".pdf"
+        GR.emergencyclosegks()
         withenv(
             "GKS_FILEPATH" => filepath,
             "GKS_ENCODING" => "utf8",
             "GKSwstype" => "pdf",
         ) do
             gr_display(plt)
-            GR.emergencyclosegks()
         end
+        GR.emergencyclosegks()
         println(
             "\033]1337;File=inline=1;preserveAspectRatio=0:",
             base64encode(open(read, filepath)),

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -9,6 +9,7 @@ mutable struct PlotExample
     exprs::Expr
 end
 
+# COV_EXCL_START
 PlotExample(header::AbstractString, expr::Expr) = PlotExample(header, "", expr)
 PlotExample(header::AbstractString, imports::Expr, expr::Expr) =
     PlotExample(header, "", false, imports, expr)
@@ -16,6 +17,7 @@ PlotExample(header::AbstractString, desc::AbstractString, expr::Expr) =
     PlotExample(header, desc, false, nothing, expr)
 PlotExample(header::AbstractString, desc::AbstractString, imports::Expr, expr::Expr) =
     PlotExample(header, desc, false, imports, expr)
+# COV_EXCL_STOP
 
 # the _examples we'll run for each backend
 const _examples = PlotExample[
@@ -1228,11 +1230,13 @@ function test_examples(
         try
             plts[i] = test_examples(pkgname, i; debug, disp, callback)
         catch ex
+            # COV_EXCL_START
             if strict
                 rethrow(ex)
             else
                 @warn "Example $pkgname:$i:$(_examples[i].header) failed with: $ex"
             end
+            # COV_EXCL_STOP
         end
         sleep === nothing || Base.sleep(sleep)
     end

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1136,14 +1136,12 @@ const _examples = PlotExample[
 _animation_examples = [2, 31]
 _backend_skips = Dict(
     :gr => [30],
-    :pyplot => [2, 22, 25, 30, 31, 49, 56],  # NOTE: `22` breaks docs with libstdc++.so.X: version `GLIBCXX_X.X.X' not found ...
+    :pyplot => [22, 56],  # NOTE: `22` breaks docs with libstdc++.so.X: version `GLIBCXX_X.X.X' not found ...
     :plotlyjs => [2, 21, 24, 25, 30, 31, 49, 50, 51, 55, 56],
     :pgfplotsx => [
-        2,  # animation
         6,  # images
         16,  # pgfplots thinks the upper panel is too small
         30,  # @df
-        31,  # animation
         32,  # spy
         49,  # polar heatmap
         51,  # image with custom axes

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -70,7 +70,7 @@ const POTENTIAL_VECTOR_ARGUMENTS = [
 
 @nospecialize
 
-@recipe function f(::Type{Val{:line}}, x, y, z)
+@recipe function f(::Type{Val{:line}}, x, y, z)  # COV_EXCL_LINE
     indices = sortperm(x)
     x := x[indices]
     y := y[indices]
@@ -96,7 +96,7 @@ const POTENTIAL_VECTOR_ARGUMENTS = [
 end
 @deps line path
 
-@recipe function f(::Type{Val{:hline}}, x, y, z)
+@recipe function f(::Type{Val{:hline}}, x, y, z)  # COV_EXCL_LINE
     n = length(y)
     newx = repeat(Float64[1, 2, NaN], n)
     newy = vec(Float64[yi for i in 1:3, yi in y])
@@ -107,7 +107,7 @@ end
 end
 @deps hline straightline
 
-@recipe function f(::Type{Val{:vline}}, x, y, z)
+@recipe function f(::Type{Val{:vline}}, x, y, z)  # COV_EXCL_LINE
     n = length(y)
     newx = vec(Float64[yi for i in 1:3, yi in y])
     x := newx
@@ -117,7 +117,7 @@ end
 end
 @deps vline straightline
 
-@recipe function f(::Type{Val{:hspan}}, x, y, z)
+@recipe function f(::Type{Val{:hspan}}, x, y, z)  # COV_EXCL_LINE
     n = div(length(y), 2)
     newx = repeat([-Inf, Inf, Inf, -Inf, NaN], outer = n)
     newy = vcat(map(i -> [y[2i - 1], y[2i - 1], y[2i], y[2i], NaN], 1:n)...)
@@ -129,7 +129,7 @@ end
 end
 @deps hspan shape
 
-@recipe function f(::Type{Val{:vspan}}, x, y, z)
+@recipe function f(::Type{Val{:vspan}}, x, y, z)  # COV_EXCL_LINE
     n = div(length(y), 2)
     newx = vcat(map(i -> [y[2i - 1], y[2i - 1], y[2i], y[2i], NaN], 1:n)...)
     newy = repeat([-Inf, Inf, Inf, -Inf, NaN], outer = n)
@@ -145,7 +145,7 @@ end
 # path and scatter
 
 # create a path from steps
-@recipe function f(::Type{Val{:scatterpath}}, x, y, z)
+@recipe function f(::Type{Val{:scatterpath}}, x, y, z)  # COV_EXCL_LINE
     x := x
     y := y
     seriestype := :scatter
@@ -167,7 +167,7 @@ end
 # regression line and scatter
 
 # plots line corresponding to linear regression of y on a constant and x
-@recipe function f(::Type{Val{:linearfit}}, x, y, z)
+@recipe function f(::Type{Val{:linearfit}}, x, y, z)  # COV_EXCL_LINE
     x := x
     y := y
     seriestype := :scatter
@@ -213,7 +213,7 @@ make_steps(t::Tuple, st, even) = Tuple(make_steps(ti, st, even) for ti in t)
 @nospecialize
 
 # create a path from steps
-@recipe function f(::Type{Val{:steppre}}, x, y, z)
+@recipe function f(::Type{Val{:steppre}}, x, y, z)  # COV_EXCL_LINE
     plotattributes[:x] = make_steps(x, :post, false)
     plotattributes[:y] = make_steps(y, :pre, false)
     seriestype := :path
@@ -238,7 +238,7 @@ end
 @deps steppre path scatter
 
 # create a path from steps
-@recipe function f(::Type{Val{:stepmid}}, x, y, z)
+@recipe function f(::Type{Val{:stepmid}}, x, y, z)  # COV_EXCL_LINE
     plotattributes[:x] = make_steps(x, :mid, true)
     plotattributes[:y] = make_steps(y, :post, true)
     seriestype := :path
@@ -263,7 +263,7 @@ end
 @deps stepmid path scatter
 
 # create a path from steps
-@recipe function f(::Type{Val{:steppost}}, x, y, z)
+@recipe function f(::Type{Val{:steppost}}, x, y, z)  # COV_EXCL_LINE
     plotattributes[:x] = make_steps(x, :pre, false)
     plotattributes[:y] = make_steps(y, :post, false)
     seriestype := :path
@@ -291,7 +291,7 @@ end
 # sticks
 
 # create vertical line segments from fill
-@recipe function f(::Type{Val{:sticks}}, x, y, z)
+@recipe function f(::Type{Val{:sticks}}, x, y, z)  # COV_EXCL_LINE
     n = length(x)
     fr = plotattributes[:fillrange]
     if fr === nothing
@@ -367,7 +367,7 @@ end
 @nospecialize
 
 # create segmented bezier curves in place of line segments
-@recipe function f(::Type{Val{:curves}}, x, y, z; npoints = 30)
+@recipe function f(::Type{Val{:curves}}, x, y, z; npoints = 30)  # COV_EXCL_LINE
     args = z !== nothing ? (x, y, z) : (x, y)
     newx, newy = zeros(0), zeros(0)
     fr = plotattributes[:fillrange]
@@ -407,7 +407,7 @@ end
 # ---------------------------------------------------------------------------
 
 # create a bar plot as a filled step function
-@recipe function f(::Type{Val{:bar}}, x, y, z)
+@recipe function f(::Type{Val{:bar}}, x, y, z)  # COV_EXCL_LINE
     procx, procy, xscale, yscale, baseline = _preprocess_barlike(plotattributes, x, y)
     nx, ny = length(procx), length(procy)
     axis = plotattributes[:subplot][isvertical(plotattributes) ? :xaxis : :yaxis]
@@ -510,7 +510,7 @@ end
 
 # ---------------------------------------------------------------------------
 # Plots Heatmap
-@recipe function f(::Type{Val{:plots_heatmap}}, x, y, z)
+@recipe function f(::Type{Val{:plots_heatmap}}, x, y, z)  # COV_EXCL_LINE
     xe, ye = heatmap_edges(x), heatmap_edges(y)
     m, n = size(z.surf)
     x_pts, y_pts = fill(NaN, 6 * m * n), fill(NaN, 6 * m * n)
@@ -599,7 +599,7 @@ end
 
 @nospecialize
 
-@recipe function f(::Type{Val{:barbins}}, x, y, z)
+@recipe function f(::Type{Val{:barbins}}, x, y, z)  # COV_EXCL_LINE
     edge, weights, xscale, yscale, baseline = _preprocess_binlike(plotattributes, x, y)
     if (plotattributes[:bar_width] === nothing)
         bar_width := diff(edge)
@@ -611,7 +611,7 @@ end
 end
 @deps barbins bar
 
-@recipe function f(::Type{Val{:scatterbins}}, x, y, z)
+@recipe function f(::Type{Val{:scatterbins}}, x, y, z)  # COV_EXCL_LINE
     edge, weights, xscale, yscale, baseline = _preprocess_binlike(plotattributes, x, y)
     @series begin
         x := _bin_centers(edge)
@@ -689,7 +689,7 @@ function _stepbins_path(edge, weights, baseline::Real, xscale::Symbol, yscale::S
     (x, y)
 end
 
-@recipe function f(::Type{Val{:stepbins}}, x, y, z)
+@recipe function f(::Type{Val{:stepbins}}, x, y, z)  # COV_EXCL_LINE
     @nospecialize
     axis = plotattributes[:subplot][Plots.isvertical(plotattributes) ? :xaxis : :yaxis]
 
@@ -821,13 +821,13 @@ end
 
 @nospecialize
 
-@recipe function f(::Type{Val{:histogram}}, x, y, z)
+@recipe function f(::Type{Val{:histogram}}, x, y, z)  # COV_EXCL_LINE
     seriestype := length(y) > 1e6 ? :stephist : :barhist
     ()
 end
 @deps histogram barhist
 
-@recipe function f(::Type{Val{:barhist}}, x, y, z)
+@recipe function f(::Type{Val{:barhist}}, x, y, z)  # COV_EXCL_LINE
     h = _make_hist(
         tuple(y),
         plotattributes[:bins],
@@ -841,7 +841,7 @@ end
 end
 @deps barhist barbins
 
-@recipe function f(::Type{Val{:stephist}}, x, y, z)
+@recipe function f(::Type{Val{:stephist}}, x, y, z)  # COV_EXCL_LINE
     h = _make_hist(
         tuple(y),
         plotattributes[:bins],
@@ -855,7 +855,7 @@ end
 end
 @deps stephist stepbins
 
-@recipe function f(::Type{Val{:scatterhist}}, x, y, z)
+@recipe function f(::Type{Val{:scatterhist}}, x, y, z)  # COV_EXCL_LINE
     h = _make_hist(
         tuple(y),
         plotattributes[:bins],
@@ -869,7 +869,7 @@ end
 end
 @deps scatterhist scatterbins
 
-@recipe function f(h::StatsBase.Histogram{T,1,E}) where {T,E}
+@recipe function f(h::StatsBase.Histogram{T,1,E}) where {T,E}  # COV_EXCL_LINE
     seriestype --> :barbins
 
     st_map = Dict(
@@ -892,7 +892,7 @@ end
     end
 end
 
-@recipe f(hv::AbstractVector{H}) where {H<:StatsBase.Histogram} =
+@recipe f(hv::AbstractVector{H}) where {H<:StatsBase.Histogram} =  # COV_EXCL_LINE
     for h in hv
         @series begin
             h
@@ -902,7 +902,7 @@ end
 # ---------------------------------------------------------------------------
 # Histogram 2D
 
-@recipe function f(::Type{Val{:bins2d}}, x, y, z)
+@recipe function f(::Type{Val{:bins2d}}, x, y, z)  # COV_EXCL_LINE
     edge_x, edge_y, weights = x, y, z.surf
 
     float_weights = float(weights)
@@ -925,7 +925,7 @@ end
 end
 Plots.@deps bins2d heatmap
 
-@recipe function f(::Type{Val{:histogram2d}}, x, y, z)
+@recipe function f(::Type{Val{:histogram2d}}, x, y, z)  # COV_EXCL_LINE
     h = _make_hist(
         (x, y),
         plotattributes[:bins],
@@ -940,14 +940,14 @@ Plots.@deps bins2d heatmap
 end
 @deps histogram2d bins2d
 
-@recipe function f(h::StatsBase.Histogram{T,2,E}) where {T,E}
+@recipe function f(h::StatsBase.Histogram{T,2,E}) where {T,E}  # COV_EXCL_LINE
     seriestype --> :bins2d
     (h.edges[1], h.edges[2], Surface(h.weights))
 end
 
 # ---------------------------------------------------------------------------
 # pie
-@recipe function f(::Type{Val{:pie}}, x, y, z)
+@recipe function f(::Type{Val{:pie}}, x, y, z)  # COV_EXCL_LINE
     framestyle --> :none
     aspect_ratio --> 1
     s = sum(y)
@@ -971,7 +971,7 @@ end
 # ---------------------------------------------------------------------------
 # mesh 3d replacement for non-plotly backends
 
-@recipe function f(::Type{Val{:mesh3d}}, x, y, z)
+@recipe function f(::Type{Val{:mesh3d}}, x, y, z)  # COV_EXCL_LINE
     # As long as no i,j,k are supplied this should work with PyPlot and GR
     seriestype := :surface
     if plotattributes[:connections] !== nothing
@@ -987,7 +987,7 @@ end
 # ---------------------------------------------------------------------------
 # scatter 3d
 
-@recipe function f(::Type{Val{:scatter3d}}, x, y, z)
+@recipe function f(::Type{Val{:scatter3d}}, x, y, z)  # COV_EXCL_LINE
     seriestype := :path3d
     if plotattributes[:markershape] === :none
         markershape := :circle
@@ -1003,7 +1003,7 @@ end
 # lens! - magnify a region of a plot
 lens!(args...; kwargs...) = plot!(args...; seriestype = :lens, kwargs...)
 export lens!
-@recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)
+@recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)  # COV_EXCL_LINE
     sp_index, inset_bbox = plotattributes[:inset_subplots]
     if !(width(inset_bbox) isa Measures.Length{:w,<:Real})
         throw(ArgumentError("Inset bounding box needs to in relative coordinates."))
@@ -1101,7 +1101,7 @@ end
 # ---------------------------------------------------------------------------
 # contourf - filled contours
 
-@recipe function f(::Type{Val{:contourf}}, x, y, z)
+@recipe function f(::Type{Val{:contourf}}, x, y, z)  # COV_EXCL_LINE
     @nospecialize
     fillrange := true
     seriestype := :contour
@@ -1169,7 +1169,7 @@ clamp_to_eps!(ary) = (replace!(x -> x <= 0.0 ? Base.eps(Float64) : x, ary); noth
 
 @nospecialize
 
-@recipe function f(::Type{Val{:xerror}}, x, y, z)
+@recipe function f(::Type{Val{:xerror}}, x, y, z)  # COV_EXCL_LINE
     error_style!(plotattributes)
     markershape --> :vline
     xerr = error_zipit(plotattributes[:xerror])
@@ -1186,7 +1186,7 @@ clamp_to_eps!(ary) = (replace!(x -> x <= 0.0 ? Base.eps(Float64) : x, ary); noth
 end
 @deps xerror path
 
-@recipe function f(::Type{Val{:yerror}}, x, y, z)
+@recipe function f(::Type{Val{:yerror}}, x, y, z)  # COV_EXCL_LINE
     error_style!(plotattributes)
     markershape --> :hline
     yerr = error_zipit(plotattributes[:yerror])
@@ -1203,7 +1203,7 @@ end
 end
 @deps yerror path
 
-@recipe function f(::Type{Val{:zerror}}, x, y, z)
+@recipe function f(::Type{Val{:zerror}}, x, y, z)  # COV_EXCL_LINE
     error_style!(plotattributes)
     markershape --> :hline
     if z !== nothing
@@ -1324,7 +1324,7 @@ function quiver_using_hack(plotattributes::AKW)
 end
 
 # function apply_series_recipe(plotattributes::AKW, ::Type{Val{:quiver}})
-@recipe function f(::Type{Val{:quiver}}, x, y, z)
+@recipe function f(::Type{Val{:quiver}}, x, y, z)  # COV_EXCL_LINE
     @nospecialize
     if :arrow in supported_attrs()
         quiver_using_arrows(plotattributes)
@@ -1348,7 +1348,7 @@ function clamp_greys!(mat::AMat{<:Gray})
     mat
 end
 
-@recipe function f(mat::AMat{<:Gray})
+@recipe function f(mat::AMat{<:Gray})  # COV_EXCL_LINE
     n, m = map(a -> range(0.5, stop = a.stop + 0.5), axes(mat))
 
     if is_seriestype_supported(:image)
@@ -1367,7 +1367,7 @@ end
 @nospecialize
 
 # images - colors
-@recipe function f(mat::AMat{T}) where {T<:Colorant}
+@recipe function f(mat::AMat{T}) where {T<:Colorant}  # COV_EXCL_LINE
     n, m = map(a -> range(0.5, stop = a.stop + 0.5), axes(mat))
 
     if is_seriestype_supported(:image)
@@ -1386,12 +1386,12 @@ end
 
 # plotting arbitrary shapes/polygons
 
-@recipe function f(shape::Shape)
+@recipe function f(shape::Shape)  # COV_EXCL_LINE
     seriestype --> :shape
     coords(shape)
 end
 
-@recipe function f(shapes::AVec{<:Shape})
+@recipe function f(shapes::AVec{<:Shape})  # COV_EXCL_LINE
     seriestype --> :shape
     # For backwards compatibility, column vectors of segmenting attributes are
     # interpreted as having one element per shape
@@ -1406,7 +1406,7 @@ end
     coords(shapes)
 end
 
-@recipe function f(shapes::AMat{<:Shape})
+@recipe function f(shapes::AMat{<:Shape})  # COV_EXCL_LINE
     seriestype --> :shape
     for j in axes(shapes, 2)
         @series coords(vec(shapes[:, j]))
@@ -1418,7 +1418,7 @@ end
 # --------------------------------------------------------------------
 
 # images - grays
-@recipe function f(x::AVec, y::AVec, mat::AMat{T}) where {T<:Gray}
+@recipe function f(x::AVec, y::AVec, mat::AMat{T}) where {T<:Gray}  # COV_EXCL_LINE
     if is_seriestype_supported(:image)
         seriestype := :image
         yflip --> true
@@ -1433,7 +1433,7 @@ end
 end
 
 # images - colors
-@recipe function f(x::AVec, y::AVec, mat::AMat{T}) where {T<:Colorant}
+@recipe function f(x::AVec, y::AVec, mat::AMat{T}) where {T<:Colorant}  # COV_EXCL_LINE
     if is_seriestype_supported(:image)
         seriestype := :image
         yflip --> true
@@ -1495,12 +1495,12 @@ end
     get(plotattributes, :seriestype, :path) === :ohlc ? map(t -> OHLC(t...), xyuv) :
     RecipesPipeline.unzip(xyuv)
 
-@recipe function f(x::AVec, v::AVec{OHLC})
+@recipe function f(x::AVec, v::AVec{OHLC})  # COV_EXCL_LINE
     seriestype := :path
     get_xy(v, x)
 end
 
-@recipe function f(v::AVec{OHLC})
+@recipe function f(v::AVec{OHLC})  # COV_EXCL_LINE
     seriestype := :path
     get_xy(v)
 end
@@ -1526,7 +1526,7 @@ end
 
 @userplot Spy
 
-@recipe function f(g::Spy)
+@recipe function f(g::Spy)  # COV_EXCL_LINE
     @assert length(g.args) == 1 && typeof(g.args[1]) <: AbstractMatrix
     seriestype := :spy
     mat = g.args[1]
@@ -1534,7 +1534,7 @@ end
     Plots.SliceIt, m, n, Surface(mat)
 end
 
-@recipe function f(::Type{Val{:spy}}, x, y, z)
+@recipe function f(::Type{Val{:spy}}, x, y, z)  # COV_EXCL_LINE
     yflip := true
     aspect_ratio := 1
     rs, cs, zs = findnz(z.surf)
@@ -1584,7 +1584,7 @@ abline!(args...; kw...) = abline!(current(), args...; kw...)
 # -------------------------------------------------
 # Complex Numbers
 
-@recipe function f(A::AbstractArray{Complex{T}}) where {T<:Number}
+@recipe function f(A::AbstractArray{Complex{T}}) where {T<:Number}  # COV_EXCL_LINE
     xguide --> "Re(x)"
     yguide --> "Im(x)"
     real.(A), imag.(A)
@@ -1593,7 +1593,7 @@ end
 # Splits a complex matrix to its real and complex parts
 # Reals defaults solid, imaginary defaults dashed
 # Label defaults are changed to match the real-imaginary reference / indexing
-@recipe function f(x::AbstractArray{Real}, y::AbstractMatrix{Complex})
+@recipe function f(x::AbstractArray{Real}, y::AbstractMatrix{Complex})  # COV_EXCL_LINE
     ylabel --> "Re(y)"
     zlabel --> "Im(y)"
     x, real.(y), imag.(y)
@@ -1606,7 +1606,7 @@ end
 # - "returns" are the dependent variable
 # - "weights" are a matrix where the ith column is the composition for returns[i]
 # - since each polygon is its own series, you can assign labels easily
-@recipe function f(pc::PortfolioComposition)
+@recipe function f(pc::PortfolioComposition)  # COV_EXCL_LINE
     weights, returns = pc.args
     n = length(returns)
     weights = cumsum(weights, dims = 2)
@@ -1622,7 +1622,7 @@ end
 
 @userplot AreaPlot
 
-@recipe function f(a::AreaPlot; seriestype = :line)
+@recipe function f(a::AreaPlot; seriestype = :line)  # COV_EXCL_LINE
     data = cumsum(a.args[end], dims = 2)
     x = length(a.args) == 1 ? (axes(data, 1)) : a.args[1]
     for i in axes(data, 2)

--- a/test/test_animations.jl
+++ b/test/test_animations.jl
@@ -35,6 +35,10 @@ end
         circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
     end every 5
 
+    @gif for i in 1:n
+        circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
+    end when i % 5 == 0
+
     Plots.@apng for i in 1:n
         circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
     end every 5
@@ -77,6 +81,10 @@ end
         show(io, MIME("image/gif"), gif)
     end
     @test filesize(fn) > 1_000
-    @test animate([1:2, 2:3]; variable_palette = false, show_msg = false) isa
+end
+
+@testset "coverage" begin
+    @test animate([1:2, 2:3]; variable_palette = true, show_msg = false) isa
           Plots.AnimatedGif
+    @test Plot.FrameIterator([1:2, 2:3]).every == 1
 end

--- a/test/test_animations.jl
+++ b/test/test_animations.jl
@@ -86,5 +86,5 @@ end
 @testset "coverage" begin
     @test animate([1:2, 2:3]; variable_palette = true, show_msg = false) isa
           Plots.AnimatedGif
-    @test Plot.FrameIterator([1:2, 2:3]).every == 1
+    @test Plots.FrameIterator([1:2, 2:3]).every == 1
 end

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -7,8 +7,8 @@
     @test Plots.ignorenan_extrema(axis) == (0.5, 1.5)
     @test axis[:discrete_map] == Dict{Any,Any}(:yo => 2, "HI" => 1)
 
-    Plots.discrete_value!(axis, ["x$i" for i in 1:5])
-    Plots.discrete_value!(axis, ["x$i" for i in 0:2])
+    Plots.discrete_value!(axis, map(i -> "x$i", 1:5))
+    Plots.discrete_value!(axis, map(i -> "x$i", 0:2))
     @test Plots.ignorenan_extrema(axis) == (0.5, 7.5)
 
     # JuliaPlots/Plots.jl/issues/4375
@@ -16,6 +16,10 @@
         pl = plot(1:2, xlabel = lab, ylabel = lab, title = lab)
         show(devnull, pl)
     end
+
+    @test Plots.labelfunc_tex(:log10)(1) == "10^{1}"
+    @test Plots.labelfunc_tex(:log2)(1) == "2^{1}"
+    @test Plots.labelfunc_tex(:ln)(1) == "e^{1}"
 end
 
 @testset "Showaxis" begin

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -6,6 +6,7 @@
         @test Plots.vertices(square) == [(0, 0), (1, 0), (1, 1), (0, 1)]
         @test isa(square, Shape{Int64,Float64})
         @test coords(square) isa Tuple{Vector{S},Vector{T}} where {T,S}
+        @test Shape(:circle) isa Shape
     end
 
     @testset "Copy" begin
@@ -133,6 +134,10 @@ end
     @test Plots.locate_annotation(sp, 1, 2, 3, t) == (1, 2, 3, t)
     @test Plots.locate_annotation(sp, (0.1, 0.2), t) isa Tuple
     @test Plots.locate_annotation(sp, (0.1, 0.2, 0.3), t) isa Tuple
+
+    # see github.com/JuliaPlots/Plots.jl/issues/4073
+    anns = [(["x", "y"], [10, 20], :hexagon) (["a", "b"], [3, 4], :circle)]
+    pl = plot(rand(2, 2), layout = 2, series_annotations = anns)
 end
 
 @testset "Fonts" begin

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -218,12 +218,14 @@ end
         extra_kwargs = Dict(
             :series => Dict(:display_option => Plots.GR.OPTION_SHADED_MESH),
             :subplot => Dict(:legend_hfactor => 2),
+            :plot => Dict(:foo => nothing),
         )
         show(io, surface(x, y, (x, y) -> exp(-x^2 - y^2); extra_kwargs))
         str = read(io, String)
         @test occursin("extra kwargs", str)
         @test occursin("Series{1}", str)
         @test occursin("SubplotPlot{1}", str)
+        @test occursin("Plot:", str)
     end
 end
 

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -250,7 +250,7 @@ end
     end
 end
 
-@testset "mesh3d" do
+@testset "mesh3d" begin
     with(:gr) do
         x = [0, 1, 2, 0]
         y = [0, 0, 1, 2]

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -249,3 +249,55 @@ end
         @test Plots.findnz([0 1; 2 0]) == ([2, 1], [1, 2], [2, 1])
     end
 end
+
+@testset "mesh3d" do
+    with(:gr) do
+        x = [0, 1, 2, 0]
+        y = [0, 0, 1, 2]
+        z = [0, 2, 0, 1]
+        i = [0, 0, 0, 1]
+        j = [1, 2, 3, 2]
+        k = [2, 3, 1, 3]
+        # github.com/JuliaPlots/Plots.jl/pull/3868#issuecomment-939446686
+        mesh3d(
+            x,
+            y,
+            z;
+            connections = (i, j, k),
+            fillcolor = [:blue, :red, :green, :yellow],
+            fillalpha = 0.5,
+        )
+
+        # github.com/JuliaPlots/Plots.jl/pull/3835#issue-1002117649
+        p0 = [0.0, 0.0, 0.0]
+        p1 = [1.0, 0.0, 0.0]
+        p2 = [0.0, 1.0, 0.0]
+        p3 = [1.0, 1.0, 0.0]
+        p4 = [0.5, 0.5, 1.0]
+        pts = [p0, p1, p2, p3, p4]
+        x, y, z = broadcast(i -> getindex.(pts, i), (1, 2, 3))
+        # [x[i],y[i],z[i]] is the i-th vertix of the mesh
+        mesh3d(
+            x,
+            y,
+            z;
+            connections = [
+                [1, 2, 4, 3], # Quadrangle 
+                [1, 2, 5], # Triangle
+                [2, 4, 5], # Triangle
+                [4, 3, 5], # Triangle
+                [3, 1, 5],  # Triangle
+            ],
+            linecolor = :black,
+            fillcolor = :blue,
+            fillalpha = 0.2,
+        )
+        @test true
+    end
+end
+
+@testset "fillstyle" begin
+    with(:gr) do
+        @test histogram(rand(10); fillstyle = :/) isa Plot
+    end
+end

--- a/test/test_shorthands.jl
+++ b/test/test_shorthands.jl
@@ -36,6 +36,8 @@ end
     @test sp[:xaxis][:guide] == "xlabel"
     ylabel!(pl, "ylabel")
     @test sp[:yaxis][:guide] == "ylabel"
+    zlabel!(pl, "zlabel")
+    @test sp[:zaxis][:guide] == "zlabel"
 end
 
 @testset "Misc" begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -80,6 +80,7 @@
 
     pl = plot(1:2)
     Plots.dumpdict(devnull, first(pl.series_list).plotattributes)
+    show(devnull, pl[1][:xaxis])
 
     Plots.debugplots(false)
     ######################


### PR DESCRIPTION
- nearly all `PyPlot` disabled examples are ok now;
- bump coverage (:tired_face:, never enough), add more tests.