### PR TITLE
eachindex call incorrectly assumes that the returned index is IndexLinear

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -97,6 +97,7 @@ PlotlyKaleido = "f2990250-8cf9-495f-b13a-cce12b45703c"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
+SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
@@ -107,4 +108,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 
 [targets]
-test = ["Aqua", "Colors", "Conda", "Distributions", "FileIO", "FilePathsBase", "Gaston", "GeometryBasics", "Gtk", "ImageMagick", "Images", "InspectDR", "LibGit2", "OffsetArrays", "PGFPlotsX", "PlotlyJS", "PlotlyBase", "PyCall", "PyPlot", "PlotlyKaleido", "HDF5", "RDatasets", "StableRNGs", "StaticArrays", "StatsPlots", "Test", "TestImages", "UnicodePlots", "Unitful", "VisualRegressionTests"]
+test = ["Aqua", "Colors", "Conda", "Distributions", "FileIO", "FilePathsBase", "Gaston", "GeometryBasics", "Gtk", "ImageMagick", "Images", "InspectDR", "LibGit2", "OffsetArrays", "PGFPlotsX", "PlotlyJS", "PlotlyBase", "PyCall", "PyPlot", "PlotlyKaleido", "HDF5", "RDatasets", "SentinelArrays", "StableRNGs", "StaticArrays", "StatsPlots", "Test", "TestImages", "UnicodePlots", "Unitful", "VisualRegressionTests"]

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1714,7 +1714,7 @@ function gr_draw_markers(
     (shapes = series[:markershape]) === :none && return
     for segment in series_segments(series, :scatter)
         i = segment.attr_index
-        rng = intersect(eachindex(x), segment.range)
+        rng = intersect(eachindex(IndexLinear(), x), segment.range)
         isempty(rng) && continue
         ms = get_thickness_scaling(series) * _cycle(msize, i)
         msw = get_thickness_scaling(series) * _cycle(strokewidth, i)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1713,9 +1713,9 @@ function gr_draw_markers(
     GR.setfillintstyle(GR.INTSTYLE_SOLID)
     (shapes = series[:markershape]) === :none && return
     for segment in series_segments(series, :scatter)
-        i = segment.attr_index
         rng = intersect(eachindex(IndexLinear(), x), segment.range)
         isempty(rng) && continue
+        i = segment.attr_index
         ms = get_thickness_scaling(series) * _cycle(msize, i)
         msw = get_thickness_scaling(series) * _cycle(strokewidth, i)
         shape = _cycle(shapes, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 import Unitful: m, s, cm, DimensionError
 import Plots: PLOTS_SEED, Plot, with
+import SentinelArrays: ChainedVector
 import GeometryBasics
 import ImageMagick
 import LibGit2

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -176,3 +176,9 @@ end
     X, Y, Z = Plots.mesh3d_triangles(x, y, z, cns)
     @test length(X) == length(Y) == length(Z) == 4length(i)
 end
+
+@testset "SentinelArrays - _cycle" begin
+    # discourse.julialang.org/t/plots-borking-on-sentinelarrays-produced-by-csv-read/89505
+    # `CSV` produces `SentinelArrays` data
+    @test scatter(ChainedVector([[1, 2], [3, 4]]), 1:4) isa Plot
+end


### PR DESCRIPTION
I am not sure if other calls to `eachindex` in Plots.jl have the same problem. The fix should resolve https://discourse.julialang.org/t/plots-borking-on-sentinelarrays-produced-by-csv-read/89505, but maybe there are other cases in the code when the same issue would be raised (I have checked the `eachindex` calls, but often I was not sure if the type on which it is called returns `IndexLinear` by default or not).