### PR TITLE
fix inset padding

### DIFF
--- a/RecipesPipeline/src/utils.jl
+++ b/RecipesPipeline/src/utils.jl
@@ -14,6 +14,8 @@ struct DefaultsDict <: AbstractDict{Symbol,Any}
     defaults::KW
 end
 
+Base.merge(d1::DefaultsDict, d2::DefaultsDict) =
+    DefaultsDict(merge(d1.explicit, d2.explicit), merge(d1.defaults, d2.defaults))
 Base.getindex(dd::DefaultsDict, k) =
     if haskey(dd.explicit, k)
         dd.explicit[k]
@@ -31,7 +33,7 @@ Base.get!(dd::DefaultsDict, k, default) =
 function Base.delete!(dd::DefaultsDict, k)
     haskey(dd.explicit, k) && delete!(dd.explicit, k)
     haskey(dd.defaults, k) && delete!(dd.defaults, k)
-    return dd
+    dd
 end
 Base.length(dd::DefaultsDict) = length(union(keys(dd.explicit), keys(dd.defaults)))
 function Base.iterate(dd::DefaultsDict)
@@ -54,7 +56,7 @@ Base.setindex!(dd::DefaultsDict, v, k) = dd.explicit[k] = v
 # Reset to default value and return dict
 function reset_kw!(dd::DefaultsDict, k)
     is_explicit(dd, k) && delete!(dd.explicit, k)
-    return dd
+    dd
 end
 # Reset to default value and return old value
 pop_kw!(dd::DefaultsDict, k) = is_explicit(dd, k) ? pop!(dd.explicit, k) : dd.defaults[k]

--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -85,6 +85,7 @@ export
     default,
     with,
     twinx,
+    twiny,
 
     pie,
     pie!,

--- a/src/args.jl
+++ b/src/args.jl
@@ -1862,13 +1862,6 @@ function _update_plot_args(plt::Plot, plotattributes_in::AKW)
     plotattributes = plt.attr
     plt[:background_color] = plot_color(plotattributes[:background_color])
     plt[:foreground_color] = fg_color(plotattributes)
-    # bg = plot_color(plt.attr[:background_color])
-    # fg = plt.attr[:foreground_color]
-    # if fg === :auto
-    #     fg = isdark(bg) ? colorant"white" : colorant"black"
-    # end
-    # plt.attr[:background_color] = bg
-    # plt.attr[:foreground_color] = plot_color(fg)
     color_or_nothing!(plt.attr, :background_color_outside)
 end
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -530,6 +530,7 @@ const _suppress_warnings = Set{Symbol}([
     :smooth,
     :relative_bbox,
     :layout_insets,
+    :force_minpad,
 ])
 
 is_subplot_attr(k) = k in _all_subplot_args
@@ -1733,7 +1734,7 @@ function slice_arg!(
     remove_pair::Bool,
 )
     v = get(plotattributes_in, k, plotattributes_out[k])
-    plotattributes_out[k] = if haskey(plotattributes_in, k) && !(k in _plot_args)
+    plotattributes_out[k] = if haskey(plotattributes_in, k) && k ∉ _plot_args
         slice_arg(v, idx)
     else
         v
@@ -1859,9 +1860,8 @@ function _update_plot_args(plt::Plot, plotattributes_in::AKW)
     end
 
     # handle colors
-    plotattributes = plt.attr
-    plt[:background_color] = plot_color(plotattributes[:background_color])
-    plt[:foreground_color] = fg_color(plotattributes)
+    plt[:background_color] = plot_color(plt.attr[:background_color])
+    plt[:foreground_color] = fg_color(plt.attr)
     color_or_nothing!(plt.attr, :background_color_outside)
 end
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -529,6 +529,7 @@ const _suppress_warnings = Set{Symbol}([
     :primary,
     :smooth,
     :relative_bbox,
+    :layout_insets,
 ])
 
 is_subplot_attr(k) = k in _all_subplot_args

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -43,10 +43,7 @@ function _before_layout_calcs(plt::Plot{GastonBackend})
     nothing
 end
 
-function _update_min_padding!(sp::Subplot{GastonBackend})
-    sp.minpad = 0mm, 0mm, 0mm, 0mm
-    nothing
-end
+_update_min_padding!(sp::Subplot{GastonBackend}) = sp.minpad = 0mm, 0mm, 0mm, 0mm
 
 function _update_plot_object(plt::Plot{GastonBackend})
     # respect the layout ratio

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -107,7 +107,7 @@ function gaston_saveopts(plt::Plot{GastonBackend})
         "fontscale $scaling lw $scaling dl $scaling",  # ps $scaling
     )
 
-    return join(saveopts, " ")
+    join(saveopts, " ")
 end
 
 function gaston_get_subplots(n, plt_subplots, layout)
@@ -122,7 +122,7 @@ function gaston_get_subplots(n, plt_subplots, layout)
             get(l.attr, :blank, false) ? nothing : plt_subplots[n += 1]
         end
     end
-    return n, sps
+    n, sps
 end
 
 function gaston_init_subplots(plt, sps)
@@ -136,7 +136,7 @@ function gaston_init_subplots(plt, sps)
             sz = max.(sz, size(sp))
         end
     end
-    return sz
+    sz
 end
 
 function gaston_init_subplot(
@@ -190,7 +190,7 @@ function gaston_multiplot_pos_size(layout, parent_xy_wh)
             end
         end
     end
-    return dat
+    dat
 end
 
 function gaston_multiplot_pos_size!(dat)
@@ -346,7 +346,7 @@ function gaston_seriesconf!(
         @warn "Gaston: $st is not implemented yet"
     end
 
-    return [join(curveconf, " "), extra...]
+    [join(curveconf, " "), extra...]
 end
 
 function gaston_parse_axes_args(
@@ -448,7 +448,7 @@ function gaston_parse_axes_args(
         )
     end
 
-    return join(axesconf, "\n")
+    join(axesconf, "\n")
 end
 
 function gaston_set_ticks!(axesconf, ticks, letter, maj_min, add)
@@ -536,7 +536,7 @@ function gaston_font(f; rot = true, align = true, color = true, scale = 1)
     align && push!(font, "$(gaston_halign(f.halign))")
     rot && push!(font, "rotate by $(f.rotation)")
     color && push!(font, "textcolor $(gaston_color(f.color))")
-    return join(font, " ")
+    join(font, " ")
 end
 
 function gaston_palette(gradient)
@@ -545,7 +545,7 @@ function gaston_palette(gradient)
     for rgba in gradient  # FIXME: naive conversion, inefficient ?
         push!(palette, "$(n += 1) $(rgba.r) $(rgba.g) $(rgba.b)")
     end
-    return '(' * join(palette, ", ") * ')'
+    '(' * join(palette, ", ") * ')'
 end
 
 function gaston_marker(marker, alpha)
@@ -564,13 +564,13 @@ function gaston_marker(marker, alpha)
     marker === :pentagon && return filled ? 15 : 14
 
     @warn "Gaston: unsupported marker $marker"
-    return 1
+    1
 end
 
 function gaston_color(col, alpha = 0)
     col = single_color(col)  # in case of gradients
     col = alphacolor(col, gaston_alpha(alpha))  # add a default alpha if non existent
-    return "rgb '#$(hex(col, :aarrggbb))'"
+    "rgb '#$(hex(col, :aarrggbb))'"
 end
 
 function gaston_linestyle(style)
@@ -584,5 +584,5 @@ end
 function gaston_enclose_tick_string(tick_string)
     findfirst("^", tick_string) === nothing && return tick_string
     base, power = split(tick_string, "^")
-    return "$base^{$power}"
+    "$base^{$power}"
 end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1073,21 +1073,24 @@ function gr_legend_pos(sp::Subplot, leg, vp)
     xaxis, yaxis = sp[:xaxis], sp[:yaxis]
     xmirror = mirrored(xaxis, :top)
     ymirror = mirrored(yaxis, :right)
-    if (s = sp[:legend_position]) isa Real
-        return gr_legend_pos(s, leg, vp)
-    elseif s isa Tuple{<:Real,Symbol}
-        s[2] === :outer || return gr_legend_pos(s[1], leg, vp)
+    if (lp = sp[:legend_position]) isa Real
+        return gr_legend_pos(lp, leg, vp)
+    elseif lp isa Tuple{<:Real,Symbol}
+        lp[2] === :outer || return gr_legend_pos(lp[1], leg, vp)
         axisclearance = [
             !ymirror * gr_axis_width(sp, yaxis),
             ymirror * gr_axis_width(sp, yaxis),
             !xmirror * gr_axis_height(sp, xaxis),
             xmirror * gr_axis_height(sp, xaxis),
         ]
-        return gr_legend_pos(s[1], leg, vp; axisclearance)
-    elseif !(s isa Symbol)
-        return gr_legend_pos(s, vp)
+        return gr_legend_pos(lp[1], leg, vp; axisclearance)
+    elseif !(lp isa Symbol)
+        return gr_legend_pos(lp, vp)
     end
-    (str = string(s)) == "best" && (str = "topright")
+    if (str = string(lp)) == "best"
+        # str = ymirror ? "topleft" : "topright"  # for twinx
+        str = "topright"
+    end
     xpos = if occursin("left", str)
         if occursin("outer", str)
             -!ymirror * gr_axis_width(sp, yaxis) - 2leg.xoffset - leg.rightw - leg.textw
@@ -1104,13 +1107,13 @@ function gr_legend_pos(sp::Subplot, leg, vp)
         vp.xmin + leg.leftw - leg.rightw - leg.textw - 2leg.xoffset
     end
     ypos = if occursin("bottom", str)
-        if s === :outerbottom
+        if lp === :outerbottom
             -leg.yoffset - leg.dy - !xmirror * gr_axis_height(sp, xaxis)
         else
             leg.yoffset + leg.h
         end + vp.ymin
     elseif occursin("top", str)
-        if s === :outertop
+        if lp === :outertop
             leg.yoffset + leg.h + xmirror * gr_axis_height(sp, xaxis)
         else
             -leg.yoffset - leg.dy

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1087,18 +1087,18 @@ function gr_legend_pos(sp::Subplot, leg, vp)
     elseif !(lp isa Symbol)
         return gr_legend_pos(lp, vp)
     end
-    if (str = string(lp)) == "best"
-        # str = ymirror ? "topleft" : "topright"  # for twinx
-        str = "topright"
+    if (leg_str = string(lp)) == "best"
+        # leg_str = ymirror ? "topleft" : "topright"  # for twinx ?
+        leg_str = "topright"
     end
-    xpos = if occursin("left", str)
-        if occursin("outer", str)
+    xpos = if occursin("left", leg_str)
+        if occursin("outer", leg_str)
             -!ymirror * gr_axis_width(sp, yaxis) - 2leg.xoffset - leg.rightw - leg.textw
         else
             leg.leftw + leg.xoffset
         end + vp.xmin
-    elseif occursin("right", str)
-        if occursin("outer", str)  # per https://github.com/jheinen/GR.jl/blob/master/src/jlgr.jl#L525
+    elseif occursin("right", leg_str)
+        if occursin("outer", leg_str)  # per https://github.com/jheinen/GR.jl/blob/master/src/jlgr.jl#L525
             leg.xoffset + leg.leftw + ymirror * gr_axis_width(sp, yaxis)
         else
             -leg.rightw - leg.textw - leg.xoffset
@@ -1106,13 +1106,13 @@ function gr_legend_pos(sp::Subplot, leg, vp)
     else
         vp.xmin + leg.leftw - leg.rightw - leg.textw - 2leg.xoffset
     end
-    ypos = if occursin("bottom", str)
+    ypos = if occursin("bottom", leg_str)
         if lp === :outerbottom
             -leg.yoffset - leg.dy - !xmirror * gr_axis_height(sp, xaxis)
         else
             leg.yoffset + leg.h
         end + vp.ymin
-    elseif occursin("top", str)
+    elseif occursin("top", leg_str)
         if lp === :outertop
             leg.yoffset + leg.h + xmirror * gr_axis_height(sp, xaxis)
         else
@@ -1189,8 +1189,8 @@ function gr_update_viewport_legend!(vp, sp, leg)
     xaxis, yaxis = sp[:xaxis], sp[:yaxis]
     xmirror = mirrored(xaxis, :top)
     ymirror = mirrored(yaxis, :right)
-    if (s = sp[:legend_position]) isa Tuple{<:Real,Symbol}
-        if s[2] === :outer
+    if (lp = sp[:legend_position]) isa Tuple{<:Real,Symbol}
+        if lp[2] === :outer
             x, y = gr_legend_pos(sp, leg, vp) # Dry run, to figure out
             if x < vp.xmin
                 vp.xmin +=
@@ -1210,7 +1210,7 @@ function gr_update_viewport_legend!(vp, sp, leg)
             end
         end
     end
-    leg_str = string(s)
+    leg_str = string(lp)
     if occursin("outer", leg_str)
         if occursin("right", leg_str)
             vp.xmax -= leg.leftw + leg.textw + leg.rightw + leg.xoffset
@@ -1227,7 +1227,7 @@ function gr_update_viewport_legend!(vp, sp, leg)
             vp.ymin += leg.h + leg.dy + leg.yoffset + !xmirror * gr_axis_height(sp, xaxis)
         end
     end
-    if s === :inline
+    if lp === :inline
         if yaxis[:mirror]
             vp.xmin += leg.w
         else

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -20,12 +20,12 @@ is_marker_supported(::InspectDRBackend, shape::Shape) = true
 #Do we avoid Map to avoid possible pre-comile issues?
 function _inspectdr_mapglyph(s::Symbol)
     s === :rect && return :square
-    return s
+    s
 end
 
 function _inspectdr_mapglyph(s::Shape)
     x, y = coords(s)
-    return InspectDR.GlyphPolyline(x, y)
+    InspectDR.GlyphPolyline(x, y)
 end
 
 # py_marker(markers::AVec) = map(py_marker, markers)
@@ -76,7 +76,7 @@ function _inspectdr_add_annotations(plot, x, y, val::PlotText)
         align = align,
     )
     InspectDR.add(plot, ann)
-    return
+    nothing
 end
 
 # ---------------------------------------------------------------------------
@@ -109,7 +109,7 @@ function _inspectdr_getaxisticks(ticks, gridlines, xfrm)
         # keep current
     end
 
-    return gridlines #keep current
+    gridlines  # keep current
 end
 
 function _inspectdr_setticks(sp::Subplot, plot, strip, xaxis, yaxis)
@@ -135,7 +135,7 @@ end
 function _inspectdr_getscale(s::Symbol, yaxis::Bool)
     #TODO: Support :asinh, :sqrt
     kwargs = yaxis ? (:tgtmajor => 8, :tgtminor => 2) : () #More grid lines on y-axis
-    return if :log2 == s
+    if :log2 == s
         InspectDR.AxisScale(:log2; kwargs...)
     elseif :log10 == s
         InspectDR.AxisScale(:log10; kwargs...)
@@ -186,7 +186,7 @@ function _create_backend_figure(plt::Plot{InspectDRBackend})
     # break link with old subplots
     foreach(sp -> sp.o = nothing, plt.subplots)
 
-    return InspecDRPlotRef(mplot, gplot)
+    InspecDRPlotRef(mplot, gplot)
 end
 
 # ---------------------------------------------------------------------------
@@ -198,7 +198,7 @@ function _initialize_subplot(plt::Plot{InspectDRBackend}, sp::Subplot{InspectDRB
     plot === nothing && return
     plot.data = []
     plot.userannot = [] #Clear old markers/text annotation/polyline "annotation"
-    return plot
+    plot
 end
 
 # ---------------------------------------------------------------------------
@@ -321,7 +321,6 @@ function _series_added(plt::Plot{InspectDRBackend}, series::Series)
     for (xi, yi, str, fnt) in EachAnn(anns, x, y)
         _inspectdr_add_annotations(plot, xi, yi, PlotText(str, fnt))
     end
-    return
 end
 
 # ---------------------------------------------------------------------------
@@ -401,7 +400,6 @@ function _inspectdr_setupsubplot(sp::Subplot{InspectDRBackend})
     l.frame_legend.fillcolor = _inspectdr_mapcolor(sp[:legend_background_color])
     #_round!() ensures values use integer spacings (looks better on screen):
     InspectDR._round!(InspectDR.autofit2font!(l, legend_width = 10.0)) #10 "em"s wide
-    return
 end
 
 # called just before updating layout bounding boxes... in case you need to prep
@@ -447,7 +445,7 @@ function _before_layout_calcs(plt::Plot{InspectDRBackend})
     end
 
     foreach(series -> _series_added(plt, series), plt.series_list)
-    return
+    nothing
 end
 
 # ----------------------------------------------------------------
@@ -491,7 +489,7 @@ function _update_plot_object(plt::Plot{InspectDRBackend})
 
     gplot.src = mplot #Ensure still references current plot
     InspectDR.refresh(gplot)
-    return
+    nothing
 end
 
 # ----------------------------------------------------------------
@@ -530,5 +528,5 @@ function _display(plt::Plot{InspectDRBackend})
         # InspectDR.refresh(gplot)
     end
     plt.o = InspecDRPlotRef(mplot, gplot)
-    return gplot
+    gplot
 end

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1216,6 +1216,7 @@ _backend_skips = Dict(
         50,  # TODO: 1D data not supported for pm3d
         60,  # :perspective projection unsupported
         62,  # fillstyle
+        63,  # un-identified bug
     ],
 )
 _backend_skips[:plotly] = _backend_skips[:plotlyjs]

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1140,6 +1140,38 @@ const _examples = PlotExample[
             plot(y .+ 1, fillrange = y, fillstyle = :/)
         end,
     ),
+    PlotExample(  # 63
+        "twinx - twiny",
+        quote
+            x = π:0.1:(2π)
+
+            kw = (; lab = "", title_loc = :left)
+
+            plot(
+                x,
+                sin.(x),
+                xaxis = "common X label",
+                yaxis = "Y label 1",
+                color = :red,
+                title = "twinx";
+                kw...,
+            )
+            p1 = plot!(twinx(), x, 2cos.(x), yaxis = "Y label 2"; kw...)
+
+            plot(
+                x,
+                cos.(x),
+                xaxis = "X label 1",
+                yaxis = "common Y label",
+                color = :red,
+                title = "twiny";
+                kw...,
+            )
+            p2 = plot!(twiny(), 2x, cos.(2x), xaxis = "X label 2"; kw...)
+
+            plot(p1, p2)
+        end,
+    ),
 ]
 
 # Some constants for PlotDocs and PlotReferenceImages

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1169,7 +1169,8 @@ const _examples = PlotExample[
             )
             p2 = plot!(twiny(), 2x, cos.(2x), xaxis = "X label 2"; kw...)
 
-            plot(p1, p2)
+            pl = plot(p1, p2)
+            pl
         end,
     ),
 ]

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -941,7 +941,7 @@ const _examples = PlotExample[
         "3D axis flip / mirror",
         :(using LinearAlgebra),
         quote
-            scalefontsizes(0.4)
+            scalefontsizes(0.5)
 
             x, y = collect(-6:0.5:10), collect(-8:0.5:8)
 
@@ -1142,10 +1142,10 @@ const _examples = PlotExample[
     ),
     PlotExample(  # 63
         "twinx - twiny",
+        "Share X or Y axis.",
         quote
-            x = π:0.1:(2π)
-
             kw = (; lab = "", title_loc = :left)
+            x = π:0.1:(2π)
 
             plot(
                 x,
@@ -1156,7 +1156,7 @@ const _examples = PlotExample[
                 title = "twinx";
                 kw...,
             )
-            p1 = plot!(twinx(), x, 2cos.(x), yaxis = "Y label 2"; kw...)
+            pl = plot!(twinx(), x, 2cos.(x), yaxis = "Y label 2"; kw...)
 
             plot(
                 x,
@@ -1167,10 +1167,9 @@ const _examples = PlotExample[
                 title = "twiny";
                 kw...,
             )
-            p2 = plot!(twiny(), 2x, cos.(2x), xaxis = "X label 2"; kw...)
+            pr = plot!(twiny(), 2x, cos.(2x), xaxis = "X label 2"; kw...)
 
-            pl = plot(p1, p2)
-            pl
+            plot(pl, pr)
         end,
     ),
 ]

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -378,6 +378,12 @@ function update_child_bboxes!(
             c == nc ? rightpad(layout) : pad_right[c],
             r == nr ? bottompad(layout) : pad_bottom[r],
         ]
+        min_child_perimeter = [
+            max(leftpad(min_child_perimeter), leftpad(inset_perim)),
+            max(toppad(min_child_perimeter), toppad(inset_perim)),
+            max(rightpad(min_child_perimeter), rightpad(inset_perim)),
+            max(bottompad(min_child_perimeter), bottompad(inset_perim)),
+        ]
 
         # recursively update the child's children
         update_child_bboxes!(child, min_child_perimeter)

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -130,7 +130,7 @@ parent_bbox(layout::AbstractLayout) = bbox(parent(layout))
 # padding(layout::AbstractLayout) = (padding_w(layout), padding_h(layout))
 
 update_position!(layout::AbstractLayout) = nothing
-update_child_bboxes!(layout::AbstractLayout, minimum_perimeter = [0mm, 0mm, 0mm, 0mm]) =
+update_child_bboxes!(layout::AbstractLayout, minimum_perimeter = [0mm, 0mm, 0mm, 0mm]; kw...) =
     nothing
 
 left(layout::AbstractLayout) = left(bbox(layout))
@@ -344,10 +344,6 @@ function update_child_bboxes!(
     layout.widths = recompute_lengths(layout.widths)
     layout.heights = recompute_lengths(layout.heights)
 
-    # normalize widths/heights so they sum to 1
-    # denom_w = sum(layout.widths)
-    # denom_h = sum(layout.heights)
-
     # we have all the data we need... lets compute the plot areas and set the bounding boxes
     for r in 1:nr, c in 1:nc
         child = layout[r, c]
@@ -372,21 +368,15 @@ function update_child_bboxes!(
 
         # this is the minimum perimeter as decided by this child's parent, so that
         # all children on this border have the same value
-        min_child_perimeter = [
-            c == 1 ? leftpad(layout) : pad_left[c],
-            r == 1 ? toppad(layout) : pad_top[r],
-            c == nc ? rightpad(layout) : pad_right[c],
-            r == nr ? bottompad(layout) : pad_bottom[r],
-        ]
-        min_child_perimeter = [
-            max(leftpad(min_child_perimeter), leftpad(inset_perim)),
-            max(toppad(min_child_perimeter), toppad(inset_perim)),
-            max(rightpad(min_child_perimeter), rightpad(inset_perim)),
-            max(bottompad(min_child_perimeter), bottompad(inset_perim)),
+        min_child_perim = [
+            max(c == 1 ? leftpad(layout) : pad_left[c],  leftpad(inset_perim)),
+            max(r == 1 ? toppad(layout) : pad_top[r], toppad(inset_perim)),
+            max(c == nc ? rightpad(layout) : pad_right[c], rightpad(inset_perim)),
+            max(r == nr ? bottompad(layout) : pad_bottom[r], bottompad(inset_perim)),
         ]
 
         # recursively update the child's children
-        update_child_bboxes!(child, min_child_perimeter)
+        update_child_bboxes!(child, min_child_perim; insets)
     end
 end
 

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -635,9 +635,9 @@ end
 
 # -------------------------------------------------------------------------
 
-"Adds a new, empty subplot overlayed on top of `sp`, with a mirrored y-axis and linked x-axis."
-function twinx(sp::Subplot)
+function twin(sp, letter)
     plt = sp.plt
+    plt[:layout_insets] = true
     plot!(
         plt,
         inset = (sp[:subplot_index], bbox(0, 0, 1, 1)),
@@ -647,14 +647,30 @@ function twinx(sp::Subplot)
         bottom_margin = sp[:bottom_margin],
     )
     twinsp = last(plt.subplots)
-    twinsp[:xaxis][:grid] = false
-    twinsp[:xaxis][:showaxis] = false
-    twinsp[:xaxis][:ticks] = :none
-    twinsp[:yaxis][:grid] = false
-    twinsp[:yaxis][:mirror] = true
+    letters = axes_letters(twinsp, letter)
+    tax, oax = map(l -> twinsp[get_attr_symbol(l, :axis)], letters)
+    tax[:grid] = false
+    tax[:showaxis] = false
+    tax[:ticks] = :none
+    oax[:grid] = false
+    oax[:mirror] = true
     twinsp[:background_color_inside] = RGBA{Float64}(0, 0, 0, 0)
-    link_axes!(sp[:xaxis], twinsp[:xaxis])
+    link_axes!(sp[get_attr_symbol(letter, :axis)], tax)
     twinsp
 end
 
+"""
+    twinx(sp)
+
+Adds a new, empty subplot overlayed on top of `sp`, with a mirrored y-axis and linked x-axis.
+"""
+twinx(sp::Subplot) = twin(sp, :x)
 twinx(plt::Plot = current()) = twinx(plt[1])
+
+"""
+    twiny(sp)
+
+Adds a new, empty subplot overlayed on top of `sp`, with a mirrored x-axis and linked y-axis.
+"""
+twiny(sp::Subplot) = twin(sp, :y)
+twiny(plt::Plot = current()) = twiny(plt[1])

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -130,8 +130,11 @@ parent_bbox(layout::AbstractLayout) = bbox(parent(layout))
 # padding(layout::AbstractLayout) = (padding_w(layout), padding_h(layout))
 
 update_position!(layout::AbstractLayout) = nothing
-update_child_bboxes!(layout::AbstractLayout, minimum_perimeter = [0mm, 0mm, 0mm, 0mm]; kw...) =
-    nothing
+update_child_bboxes!(
+    layout::AbstractLayout,
+    minimum_perimeter = [0mm, 0mm, 0mm, 0mm];
+    kw...,
+) = nothing
 
 left(layout::AbstractLayout) = left(bbox(layout))
 top(layout::AbstractLayout) = top(bbox(layout))
@@ -369,7 +372,7 @@ function update_child_bboxes!(
         # this is the minimum perimeter as decided by this child's parent, so that
         # all children on this border have the same value
         min_child_perim = [
-            max(c == 1 ? leftpad(layout) : pad_left[c],  leftpad(inset_perim)),
+            max(c == 1 ? leftpad(layout) : pad_left[c], leftpad(inset_perim)),
             max(r == 1 ? toppad(layout) : pad_top[r], toppad(inset_perim)),
             max(c == nc ? rightpad(layout) : pad_right[c], rightpad(inset_perim)),
             max(r == nr ? bottompad(layout) : pad_bottom[r], bottompad(inset_perim)),

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -140,7 +140,7 @@ function plot!(
     # TODO: replace this with proper processing from a merged user_attr KW
     # update plot args
     for p in plts
-        plt.attr = merge(p.attr, plt.attr)  # plt.attr preempts p.attr
+        plt.attr = merge(p.attr, plt.attr)  # plt.attr preempts p.attr (for `twinx`)
         plt.n += p.n
     end
     plt[:size] = last(sort(getindex.(plts, :size), by = x -> x[1] * x[2]))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -250,7 +250,10 @@ function prepare_output(plt::Plot)
     end
 
     # now another pass down, to update the bounding boxes
-    update_child_bboxes!(plt.layout; insets = plt.inset_subplots)
+    update_child_bboxes!(
+        plt.layout;
+        insets = get(plt, :layout_insets, false) ? plt.inset_subplots : (),
+    )
 
     # update those bounding boxes of inset subplots
     update_inset_bboxes!(plt)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -140,7 +140,7 @@ function plot!(
     # TODO: replace this with proper processing from a merged user_attr KW
     # update plot args
     for p in plts
-        _update_plot_args(plt, copy(p.attr))  # needed e.g. for `twinx` - `twiny`
+        plt.attr = merge(p.attr, plt.attr)  # plt.attr preempts p.attr
         plt.n += p.n
     end
     plt[:size] = last(sort(getindex.(plts, :size), by = x -> x[1] * x[2]))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -140,7 +140,7 @@ function plot!(
     # TODO: replace this with proper processing from a merged user_attr KW
     # update plot args
     for p in plts
-        # _update_plot_args(plt, copy(p.attr))
+        _update_plot_args(plt, copy(p.attr))  # needed e.g. for `twinx` - `twiny`
         plt.n += p.n
     end
     plt[:size] = last(sort(getindex.(plts, :size), by = x -> x[1] * x[2]))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -239,7 +239,6 @@ function prepare_output(plt::Plot)
     # One pass down and back up the tree to compute the minimum padding
     # of the children on the perimeter.  This is an backend callback.
     _update_min_padding!(plt.layout)
-    foreach(sp -> _update_min_padding!(sp), plt.inset_subplots)
 
     # spedific to :plot_title see _add_plot_title!
     force_minpad = get(plt, :force_minpad, ())
@@ -251,7 +250,7 @@ function prepare_output(plt::Plot)
     end
 
     # now another pass down, to update the bounding boxes
-    update_child_bboxes!(plt.layout)
+    update_child_bboxes!(plt.layout; insets = plt.inset_subplots)
 
     # update those bounding boxes of inset subplots
     update_inset_bboxes!(plt)

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -67,22 +67,20 @@ function image_comparison_tests(
 
     reffn = reference_file(pkg, idx, Plots._current_plots_version)
     newfn = joinpath(reference_path(pkg, Plots._current_plots_version), "ref$idx.png")
-    @debug example.exprs
 
-    # test function
-    func = fn -> Base.eval(TESTS_MODULE, quote
-        Plots._debugMode[] = $debug
+    ex = quote
+        Plots.debugplots($debug)
         backend($(QuoteNode(pkg)))
         theme(:default)
-        default(show = false, reuse = true)
         rng = StableRNG(Plots.PLOTS_SEED)
         $(something(example.imports, :()))
         $(replace_rand(example.exprs))
         png($fn)
-    end)
+    end
+    @debug ex
 
     test_images(
-        VisualTest(func, reffn),
+        VisualTest(fn -> Base.eval(TESTS_MODULE, ex), reffn),
         newfn = newfn,
         popup = popup,
         sigma = sigma,

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -1,7 +1,7 @@
 is_ci() = get(ENV, "CI", "false") == "true"
 ci_tol() =
     if Sys.islinux()
-        "1e-4"
+        "5e-4"
     elseif Sys.isapple()
         "1e-3"
     else

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -1,7 +1,15 @@
 is_ci() = get(ENV, "CI", "false") == "true"
+ci_tol() =
+    if Sys.islinux()
+        "1e-4"
+    elseif Sys.isapple()
+        "1e-3"
+    else
+        "1e-2"
+    end
 
 const TESTS_MODULE = Module(:PlotsTestsModule)
-const PLOTS_IMG_TOL = parse(Float64, get(ENV, "PLOTS_IMG_TOL", is_ci() ? "2e-3" : "1e-5"))
+const PLOTS_IMG_TOL = parse(Float64, get(ENV, "PLOTS_IMG_TOL", is_ci() ? ci_tol() : "1e-5"))
 
 Base.eval(TESTS_MODULE, :(using Random, StableRNGs, Plots))
 

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -68,19 +68,19 @@ function image_comparison_tests(
     reffn = reference_file(pkg, idx, Plots._current_plots_version)
     newfn = joinpath(reference_path(pkg, Plots._current_plots_version), "ref$idx.png")
 
-    ex = quote
+    imports = something(example.imports, :())
+    exprs = quote
         Plots.debugplots($debug)
         backend($(QuoteNode(pkg)))
         theme(:default)
         rng = StableRNG(Plots.PLOTS_SEED)
-        $(something(example.imports, :()))
         $(replace_rand(example.exprs))
-        png($fn)
     end
-    @debug ex
+    @debug imports exprs
 
+    func = fn -> Base.eval.(Ref(TESTS_MODULE), (imports, exprs, :(png($fn))))
     test_images(
-        VisualTest(fn -> Base.eval(TESTS_MODULE, ex), reffn),
+        VisualTest(func, reffn),
         newfn = newfn,
         popup = popup,
         sigma = sigma,


### PR DESCRIPTION
Fix `twinx` right padding, as seen in https://github.com/JuliaPlots/Plots.jl/issues/4325 example.

Inset plots (used by `twinx` and `twiny`) are now used to compute the total layout padding.
For now (as of caution), this is only activated if `plt[:layout_insets] = true`, which is set by `twinx` or `twiny`.

Add and export `twiny`.

New example `63`, using both `twinx` and `twiny`:
![ref63](https://user-images.githubusercontent.com/13423344/199299238-27aae8af-a4cb-40da-8218-86dc1cfa5d51.png)

The ref images have been updated to use the default `Plots` size, they were to small for debugging before.

Fix https://github.com/JuliaPlots/Plots.jl/issues/2579.
Fix https://github.com/JuliaPlots/Plots.jl/issues/2218.
Fix https://github.com/JuliaPlots/Plots.jl/issues/3210.
Fix https://github.com/JuliaPlots/Plots.jl/issues/2636.
Supersedes https://github.com/JuliaPlots/Plots.jl/pull/3532.