### PR TITLE
`unicodeplots`: transpose `surfaceplot` z - support `xflip` and `yflip`

### DIFF
--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -105,6 +105,8 @@ function _before_layout_calcs(plt::Plot{UnicodePlotsBackend})
             width = width,
             xscale = xaxis[:scale],
             yscale = yaxis[:scale],
+            xflip = xaxis[:flip],
+            yflip = yaxis[:flip],
             border = border,
             xlim = xlim,
             ylim = ylim,

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -222,7 +222,8 @@ function addUnicodeSeries!(
             zscale = zscale,
             lines = lines,
         )
-        return UnicodePlots.surfaceplot(x, y, Array(series[:z]); kw...)
+        # NOTE: inconsistency between `contourplot` and `surfaceplot`
+        return UnicodePlots.surfaceplot(y, x, transpose(Array(series[:z])); kw...)
     elseif st === :mesh3d
         return UnicodePlots.lineplot!(
             up,


### PR DESCRIPTION
- transpose `surfaceplot` arguments (different convention in `UnicodePlots` do adjust behaviour to e.g. `GR`);
- support `xflip` and `yflip`.

The following was inconsistent:
```julia
julia> using Plots; unicodeplots()
julia> x = -2:0.2:2;
julia> y = -3:0.2:1;
julia> z = (x, y) -> 10x * exp(-x^2 - y^2);
julia> surface(x, y, z)
julia> contour(x, y, z)
```

In plain `UnicodePlots`, this was consistent:
```julia
julia> using UnicodePlots
julia> x = -2:0.2:2;
julia> y = -3:0.2:1;
julia> z = (x, y) -> 10x * exp(-x^2 - y^2);
julia> surfaceplot(x, y, z; azimuth=-60, elevation=30)
julia> contourplot(x, y, z; levels=10)
```