### PR TITLE
colorbar improvements

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -882,7 +882,7 @@ function _update_min_padding!(sp::Subplot{GRBackend})
         end
     end
     if (title = gr_colorbar_title(sp)).str != ""
-        padding.right[] += @static if false
+        padding.right[] += @static if true
             sz = gr_text_size(title)
             l = is_horizontal(title) ? first(sz) : last(sz)
             l * width * px

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -102,31 +102,23 @@ const gr_font_family = Dict(
     "dejavu sans" => 233,
 )
 
-struct GRViewport{T}
-    xmin::Base.RefValue{T}
-    xmax::Base.RefValue{T}
-    ymin::Base.RefValue{T}
-    ymax::Base.RefValue{T}
+mutable struct GRViewport{T}
+    xmin::T
+    xmax::T
+    ymin::T
+    ymax::T
 end
 
-GRViewport(xm::Number, xM::Number, ym::Number, yM::Number) =
-    GRViewport(Ref(xm), Ref(xM), Ref(ym), Ref(yM))
+xyminmax(v::GRViewport) = v.xmin, v.xmax, v.ymin, v.ymax
 
-xmin(v::GRViewport) = v.xmin[]
-xmax(v::GRViewport) = v.xmax[]
-ymin(v::GRViewport) = v.ymin[]
-ymax(v::GRViewport) = v.ymax[]
+width(v::GRViewport) = v.xmax - v.xmin
+height(v::GRViewport) = v.ymax - v.ymin
 
-xyminmax(v::GRViewport) = xmin(v), xmax(v), ymin(v), ymax(v)
+xcenter(v::GRViewport) = 0.5(v.xmin + v.xmax)
+ycenter(v::GRViewport) = 0.5(v.ymin + v.ymax)
 
-width(v::GRViewport) = xmax(v) - xmin(v)
-height(v::GRViewport) = ymax(v) - ymin(v)
-
-xcenter(v::GRViewport) = 0.5(xmin(v) + xmax(v))
-ycenter(v::GRViewport) = 0.5(ymin(v) + ymax(v))
-
-xposition(v::GRViewport, pos) = xmin(v) + pos * width(v)
-yposition(v::GRViewport, pos) = ymin(v) + pos * height(v)
+xposition(v::GRViewport, pos) = v.xmin + pos * width(v)
+yposition(v::GRViewport, pos) = v.ymin + pos * height(v)
 
 # --------------------------------------------------------------------------------------
 gr_is3d(st) = RecipesPipeline.is3d(st)
@@ -186,8 +178,10 @@ gr_set_projectiontype(sp) = GR.setprojectiontype(gr_projections[sp[:projection_t
 # draw line segments, splitting x/y into contiguous/finite segments
 # note: this can be used for shapes by passing func `GR.fillarea`
 function gr_polyline(x, y, func = GR.polyline; arrowside = :none, arrowstyle = :simple)
-    iend = 0
+    draw_head = arrowside in (:head, :both)
+    draw_tail = arrowside in (:tail, :both)
     n = length(x)
+    iend = 0
     while iend < n - 1
         istart = -1  # set istart to the first index that is finite
         for j in (iend + 1):n
@@ -209,11 +203,11 @@ function gr_polyline(x, y, func = GR.polyline; arrowside = :none, arrowstyle = :
         # if we found a start and end, draw the line segment, otherwise we're done
         if istart > 0 && iend > 0
             func(x[istart:iend], y[istart:iend])
-            if arrowside in (:head, :both)
+            if draw_head
                 gr_set_arrowstyle(arrowstyle)
                 GR.drawarrow(x[iend - 1], y[iend - 1], x[iend], y[iend])
             end
-            if arrowside in (:tail, :both)
+            if draw_tail
                 gr_set_arrowstyle(arrowstyle)
                 GR.drawarrow(x[istart + 1], y[istart + 1], x[istart], y[istart])
             end
@@ -227,18 +221,15 @@ function gr_polyline3d(x, y, z, func = GR.polyline3d)
     iend = 0
     n = length(x)
     while iend < n - 1
-        # set istart to the first index that is finite
-        istart = -1
+        istart = -1  # set istart to the first index that is finite
         for j in (iend + 1):n
             if ok(x[j], y[j], z[j])
                 istart = j
                 break
             end
         end
-
         if istart > 0
-            # iend is the last finite index
-            iend = -1
+            iend = -1  # iend is the last finite index
             for j in (istart + 1):n
                 if ok(x[j], y[j], z[j])
                     iend = j
@@ -247,7 +238,6 @@ function gr_polyline3d(x, y, z, func = GR.polyline3d)
                 end
             end
         end
-
         # if we found a start and end, draw the line segment, otherwise we're done
         if istart > 0 && iend > 0
             func(x[istart:iend], y[istart:iend], z[istart:iend])
@@ -336,6 +326,7 @@ function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)
         (r ≤ 1 && r ≥ 0) && gr_text(GR.wctondc(0.05, r)..., _cycle(rtick_labels, i))
     end
     GR.restorestate()
+    nothing
 end
 
 # using the axis extrema and limit overrides, return the min/max value for this axis
@@ -353,6 +344,7 @@ function gr_fill_viewport(vp::GRViewport, c)
     GR.fillrect(xyminmax(vp)...)
     GR.selntran(1)
     GR.restorestate()
+    nothing
 end
 
 gr_fill_plotarea(sp, vp::GRViewport) =
@@ -388,6 +380,7 @@ function gr_draw_marker(series, xi, yi, zi, clims, i, msize, strokewidth, shape:
     gr_set_line(strokewidth, :solid, msc, series)
     gr_set_transparency(msc, get_markerstrokealpha(series, i))
     GR.polyline(xs, ys)
+    nothing
 end
 
 # draw ONE symbol marker
@@ -403,6 +396,7 @@ function gr_draw_marker(series, xi, yi, zi, clims, i, msize, strokewidth, shape:
     else
         GR.polymarker3d([xi], [yi], [zi])
     end
+    nothing
 end
 
 # ---------------------------------------------------------
@@ -411,6 +405,7 @@ function gr_set_line(lw, style, c, s)  # s can be Subplot or Series
     GR.setlinetype(gr_linetypes[style])
     GR.setlinewidth(get_thickness_scaling(s) * max(0, lw / gr_nominal_size(s)))
     gr_set_linecolor(c)
+    nothing
 end
 
 gr_set_fill(c) = (gr_set_fillcolor(c); GR.setfillintstyle(GR.INTSTYLE_SOLID); nothing)
@@ -437,6 +432,7 @@ function gr_set_font(
     )
     gr_set_textcolor(plot_color(color))
     GR.settextalign(gr_haligns[halign], gr_valigns[valign])
+    nothing
 end
 
 function gr_w3tondc(x, y, z)
@@ -449,12 +445,12 @@ end
 
 function gr_viewport_from_bbox(sp::Subplot{GRBackend}, bb::BoundingBox, w, h, vp_canvas)
     viewport = GRViewport(
-        vp_canvas.xmax[] * (left(bb) / w),
-        vp_canvas.xmax[] * (right(bb) / w),
-        vp_canvas.ymax[] * (1 - bottom(bb) / h),
-        vp_canvas.ymax[] * (1 - top(bb) / h),
+        vp_canvas.xmax * (left(bb) / w),
+        vp_canvas.xmax * (right(bb) / w),
+        vp_canvas.ymax * (1 - bottom(bb) / h),
+        vp_canvas.ymax * (1 - top(bb) / h),
     )
-    hascolorbar(sp) && (viewport.xmax[] -= 0.1(1 + 0.5gr_is3d(sp)))
+    hascolorbar(sp) && (viewport.xmax -= 0.1(1 + 0.5gr_is3d(sp)))
     viewport
 end
 
@@ -467,12 +463,8 @@ const gr_cbar_off_3d = Ref(0.07)
 
 function gr_set_viewport_cmap(sp::Subplot, vp::GRViewport)
     offset = gr_is3d(sp) ? gr_cbar_off_3d[] : gr_cbar_off_2d[]
-    args = GRViewport(
-        xmax(vp) + offset,
-        xmax(vp) + offset + gr_cbar_width[],
-        ymin(vp),
-        ymax(vp),
-    )
+    args =
+        GRViewport(vp.xmax + offset, vp.xmax + offset + gr_cbar_width[], vp.ymin, vp.ymax)
     GR.setviewport(xyminmax(args)...)
     args
 end
@@ -537,7 +529,7 @@ end
 
 const gr_colorbar_tick_size = Ref(0.005)
 
-function gr_colorbar_title(sp::Subplot) =
+function gr_colorbar_title(sp::Subplot)
     title = if (ttl = sp[:colorbar_title]) isa PlotText
         ttl
     else
@@ -615,9 +607,14 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, vp::GRViewport)
 
     title = gr_colorbar_title(sp)
     gr_set_font(title.font, sp; halign = :center, valign = :top)
-    gr_text(xmax(vp_cmap) + tick_max_width + 2gr_colorbar_tick_size[], ycenter(vp), title.str)
+    gr_text(
+        vp_cmap.xmax + tick_max_width + 2gr_colorbar_tick_size[],
+        ycenter(vp),
+        title.str,
+    )
 
     GR.restorestate()
+    nothing
 end
 
 position(symb) =
@@ -669,15 +666,15 @@ function gr_display(plt::Plot, dpi_factor = 1)
         msize = dsp_width_ratio * w * dpi_factor
         GR.setwsviewport(0, msize, 0, msize * ratio)
         GR.setwswindow(0, 1, 0, ratio)
-        vp_canvas.ymin[] *= ratio
-        vp_canvas.ymax[] *= ratio
+        vp_canvas.ymin *= ratio
+        vp_canvas.ymax *= ratio
     else
         ratio = float(w) / h
         msize = dsp_height_ratio * h * dpi_factor
         GR.setwsviewport(0, msize * ratio, 0, msize)
         GR.setwswindow(0, ratio, 0, 1)
-        vp_canvas.xmin[] *= ratio
-        vp_canvas.xmax[] *= ratio
+        vp_canvas.xmin *= ratio
+        vp_canvas.xmax *= ratio
     end
 
     # fill in the viewport_canvas background
@@ -689,6 +686,7 @@ function gr_display(plt::Plot, dpi_factor = 1)
     end
 
     GR.updatews()
+    nothing
 end
 
 gr_set_tickfont(sp, ax::Axis; kw...) = gr_set_font(
@@ -774,9 +772,9 @@ function gr_axis_height(sp, axis)
         ticks in (nothing, false, :none) ? 0 :
         last(gr_get_ticks_size(ticks, axis[:rotation]))
     )
-    if axis[:guide] != ""
+    if (guide = axis[:guide]) != ""
         gr_set_font(guidefont(axis), sp)
-        h += last(gr_text_size(axis[:guide]))
+        h += last(gr_text_size(guide))
     end
     GR.restorestate()
     h
@@ -790,9 +788,9 @@ function gr_axis_width(sp, axis)
         ticks in (nothing, false, :none) ? 0 :
         first(gr_get_ticks_size(ticks, axis[:rotation]))
     )
-    if axis[:guide] != ""
+    if (guide = axis[:guide]) != ""
         gr_set_font(guidefont(axis), sp)
-        w += last(gr_text_size(axis[:guide]))
+        w += last(gr_text_size(guide))
     end
     GR.restorestate()
     w
@@ -989,14 +987,14 @@ function gr_add_legend(sp, leg, viewport_area)
             xpos + leg.textw + leg.rightw,
             ypos + leg.dy,
             ypos - leg.h,
-        ) # Allocating white space for actual legend width here
+        )  # Allocating white space for actual legend width here
         gr_set_line(1, :solid, sp[:legend_foreground_color], sp)
         GR.drawrect(
             xpos - leg.leftw,
             xpos + leg.textw + leg.rightw,
             ypos + leg.dy,
             ypos - leg.h,
-        ) # Drawing actual legend width here
+        )  # Drawing actual legend width here
         if sp[:legend_title] !== nothing
             gr_set_font(legendtitlefont(sp), sp; halign = :center, valign = :center)
             gr_text(xpos - 0.03 + 0.5leg.w, ypos, string(sp[:legend_title]))
@@ -1070,6 +1068,7 @@ function gr_add_legend(sp, leg, viewport_area)
     end
     GR.selntran(1)
     GR.restorestate()
+    nothing
 end
 
 mirrored(ax::Axis, sym::Symbol) =
@@ -1099,31 +1098,31 @@ function gr_legend_pos(sp::Subplot, leg, vp)
             -!ymirror * gr_axis_width(sp, yaxis) - 2leg.xoffset - leg.rightw - leg.textw
         else
             leg.leftw + leg.xoffset
-        end + xmin(vp)
+        end + vp.xmin
     elseif occursin("right", str)
         if occursin("outer", str)  # per https://github.com/jheinen/GR.jl/blob/master/src/jlgr.jl#L525
             leg.xoffset + leg.leftw + ymirror * gr_axis_width(sp, yaxis)
         else
             -leg.rightw - leg.textw - leg.xoffset
-        end + xmax(vp)
+        end + vp.xmax
     else
-        xposition(vp, 0) + leg.leftw - leg.rightw - leg.textw - 2leg.xoffset
+        vp.xmin + leg.leftw - leg.rightw - leg.textw - 2leg.xoffset
     end
     ypos = if occursin("bottom", str)
         if s === :outerbottom
             -leg.yoffset - leg.dy - !xmirror * gr_axis_height(sp, xaxis)
         else
             leg.yoffset + leg.h
-        end + ymin(vp)
+        end + vp.ymin
     elseif occursin("top", str)
         if s === :outertop
             leg.yoffset + leg.h + xmirror * gr_axis_height(sp, xaxis)
         else
             -leg.yoffset - leg.dy
-        end + ymax(vp)
+        end + vp.ymax
     else
         # Adding min y to shift legend pos to correct graph (#2377)
-        0.5(height(vp) + leg.h) + xmin(vp)
+        0.5(height(vp) + leg.h) + vp.xmin
     end
     xpos, ypos
 end
@@ -1195,52 +1194,52 @@ function gr_update_viewport_legend!(vp, sp, leg)
     if (s = sp[:legend_position]) isa Tuple{<:Real,Symbol}
         if s[2] === :outer
             x, y = gr_legend_pos(sp, leg, vp) # Dry run, to figure out
-            if x < xmin(vp)
-                vp.xmin[] +=
+            if x < vp.xmin
+                vp.xmin +=
                     leg.leftw +
                     leg.textw +
                     leg.rightw +
                     leg.xoffset +
                     !ymirror * gr_axis_width(sp, yaxis)
-            elseif x > xmax(vp)
-                vp.xmax[] -= leg.leftw + leg.textw + leg.rightw + leg.xoffset
+            elseif x > vp.xmax
+                vp.xmax -= leg.leftw + leg.textw + leg.rightw + leg.xoffset
             end
-            if y < ymin(vp)
-                vp.ymin[] +=
+            if y < vp.ymin
+                vp.ymin +=
                     leg.h + leg.dy + leg.yoffset + !xmirror * gr_axis_height(sp, xaxis)
-            elseif y > ymax(vp)
-                vp.ymax[] -= leg.h + leg.dy + leg.yoffset
+            elseif y > vp.ymax
+                vp.ymax -= leg.h + leg.dy + leg.yoffset
             end
         end
     end
     leg_str = string(s)
     if occursin("outer", leg_str)
         if occursin("right", leg_str)
-            vp.xmax[] -= leg.leftw + leg.textw + leg.rightw + leg.xoffset
+            vp.xmax -= leg.leftw + leg.textw + leg.rightw + leg.xoffset
         elseif occursin("left", leg_str)
-            vp.xmin[] +=
+            vp.xmin +=
                 leg.leftw +
                 leg.textw +
                 leg.rightw +
                 leg.xoffset +
                 !ymirror * gr_axis_width(sp, yaxis)
         elseif occursin("top", leg_str)
-            vp.ymax[] -= leg.h + leg.dy + leg.yoffset
+            vp.ymax -= leg.h + leg.dy + leg.yoffset
         elseif occursin("bottom", leg_str)
-            vp.ymin[] += leg.h + leg.dy + leg.yoffset + !xmirror * gr_axis_height(sp, xaxis)
+            vp.ymin += leg.h + leg.dy + leg.yoffset + !xmirror * gr_axis_height(sp, xaxis)
         end
     end
     if s === :inline
         if yaxis[:mirror]
-            vp.xmin[] += leg.w
+            vp.xmin += leg.w
         else
-            vp.xmax[] -= leg.w
+            vp.xmax -= leg.w
         end
     end
     nothing
 end
 
-function gr_update_viewport_ratio!(vp, sp)
+gr_update_viewport_ratio!(vp, sp) =
     if (ratio = get_aspect_ratio(sp)) !== :none
         ratio === :equal && (ratio = 1)
         x_min, x_max, y_min, y_max = gr_xy_axislims(sp)
@@ -1249,18 +1248,17 @@ function gr_update_viewport_ratio!(vp, sp)
         if window_ratio < viewport_ratio
             viewport_center = xcenter(vp)
             viewport_size = width(vp) * window_ratio / viewport_ratio
-            vp.xmin[] = viewport_center - 0.5viewport_size
-            vp.xmax[] = viewport_center + 0.5viewport_size
+            vp.xmin = viewport_center - 0.5viewport_size
+            vp.xmax = viewport_center + 0.5viewport_size
         elseif window_ratio > viewport_ratio
             viewport_center = ycenter(vp)
             viewport_size = height(vp) * viewport_ratio / window_ratio
-            vp.ymin[] = viewport_center - 0.5viewport_size
-            vp.ymax[] = viewport_center + 0.5viewport_size
+            vp.ymin = viewport_center - 0.5viewport_size
+            vp.ymax = viewport_center + 0.5viewport_size
         end
     end
-end
 
-function gr_set_window(sp, vp)
+gr_set_window(sp, vp) =
     if ispolar(sp)
         gr_set_viewport_polar(vp)
     else
@@ -1285,13 +1283,11 @@ function gr_set_window(sp, vp)
             GR.setscale(scaleop)
         end
     end
-end
 
 ## Axes
 
 function gr_draw_axes(sp, vp)
     GR.setlinewidth(sp.plt[:thickness_scaling])
-
     if gr_is3d(sp)
         # set space
         x_min, x_max, y_min, y_max = gr_xy_axislims(sp)
@@ -1322,6 +1318,7 @@ function gr_draw_axes(sp, vp)
     elseif sp[:framestyle] !== :none
         foreach(letter -> gr_draw_axis(sp, letter, vp), (:x, :y))
     end
+    nothing
 end
 
 function gr_draw_axis(sp, letter, vp)
@@ -1338,6 +1335,7 @@ function gr_draw_axis(sp, letter, vp)
     # labels
     gr_label_ticks(sp, letter, ax.ticks)
     gr_label_axis(sp, letter, vp)
+    nothing
 end
 
 function gr_draw_axis_3d(sp, letter, vp)
@@ -1356,6 +1354,7 @@ function gr_draw_axis_3d(sp, letter, vp)
     gr_label_ticks_3d(sp, letter, ax.ticks)
     gr_label_axis_3d(sp, letter)
     gr_set_window(sp, vp)
+    nothing
 end
 
 gr_draw_grid(sp, axis, segments, func = gr_polyline) =
@@ -1534,9 +1533,9 @@ gr_label_axis(sp, letter, vp) =
             halign = alignment(axis[:guidefonthalign])
             ypos, valign =
                 if guide_position === :top || (guide_position === :auto && mirror)
-                    ymax(vp) + 0.015 + (mirror ? gr_axis_height(sp, axis) : 0.015), :top
+                    vp.ymax + 0.015 + (mirror ? gr_axis_height(sp, axis) : 0.015), :top
                 else
-                    ymin(vp) - 0.015 - (mirror ? 0.015 : gr_axis_height(sp, axis)), :bottom
+                    vp.ymin - 0.015 - (mirror ? 0.015 : gr_axis_height(sp, axis)), :bottom
                 end
         else
             rotation += 90  # default rotation = 0. should yield GR.setcharup(-1, 0) i.e. 180°
@@ -1544,9 +1543,9 @@ gr_label_axis(sp, letter, vp) =
             halign = alignment(axis[:guidefontvalign])
             xpos, valign =
                 if guide_position === :right || (guide_position === :auto && mirror)
-                    xmax(vp) + 0.03 + mirror * gr_axis_width(sp, axis), :bottom
+                    vp.xmax + 0.03 + mirror * gr_axis_width(sp, axis), :bottom
                 else
-                    xmin(vp) - 0.03 - !mirror * gr_axis_width(sp, axis), :top
+                    vp.xmin - 0.03 - !mirror * gr_axis_width(sp, axis), :top
                 end
         end
         gr_set_font(guidefont(axis), sp; rotation, halign, valign)
@@ -1591,11 +1590,11 @@ gr_add_title(sp, vp_plt, vp_sp) =
     if (title = sp[:title]) != ""
         GR.savestate()
         xpos, ypos, halign, valign = if (loc = sp[:titlelocation]) === :left
-            xmin(vp_plt), ymax(vp_sp), :left, :top
+            vp_plt.xmin, vp_sp.ymax, :left, :top
         elseif loc === :center
-            xcenter(vp_plt), ymax(vp_sp), :center, :top
+            vp_plt.xcenter, vp_sp.ymax, :center, :top
         elseif loc === :right
-            xmax(vp_plt), ymax(vp_sp), :right, :top
+            vp_plt.xmax, vp_sp.ymax, :right, :top
         else
             xposition(vp_plt, loc[1]),
             yposition(vp_plt, loc[2]),
@@ -1687,6 +1686,7 @@ function gr_add_series(sp, series)
         gr_text(x_l + offset, y_l, series[:label])
     end
     GR.restorestate()
+    nothing
 end
 
 function gr_draw_segments(series, x, y, z, fillrange, clims)
@@ -1803,6 +1803,7 @@ function gr_draw_contour(series, x, y, z, clims)
         coff = plot_color(series[:linecolor]) in (black, [black]) ? 0 : 1_000
         GR.contour(x, y, h, z, coff + (series[:contour_labels] == true ? 1 : 0))
     end
+    nothing
 end
 
 function gr_draw_surface(series, x, y, z, clims)
@@ -1864,6 +1865,7 @@ function gr_draw_surface(series, x, y, z, clims)
     else
         throw(ArgumentError("Not handled !"))
     end
+    nothing
 end
 
 function gr_draw_heatmap(series, x, y, z, clims)
@@ -1913,12 +1915,14 @@ function gr_draw_heatmap(series, x, y, z, clims)
             GR.nonuniformcellarray(x, y, w, h, rgba)
         end
     end
+    nothing
 end
 
 function gr_draw_image(series, x, y, z, clims)
     x_min, x_max = ignorenan_extrema(x)
     y_min, y_max = ignorenan_extrema(y)
     GR.drawimage(x_min, x_max, y_max, y_min, size(z)..., gr_color.(z))
+    nothing
 end
 
 # ----------------------------------------------------------------

--- a/src/components.jl
+++ b/src/components.jl
@@ -373,6 +373,8 @@ text(str, args...; kw...) = PlotText(string(str), font(args...; kw...))
 
 Base.length(t::PlotText) = length(t.str)
 
+is_horizontal(t::PlotText) = abs(sind(t.font.rotation - 45)) < sind(45)
+
 # -----------------------------------------------------------------------
 
 struct Stroke

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1122,7 +1122,8 @@ const rotations = Dict(
         top = :top,
         left = :left,
         bottom = :bottom,
-    ), 2 => (  # rotate by +90°
+    ),
+    2 => (  # rotate by +90°
         center = :center,
         hcenter = :vcenter,
         vcenter = :hcenter,
@@ -1130,7 +1131,8 @@ const rotations = Dict(
         top = :left,
         left = :bottom,
         bottom = :right,
-    ), 3 => (  # rotate by +180°
+    ),
+    3 => (  # rotate by +180°
         center = :center,
         hcenter = :hcenter,
         vcenter = :vcenter,
@@ -1138,7 +1140,8 @@ const rotations = Dict(
         top = :bottom,
         left = :right,
         bottom = :top,
-    ), 4 => (  # rotate by +270°
+    ),
+    4 => (  # rotate by +270°
         center = :center,
         hcenter = :vcenter,
         vcenter = :hcenter,
@@ -1146,19 +1149,18 @@ const rotations = Dict(
         top = :right,
         left = :top,
         bottom = :left,
-    )
+    ),
 )
 
 """
 given an arbitrary angle, determine the circle quadrant
 NE: I - NW: II - SW : III - SE: IV
 """
-quadrant(angle::Number) =
-    if sind(angle) > 0
-        cosd(angle) > 0 ? 1 : 2
-    else
-        cosd(angle) > 0 ? 4 : 3
-    end::Int
+quadrant(angle::Number) = if sind(angle) > 0
+    cosd(angle) > 0 ? 1 : 2
+else
+    cosd(angle) > 0 ? 4 : 3
+end::Int
 
 function rotate(halign::Symbol, valign::Symbol, angle::Number)
     θ = angle + 45

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1113,7 +1113,7 @@ macro attributes(expr::Expr)
     expr
 end
 
-const rotations = Dict(
+const _rotations = Dict(
     1 => (  # noop
         center = :center,
         hcenter = :hcenter,
@@ -1156,19 +1156,22 @@ const rotations = Dict(
 given an arbitrary angle, determine the circle quadrant
 NE: I - NW: II - SW : III - SE: IV
 """
-quadrant(angle::Number) = if sind(angle) > 0
-    cosd(angle) > 0 ? 1 : 2
-else
-    cosd(angle) > 0 ? 4 : 3
-end::Int
+function quadrant(angle::Number)
+    sn, cs = sincosd(angle)
+    if sn > 0
+        cs > 0 ? 1 : 2
+    else
+        cs > 0 ? 4 : 3
+    end::Int
+end
 
-function rotate(halign::Symbol, valign::Symbol, angle::Number)
-    θ = angle + 45
+function rotate_alignements(halign::Symbol, valign::Symbol, angle::Number)
+    θ = angle + 45  # allow a +45/-45° sector
     Q = quadrant(θ)
-    r = rotations[Q]
+    r = _rotations[Q]
     if Q == 1 || Q == 3
         r[halign], r[valign]
     else
         r[valign], r[halign]  # swap !
-    end
+    end::NTuple{2,Symbol}
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1112,3 +1112,61 @@ macro attributes(expr::Expr)
     RecipesBase.process_recipe_body!(expr)
     expr
 end
+
+const rotations = Dict(
+    1 => (  # noop
+        center = :center,
+        hcenter = :hcenter,
+        vcenter = :vcenter,
+        right = :right,
+        top = :top,
+        left = :left,
+        bottom = :bottom,
+    ), 2 => (  # rotate by +90°
+        center = :center,
+        hcenter = :vcenter,
+        vcenter = :hcenter,
+        right = :top,
+        top = :left,
+        left = :bottom,
+        bottom = :right,
+    ), 3 => (  # rotate by +180°
+        center = :center,
+        hcenter = :hcenter,
+        vcenter = :vcenter,
+        right = :left,
+        top = :bottom,
+        left = :right,
+        bottom = :top,
+    ), 4 => (  # rotate by +270°
+        center = :center,
+        hcenter = :vcenter,
+        vcenter = :hcenter,
+        right = :bottom,
+        top = :right,
+        left = :top,
+        bottom = :left,
+    )
+)
+
+"""
+given an arbitrary angle, determine the circle quadrant
+NE: I - NW: II - SW : III - SE: IV
+"""
+quadrant(angle::Number) =
+    if sind(angle) > 0
+        cosd(angle) > 0 ? 1 : 2
+    else
+        cosd(angle) > 0 ? 4 : 3
+    end::Int
+
+function rotate(halign::Symbol, valign::Symbol, angle::Number)
+    θ = angle + 45
+    Q = quadrant(θ)
+    r = rotations[Q]
+    if Q == 1 || Q == 3
+        r[halign], r[valign]
+    else
+        r[valign], r[halign]  # swap !
+    end
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -143,6 +143,16 @@
         attr!(sp; title)
         @test sp[:title] == title
     end
+
+    @test Plots.rotate_alignements(:center, :center, 120) == (:center, :center)
+    @test Plots.rotate_alignements(:right, :top, 30) == (:right, :top)
+    @test Plots.rotate_alignements(:right, :top, 60) == (:left, :top)
+    @test Plots.rotate_alignements(:right, :top, 120) == (:left, :top)
+    @test Plots.rotate_alignements(:right, :top, 150) == (:left, :bottom)
+    @test Plots.rotate_alignements(:right, :top, 210) == (:left, :bottom)
+    @test Plots.rotate_alignements(:right, :top, 240) == (:right, :bottom)
+    @test Plots.rotate_alignements(:right, :top, 300) == (:right, :bottom)
+    @test Plots.rotate_alignements(:right, :top, 330) == (:right, :top)
 end
 
 @testset "NaN-separated Segments" begin


### PR DESCRIPTION
- hoist out more `gr` hardcoded factors, making them somehow modifiable if needed;
- adjust the colorbar position, based on ticks width so they do not overlap;
- should we adjust colorbar subplot padding based on ticks width + label width (horz) or height (vert) ? currently, the label can go out of the subplot (3rd and 5th examples): this would need new ref images, so tbd;
- ~~also, the added blank space in `3d` before the colorbar is too much since the recent changes of GR projection, so I propose to use the same amount of space as of `2d` plots~~.

```julia
using Plots

main() = begin
  w, h = Plots._plot_defaults[:size]
  for (i, zcolor) in enumerate((
    1:2,
    10:11,
    100:101,
    1000:1001,
  ))
    png(scatter(0:1, 0:1,zcolor=zcolor, colorbar_title = "foo"), "cbar-2d-$i")
    png(scatter(0:1, 0:1, 0:1, zcolor=zcolor, colorbar_title = "foo"), "cbar-3d-$i")
  end
  run(`montage -border 2 -bordercolor red -geometry $(2w)x$(2h)+2+2 $(map(i -> "cbar-2d-$i.png", 1:4)) cbar-2d-old.png`)
  run(`montage -border 2 -bordercolor red -geometry $(2w)x$(2h)+2+2 $(map(i -> "cbar-3d-$i.png", 1:4)) cbar-3d-old.png`)
  return
end

main()
```

**1.35.5**
![cbar-2d-old](https://user-images.githubusercontent.com/13423344/197549549-ef3968e1-83cc-401e-8f63-0a74df9f8783.png)
![cbar-3d-old](https://user-images.githubusercontent.com/13423344/197549405-75cb783c-ce8e-4e61-813a-4b302c9408f6.png)


**PR**
![cbar-2d](https://user-images.githubusercontent.com/13423344/197549453-e14a232e-657b-46d3-8a1f-4d92e3e7c36b.png)
![cbar-3d](https://user-images.githubusercontent.com/13423344/197549491-5d942a94-33cf-4061-9bb2-af40ef079b47.png)
