### PR TITLE
`gr`: support horizontal legends

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -995,7 +995,7 @@ function gr_add_legend(sp, leg, viewport_area)
             gr_set_font(legendtitlefont(sp), sp; halign = :center, valign = :center)
             deb && gr_legend_bbox(xpos, ypos, leg)
             if vertical
-                gr_text(xpos - 0.03 + 0.5leg.w, ypos, string(ttl))
+                gr_text(xpos - 1.5leg.base_factor + 0.5leg.w, ypos, string(ttl))
                 ypos -= leg.dy
             else
                 gr_text(xpos, ypos, string(ttl))
@@ -1234,7 +1234,7 @@ function gr_update_viewport_legend!(vp, sp, leg)
         yoff = if leg.vertical
             leg.h + leg.dy + leg.yoffset
         else
-            leg.topp + leg.texth + leg.bottomp + leg.yoffset
+            leg.pad + leg.texth + leg.pad + leg.yoffset
         end
         if occursin("right", leg_str)
             vp.xmax -= xoff

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1144,7 +1144,7 @@ const gr_legend_marker_to_line_factor = Ref(2.0)
 
 function gr_get_legend_geometry(vp, sp)
     textw = texth = 0.0
-    entries = 0
+    entries = nseries = 0
     vertical = (legend_column = sp[:legend_column]) == 1
     has_title = false
     if sp[:legend_position] !== :none
@@ -1166,11 +1166,15 @@ function gr_get_legend_geometry(vp, sp)
             (l, r), (b, t) = extrema.(gr_inqtext(0, 0, string(series[:label])))
             texth = max(texth, t - b)
             textw = max(textw, r - l)  # holds text width right now
-            entries += 1
+            nseries += 1
         end
         GR.setscale(GR.OPTION_X_LOG)
         GR.selntran(1)
         GR.restorestate()
+    end
+    entries += nseries
+    if !vertical && legend_column > 0 && legend_column != nseries
+        @warn "legend_column=$legend_column is not compatible with n°series=$nseries"
     end
 
     base_factor = width(vp) / 45  # determines legend box base width (arbitrarily based on `width`)
@@ -1253,14 +1257,10 @@ function gr_update_viewport_legend!(vp, sp, leg)
         end
     end
     if lp === :inline
-        if leg.vertical
-            if yaxis[:mirror]
-                vp.xmin += leg.w
-            else
-                vp.xmax -= leg.w
-            end
+        if yaxis[:mirror]
+            vp.xmin += leg.w
         else
-            # FIXME: update these when horizontal
+            vp.xmax -= leg.w
         end
     end
     nothing

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1251,16 +1251,8 @@ function gr_update_viewport_legend!(vp, sp, leg)
         string(lp)
     end
     if occursin("outer", leg_str)
-        xoff = if leg.vertical
-            leg.pad + leg.span + leg.textw + leg.pad + leg.xoffset
-        else
-            leg.w + leg.dx + leg.xoffset
-        end
-        yoff = if leg.vertical
-            leg.h + leg.dy + leg.yoffset
-        else
-            leg.pad + leg.span + leg.texth + leg.pad + leg.yoffset
-        end
+        xoff = leg.xoffset + leg.w + leg.pad + leg.span + leg.pad
+        yoff = leg.yoffset + leg.h + leg.dy
         if occursin("right", leg_str)
             vp.xmax -= xoff
         elseif occursin("left", leg_str)
@@ -1311,7 +1303,6 @@ gr_set_window(sp, vp) =
         else
             true
         end
-
         if x_max > x_min && y_max > y_min && zok
             scaleop = 0
             sp[:xaxis][:scale] === :log10 && (scaleop |= GR.OPTION_X_LOG)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1044,7 +1044,7 @@ function gr_add_legend(sp, leg, viewport_area)
                 gr_set_transparency(lc, get_linealpha(series))
                 max_markersize = leg.base_markersize
                 xs = xpos .+ [lft, rgt]
-                ys = ypos .+ (filled ? [bot, top] : [0, 0])
+                ys = ypos .+ (filled ? [top, top] : [0, 0])
                 GR.polyline(xs, ys)
             end
 
@@ -1137,7 +1137,7 @@ function gr_legend_pos(sp::Subplot, leg, vp)
     xpos, ypos
 end
 
-const gr_legend_marker_to_line_factor = Ref(8.0)
+const gr_legend_marker_to_line_factor = Ref(2.0)
 
 function gr_get_legend_geometry(vp, sp)
     textw = texth = 0.0
@@ -1190,7 +1190,7 @@ function gr_get_legend_geometry(vp, sp)
     # We are trying to get markers to not be larger than half the line length. 
     # 1 / leg.dy translates base_factor to line length units (important in the context of size kwarg)
     # gr_legend_marker_to_line_factor is an empirical constant to translate between line length unit and marker size unit
-    base_markersize = gr_legend_marker_to_line_factor[] * base_factor / dy  # NOTE: arbitrarily based on horizontal measures !
+    base_markersize = gr_legend_marker_to_line_factor[] * span / dy  # NOTE: arbitrarily based on horizontal measures !
 
     (
         xoffset = width(vp) / 30,

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -989,11 +989,10 @@ function gr_add_legend(sp, leg, viewport_area)
         if (ttl = sp[:legend_title]) !== nothing
             gr_set_font(legendtitlefont(sp), sp; halign = :center, valign = :center)
             _debugMode[] && gr_legend_bbox(xpos, ypos, leg)
+            gr_text(xpos - leg.pad - leg.space + 0.5leg.textw, ypos, string(ttl))
             if vertical
-                gr_text(xpos - leg.pad - leg.space + 0.5leg.w, ypos, string(ttl))
                 ypos -= leg.dy
             else
-                gr_text(xpos, ypos, string(ttl))
                 xpos += leg.dx
             end
         end
@@ -1108,7 +1107,7 @@ function gr_legend_pos(sp::Subplot, leg, vp)
             -leg.pad - leg.w - leg.xoffset
         end
     else
-        vp.xmin + 0.5width(vp) + leg.span - 2leg.xoffset
+        vp.xmin + 0.5width(vp) - 0.5leg.w + leg.xoffset  # + 0.5(leg.w + leg.span)
     end
     ypos = if occursin("bottom", leg_str)
         vp.ymin + if lp === :outerbottom
@@ -1124,7 +1123,7 @@ function gr_legend_pos(sp::Subplot, leg, vp)
         end
     else
         # adding min y to shift legend pos to correct graph (#2377)
-        vp.ymin + 0.5height(vp) + 0.5leg.h
+        vp.ymin + 0.5height(vp) + 0.5leg.h - 2leg.yoffset
     end
     xpos, ypos
 end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1107,16 +1107,16 @@ function gr_legend_pos(sp::Subplot, leg, vp)
         vp.xmin + if occursin("outer", leg_str)
             -leg.pad - leg.w - 2leg.xoffset - !ymirror * gr_axis_width(sp, yaxis)
         else
-            leg.pad + leg.xoffset
+            leg.pad + leg.span + leg.xoffset
         end
     elseif occursin("right", leg_str)  # default / best
         vp.xmax + if occursin("outer", leg_str)  # per github.com/jheinen/GR.jl/blob/master/src/jlgr.jl#L525
-            leg.xoffset + leg.pad + ymirror * gr_axis_width(sp, yaxis)
+            leg.xoffset + leg.pad + leg.span + ymirror * gr_axis_width(sp, yaxis)
         else
             -leg.pad - leg.w - leg.xoffset
         end
     else
-        vp.xmin + 0.5width(vp) + leg.pad - leg.pad - leg.w - 2leg.xoffset
+        vp.xmin + 0.5width(vp) + leg.span - 2leg.xoffset
     end
     ypos = if occursin("bottom", leg_str)
         vp.ymin + if lp === :outerbottom
@@ -1173,7 +1173,7 @@ function gr_get_legend_geometry(vp, sp)
     base_factor = width(vp) / 45  # determines legend box base width (arbitrarily based on `width`)
 
     # legend box conventions ref(1)
-    #  ____________________________
+    #  ___________________________
     # |<pad> <span>   <text> <pad>|
     # |      ---o--  ⋅  y1        |
     # |______________↑____________|
@@ -1195,7 +1195,7 @@ function gr_get_legend_geometry(vp, sp)
     (
         xoffset = width(vp) / 30,
         yoffset = height(vp) / 30,
-        w = vertical ? dx : dx * entries - span,  # NOTE: `- span`, since span `joins` labels
+        w = vertical ? dx : dx * entries - span,  # NOTE: substract 1 x `span`, since it joins labels
         h = vertical ? dy * entries : dy,
         base_markersize,
         base_factor,
@@ -1227,14 +1227,14 @@ function gr_update_viewport_legend!(vp, sp, leg)
     end
     if occursin("outer", leg_str)
         xoff = if leg.vertical
-            leg.pad + leg.textw + leg.pad + leg.xoffset
+            leg.pad + leg.span + leg.textw + leg.pad + leg.xoffset
         else
             leg.w + leg.dx + leg.xoffset
         end
         yoff = if leg.vertical
             leg.h + leg.dy + leg.yoffset
         else
-            leg.pad + leg.texth + leg.pad + leg.yoffset
+            leg.pad + leg.span + leg.texth + leg.pad + leg.yoffset
         end
         if occursin("right", leg_str)
             vp.xmax -= xoff

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1099,18 +1099,18 @@ function gr_legend_pos(sp::Subplot, leg, vp)
     end
     xpos = if occursin("left", leg_str)
         vp.xmin + if occursin("outer", leg_str)
-            -leg.pad - leg.w - 2leg.xoffset - !ymirror * gr_axis_width(sp, yaxis)
+            -leg.pad - leg.w - leg.xoffset - !ymirror * gr_axis_width(sp, yaxis)
         else
             leg.pad + leg.span + leg.xoffset
         end
     elseif occursin("right", leg_str)  # default / best
         vp.xmax + if occursin("outer", leg_str)  # per github.com/jheinen/GR.jl/blob/master/src/jlgr.jl#L525
-            leg.xoffset + leg.pad + leg.span + ymirror * gr_axis_width(sp, yaxis)
+            leg.pad + leg.span + leg.xoffset + ymirror * gr_axis_width(sp, yaxis)
         else
             -leg.pad - leg.w - leg.xoffset
         end
     else
-        vp.xmin + 0.5width(vp) - 0.5leg.w + leg.xoffset  # + 0.5(leg.w + leg.span)
+        vp.xmin + 0.5width(vp) - 0.5leg.w + leg.xoffset
     end
     ypos = if occursin("bottom", leg_str)
         vp.ymin + if lp === :outerbottom

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1131,10 +1131,8 @@ function gr_legend_pos(sp::Subplot, leg, vp)
     xpos, ypos
 end
 
-gr_legend_pos(v::NTuple{2,Real}, vp) = (
-    vp.xmin + v[1] * (vp.xmax - vp.xmin),
-    vp.ymin + v[2] * (vp.ymax - vp.ymin)
-)
+gr_legend_pos(v::NTuple{2,Real}, vp) =
+    (vp.xmin + v[1] * (vp.xmax - vp.xmin), vp.ymin + v[2] * (vp.ymax - vp.ymin))
 
 function gr_legend_pos(theta::Real, leg, vp; axisclearance = nothing)
     if isnothing(axisclearance)  # inner

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1126,7 +1126,7 @@ function gr_legend_pos(sp::Subplot, leg, vp)
         end
     else
         # adding min y to shift legend pos to correct graph (#2377)
-        vp.ymin + 0.5height(vp) + 0.5leg.h - 2leg.yoffset
+        vp.ymin + 0.5height(vp) + 0.5leg.h - leg.yoffset
     end
     xpos, ypos
 end

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1174,8 +1174,20 @@ const _examples = PlotExample[
         "Horizontal or vertical legends, at different locations.",
         quote
             with(scalefonts=0.5) do
-                leg_plots(prefix; kw...) = [plot(0:1; marker=:circle, leg_title="leg", leg=Symbol(prefix, leg), kw...) for leg in (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)]
-                plot(leg_plots("")..., leg_plots("outer", legend_column=-1)...; layout=(4, 3))
+                leg_plots(; kw...) =
+                    [plot(0:1; marker=:circle, leg_title="leg", leg, kw...) for leg in (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)]
+                plot(leg_plots()..., leg_plots(legend_column=-1)...; layout=(4, 3))
+            end
+        end,
+    ),
+    PlotExample(  # 64
+        "Outer legend positions",
+        "Horizontal or vertical legends, at different locations.",
+        quote
+            with(scalefonts=0.5) do
+                leg_plots(; kw...) =
+                    [plot(0:1; marker=:circle, leg_title="leg", leg=Symbol("outer", leg), kw...) for leg in (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)]
+                plot(leg_plots()..., leg_plots(legend_column=-1)...; layout=(4, 3))
             end
         end,
     ),

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -128,9 +128,8 @@ const _examples = PlotExample[
         series.
         """,
         quote
-            ys = Vector[rand(10), rand(20)]
             plot(
-                ys,
+                [rand(10), rand(20)],
                 color = [:black :orange],
                 line = (:dot, 4),
                 marker = ([:hex :d], 12, 0.8, Plots.stroke(3, :gray)),
@@ -941,11 +940,17 @@ const _examples = PlotExample[
         "3D axis flip / mirror",
         :(using LinearAlgebra),
         quote
-            with(scalefonts=0.5) do
+            with(scalefonts = 0.5) do
                 x, y = collect(-6:0.5:10), collect(-8:0.5:8)
 
                 args = x, y, (x, y) -> sinc(norm([x, y]) / π)
-                kw = (xlabel = "x", ylabel = "y", zlabel = "z", grid = true, minorgrid = true)
+                kw = (
+                    xlabel = "x",
+                    ylabel = "y",
+                    zlabel = "z",
+                    grid = true,
+                    minorgrid = true,
+                )
 
                 plots = [wireframe(args..., title = "wire"; kw...)]
 
@@ -1173,10 +1178,12 @@ const _examples = PlotExample[
         "Legend positions",
         "Horizontal or vertical legends, at different locations.",
         quote
-            with(scalefonts=0.5) do
-                leg_plots(; kw...) =
-                    [plot(0:1; marker=:circle, leg_title="leg", leg, kw...) for leg in (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)]
-                plot(leg_plots()..., leg_plots(legend_column=-1)...; layout=(4, 3))
+            with(scalefonts = 0.5) do
+                leg_plots(; kw...) = [
+                    plot(0:1; marker = :circle, leg_title = "leg", leg, kw...) for
+                    leg in (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)
+                ]
+                plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (4, 3))
             end
         end,
     ),
@@ -1184,10 +1191,18 @@ const _examples = PlotExample[
         "Outer legend positions",
         "Horizontal or vertical legends, at different locations.",
         quote
-            with(scalefonts=0.5) do
-                leg_plots(; kw...) =
-                    [plot(0:1; marker=:circle, leg_title="leg", leg=Symbol("outer", leg), kw...) for leg in (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)]
-                plot(leg_plots()..., leg_plots(legend_column=-1)...; layout=(4, 3))
+            with(scalefonts = 0.5) do
+                leg_plots(; kw...) = [
+                    plot(
+                        0:1;
+                        marker = :circle,
+                        leg_title = "leg",
+                        leg = Symbol("outer", leg),
+                        kw...,
+                    ) for leg in
+                    (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)
+                ]
+                plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (4, 3))
             end
         end,
     ),

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1163,7 +1163,7 @@ const _examples = PlotExample[
             plot(pl, pr)
         end,
     ),
-    PlotExample(  # 63
+    PlotExample(  # 64
         "Legend positions",
         "Horizontal or vertical legends, at different locations.",
         quote
@@ -1182,7 +1182,7 @@ const _examples = PlotExample[
             end
         end,
     ),
-    PlotExample(  # 64
+    PlotExample(  # 65
         "Outer legend positions",
         "Horizontal or vertical legends, at different locations.",
         quote
@@ -1253,6 +1253,8 @@ _backend_skips = Dict(
         56,  # barplots
         62,  # fillstyle
         63,  # twin axes unsupported
+        64,  # legend pos unsupported
+        65,  # legend pos unsupported
     ],
     :gaston => [
         2,   # animations

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1180,8 +1180,15 @@ const _examples = PlotExample[
         quote
             with(scalefonts = 0.5) do
                 leg_plots(; kw...) = [
-                    plot(0:1; marker = :circle, leg_title = "leg", leg, kw...) for
-                    leg in (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)
+                    plot(
+                        0:1,
+                        [0:1, reverse(0:1)];
+                        marker = :circle,
+                        leg_title = "leg",
+                        leg,
+                        kw...,
+                    ) for leg in
+                    (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)
                 ]
                 plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (4, 3))
             end
@@ -1194,7 +1201,8 @@ const _examples = PlotExample[
             with(scalefonts = 0.5) do
                 leg_plots(; kw...) = [
                     plot(
-                        0:1;
+                        0:1,
+                        [0:1, reverse(0:1)];
                         marker = :circle,
                         leg_title = "leg",
                         leg = Symbol("outer", leg),

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -941,51 +941,48 @@ const _examples = PlotExample[
         "3D axis flip / mirror",
         :(using LinearAlgebra),
         quote
-            scalefontsizes(0.5)
+            with(scalefonts=0.5) do
+                x, y = collect(-6:0.5:10), collect(-8:0.5:8)
 
-            x, y = collect(-6:0.5:10), collect(-8:0.5:8)
+                args = x, y, (x, y) -> sinc(norm([x, y]) / π)
+                kw = (xlabel = "x", ylabel = "y", zlabel = "z", grid = true, minorgrid = true)
 
-            args = x, y, (x, y) -> sinc(norm([x, y]) / π)
-            kw = (xlabel = "x", ylabel = "y", zlabel = "z", grid = true, minorgrid = true)
+                plots = [wireframe(args..., title = "wire"; kw...)]
 
-            plots = [wireframe(args..., title = "wire"; kw...)]
+                for ax in (:x, :y, :z)
+                    push!(
+                        plots,
+                        wireframe(
+                            args...,
+                            title = "wire-flip-$ax",
+                            xflip = ax === :x,
+                            yflip = ax === :y,
+                            zflip = ax === :z;
+                            kw...,
+                        ),
+                    )
+                end
 
-            for ax in (:x, :y, :z)
-                push!(
-                    plots,
-                    wireframe(
-                        args...,
-                        title = "wire-flip-$ax",
-                        xflip = ax === :x,
-                        yflip = ax === :y,
-                        zflip = ax === :z;
-                        kw...,
-                    ),
+                for ax in (:x, :y, :z)
+                    push!(
+                        plots,
+                        wireframe(
+                            args...,
+                            title = "wire-mirror-$ax",
+                            xmirror = ax === :x,
+                            ymirror = ax === :y,
+                            zmirror = ax === :z;
+                            kw...,
+                        ),
+                    )
+                end
+
+                plot(
+                    plots...,
+                    layout = (@layout [_ ° _; ° ° °; ° ° °]),
+                    margin = 0Plots.px,
                 )
             end
-
-            for ax in (:x, :y, :z)
-                push!(
-                    plots,
-                    wireframe(
-                        args...,
-                        title = "wire-mirror-$ax",
-                        xmirror = ax === :x,
-                        ymirror = ax === :y,
-                        zmirror = ax === :z;
-                        kw...,
-                    ),
-                )
-            end
-
-            plt = plot(
-                plots...,
-                layout = (@layout [_ ° _; ° ° °; ° ° °]),
-                margin = 0Plots.px,
-            )
-
-            resetfontsizes()
-            plt
         end,
     ),
     PlotExample( # 56
@@ -1170,6 +1167,16 @@ const _examples = PlotExample[
             pr = plot!(twiny(), 2x, cos.(2x), xaxis = "X label 2"; kw...)
 
             plot(pl, pr)
+        end,
+    ),
+    PlotExample(  # 63
+        "Legend positions",
+        "Horizontal or vertical legends, at different locations.",
+        quote
+            with(scalefonts=0.5) do
+                leg_plots(prefix; kw...) = [plot(0:1; marker=:circle, leg_title="leg", leg=Symbol(prefix, leg), kw...) for leg in (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)]
+                plot(leg_plots("")..., leg_plots("outer", legend_column=-1)...; layout=(4, 3))
+            end
         end,
     ),
 ]

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1179,17 +1179,17 @@ const _examples = PlotExample[
         "Horizontal or vertical legends, at different locations.",
         quote
             with(scalefonts = 0.5) do
-                leg_plots(; kw...) = [
-                    plot(
+                leg_plots(; kw...) = map(
+                    leg -> plot(
                         0:1,
                         [0:1, reverse(0:1)];
                         marker = :circle,
                         leg_title = "leg",
                         leg,
                         kw...,
-                    ) for leg in
-                    (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)
-                ]
+                    ),
+                    (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright),
+                )
                 plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (4, 3))
             end
         end,
@@ -1199,17 +1199,17 @@ const _examples = PlotExample[
         "Horizontal or vertical legends, at different locations.",
         quote
             with(scalefonts = 0.5) do
-                leg_plots(; kw...) = [
-                    plot(
+                leg_plots(; kw...) = map(
+                    leg -> plot(
                         0:1,
                         [0:1, reverse(0:1)];
                         marker = :circle,
                         leg_title = "leg",
                         leg = Symbol("outer", leg),
                         kw...,
-                    ) for leg in
-                    (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright)
-                ]
+                    ),
+                    (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright),
+                )
                 plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (4, 3))
             end
         end,

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1167,18 +1167,19 @@ const _examples = PlotExample[
         "Legend positions",
         "Horizontal or vertical legends, at different locations.",
         quote
-            with(scalefonts = 0.5) do
+            with(scalefonts = 0.4) do
                 leg_plots(; kw...) = map(
                     leg -> plot(
                         [0:1, reverse(0:1)];
                         marker = :circle,
-                        leg_title = "leg",
+                        ticks = :none,
+                        leg_title = leg,
                         leg,
                         kw...,
                     ),
-                    (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright),
+                    (:topleft, :top, :topright, :left, :inside, :right, :bottomleft, :bottom, :bottomright),
                 )
-                plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (4, 3))
+                plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (6, 3))
             end
         end,
     ),
@@ -1186,18 +1187,18 @@ const _examples = PlotExample[
         "Outer legend positions",
         "Horizontal or vertical legends, at different locations.",
         quote
-            with(scalefonts = 0.5) do
+            with(scalefonts = 0.4) do
                 leg_plots(; kw...) = map(
                     leg -> plot(
                         [0:1, reverse(0:1)];
                         marker = :circle,
                         leg_title = "leg",
-                        leg = Symbol("outer", leg),
+                        leg = leg isa Symbol ? Symbol(:outer, leg) : :none,
                         kw...,
                     ),
-                    (:topleft, :top, :topright, :bottomleft, :bottom, :bottomright),
+                    (:topleft, :top, :topright, :left, nothing, :right, :bottomleft, :bottom, :bottomright),
                 )
-                plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (4, 3))
+                plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (6, 3))
             end
         end,
     ),

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -155,7 +155,7 @@ const _examples = PlotExample[
         quote
             linetypes = [:path :steppre :steppost :sticks :scatter]
             n = length(linetypes)
-            x = Vector[sort(rand(20)) for i in 1:n]
+            x = map(_ -> sort(rand(20)), 1:n)
             y = rand(20, n)
             plot(x, y, line = (linetypes, 3), lab = map(string, linetypes), ms = 15)
         end,
@@ -168,10 +168,8 @@ const _examples = PlotExample[
                 [:solid, :dash, :dot, :dashdot, :dashdotdot],
             )
             styles = reshape(styles, 1, length(styles)) # Julia 0.6 unfortunately gives an error when transposing symbol vectors
-            n = length(styles)
-            y = cumsum(randn(20, n), dims = 1)
             plot(
-                y,
+                cumsum(randn(20, length(styles)), dims = 1),
                 line = (5, styles),
                 label = map(string, styles),
                 legendtitle = "linestyle",
@@ -346,11 +344,9 @@ const _examples = PlotExample[
                 (0.2, 0.2),
                 (-0.2, -0.6),
             ]
-            x = 0.1:0.2:0.9
-            y = 0.7 * rand(5) .+ 0.15
             plot(
-                x,
-                y,
+                0.1:0.2:0.9,
+                0.7rand(5) .+ 0.15,
                 line = (3, :dash, :lightblue),
                 marker = (Shape(verts), 30, RGBA(0, 0, 0, 0.2)),
                 bg = :pink,
@@ -392,12 +388,10 @@ const _examples = PlotExample[
         quote
             n = 100
             ts = range(0, stop = 8π, length = n)
-            x = ts .* map(cos, ts)
-            y = 0.1ts .* map(sin, ts)
             z = 1:n
             plot(
-                x,
-                y,
+                ts .* map(cos, ts),
+                0.1ts .* map(sin, ts),
                 z,
                 zcolor = reverse(z),
                 m = (10, 0.8, :blues, Plots.stroke(0)),
@@ -583,8 +577,7 @@ const _examples = PlotExample[
         quote
             Random.seed!(111)
             tickers = ["IBM", "Google", "Apple", "Intel"]
-            N = 10
-            D = length(tickers)
+            N, D = 10, length(tickers)
             weights = rand(N, D)
             weights ./= sum(weights, dims = 2)
             returns = sort!((1:N) + D * randn(N))
@@ -693,12 +686,7 @@ const _examples = PlotExample[
     PlotExample( # 43
         "Heatmap with DateTime axis",
         :(using Dates),
-        quote
-            z = rand(5, 5)
-            x = DateTime.(2016:2020)
-            y = 1:5
-            heatmap(x, y, z)
-        end,
+        :(heatmap(DateTime.(2016:2020), 1:5, rand(5, 5))),
     ),
     PlotExample( # 44
         "Linked axes",
@@ -840,17 +828,18 @@ const _examples = PlotExample[
     PlotExample( # 50
         "3D surface with axis guides",
         quote
-            func(x, a) = 1 / x + a * x^2
             xs = collect(0.1:0.05:2.0)
-            as = collect(0.2:0.1:2.0)
+            ys = collect(0.2:0.1:2.0)
 
-            x_grid = [x for x in xs for y in as]
-            a_grid = [y for x in xs for y in as]
+            X = [x for x in xs for _ in ys]
+            Y = [y for _ in xs for y in ys]
+
+            surf = (x, y) -> 1 / x + y * x^2
 
             plot(
-                x_grid,
-                a_grid,
-                func.(x_grid, a_grid),
+                X,
+                Y,
+                surf.(X, Y),
                 st = :surface,
                 xlabel = "longer xlabel",
                 ylabel = "longer ylabel",
@@ -889,9 +878,9 @@ const _examples = PlotExample[
             y = vec([sin(θ) * sin(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θs)])
             z = vec([cos(θ) for (ϕ, θ) in Iterators.product(ϕs, θs)])
 
-            u = 0.1 * vec([sin(θ) * cos(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
-            v = 0.1 * vec([sin(θ) * sin(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
-            w = 0.1 * vec([cos(θ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
+            u = 0.1vec([sin(θ) * cos(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
+            v = 0.1vec([sin(θ) * sin(ϕ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
+            w = 0.1vec([cos(θ) for (ϕ, θ) in Iterators.product(ϕs, θqs)])
 
             quiver(x, y, z, quiver = (u, v, w))
         end,
@@ -1181,7 +1170,6 @@ const _examples = PlotExample[
             with(scalefonts = 0.5) do
                 leg_plots(; kw...) = map(
                     leg -> plot(
-                        0:1,
                         [0:1, reverse(0:1)];
                         marker = :circle,
                         leg_title = "leg",
@@ -1201,7 +1189,6 @@ const _examples = PlotExample[
             with(scalefonts = 0.5) do
                 leg_plots(; kw...) = map(
                     leg -> plot(
-                        0:1,
                         [0:1, reverse(0:1)];
                         marker = :circle,
                         leg_title = "leg",

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1192,6 +1192,7 @@ const _examples = PlotExample[
                     leg -> plot(
                         [0:1, reverse(0:1)];
                         marker = :circle,
+                        ticks = :none,
                         leg_title = "leg",
                         leg = leg isa Symbol ? Symbol(:outer, leg) : :none,
                         kw...,

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1167,18 +1167,30 @@ const _examples = PlotExample[
         "Legend positions",
         "Horizontal or vertical legends, at different locations.",
         quote
-            with(scalefonts = 0.4) do
-                leg_plots(; kw...) = map(
-                    leg -> plot(
-                        [0:1, reverse(0:1)];
-                        marker = :circle,
-                        ticks = :none,
-                        leg_title = leg,
-                        leg,
-                        kw...,
-                    ),
-                    (:topleft, :top, :topright, :left, :inside, :right, :bottomleft, :bottom, :bottomright),
-                )
+            legs = (
+                :topleft,
+                :top,
+                :topright,
+                :left,
+                :inside,
+                :right,
+                :bottomleft,
+                :bottom,
+                :bottomright,
+            )
+            leg_plots(; kw...) = map(
+                leg -> plot(
+                    [0:1, reverse(0:1)];
+                    marker = :circle,
+                    ticks = :none,
+                    leg_title = leg,
+                    leg,
+                    kw...,
+                ),
+                legs,
+            )
+            w, h = Plots._plot_defaults[:size]
+            with(scalefonts = 0.5, size = (2w, 2h)) do
                 plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (6, 3))
             end
         end,
@@ -1187,18 +1199,30 @@ const _examples = PlotExample[
         "Outer legend positions",
         "Horizontal or vertical legends, at different locations.",
         quote
-            with(scalefonts = 0.4) do
-                leg_plots(; kw...) = map(
-                    leg -> plot(
-                        [0:1, reverse(0:1)];
-                        marker = :circle,
-                        ticks = :none,
-                        leg_title = "leg",
-                        leg = leg isa Symbol ? Symbol(:outer, leg) : :none,
-                        kw...,
-                    ),
-                    (:topleft, :top, :topright, :left, nothing, :right, :bottomleft, :bottom, :bottomright),
-                )
+            legs = (
+                :topleft,
+                :top,
+                :topright,
+                :left,
+                nothing,
+                :right,
+                :bottomleft,
+                :bottom,
+                :bottomright,
+            )
+            leg_plots(; kw...) = map(
+                leg -> plot(
+                    [0:1, reverse(0:1)];
+                    marker = :circle,
+                    ticks = :none,
+                    leg_title = leg,
+                    leg = leg isa Symbol ? Symbol(:outer, leg) : :none,
+                    kw...,
+                ),
+                legs,
+            )
+            w, h = Plots._plot_defaults[:size]
+            with(scalefonts = 0.5, size = (2w, 2h)) do
                 plot(leg_plots()..., leg_plots(legend_column = -1)...; layout = (6, 3))
             end
         end,

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -52,12 +52,8 @@ function bbox_to_pcts(bb::BoundingBox, figw, figh, flipy = true)
     mms ./ Float64[figw.value, figh.value, figw.value, figh.value]
 end
 
-function Base.show(io::IO, bbox::BoundingBox)
-    print(
-        io,
-        "BBox{l,t,r,b,w,h = $(left(bbox)),$(top(bbox)), $(right(bbox)),$(bottom(bbox)), $(width(bbox)),$(height(bbox))}",
-    )
-end
+Base.show(io::IO, bbox::BoundingBox) =
+    print(io, "BBox{l,t,r,b,w,h = $(left(bbox)),$(top(bbox)), $(right(bbox)),$(bottom(bbox)), $(width(bbox)),$(height(bbox))}")
 
 # -----------------------------------------------------------
 # AbstractLayout

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -52,8 +52,10 @@ function bbox_to_pcts(bb::BoundingBox, figw, figh, flipy = true)
     mms ./ Float64[figw.value, figh.value, figw.value, figh.value]
 end
 
-Base.show(io::IO, bbox::BoundingBox) =
-    print(io, "BBox{l,t,r,b,w,h = $(left(bbox)),$(top(bbox)), $(right(bbox)),$(bottom(bbox)), $(width(bbox)),$(height(bbox))}")
+Base.show(io::IO, bbox::BoundingBox) = print(
+    io,
+    "BBox{l,t,r,b,w,h = $(left(bbox)),$(top(bbox)), $(right(bbox)),$(bottom(bbox)), $(width(bbox)),$(height(bbox))}",
+)
 
 # -----------------------------------------------------------
 # AbstractLayout

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -481,12 +481,8 @@ function layout_args(m::AbstractVecOrMat)
     layout_args(gl)
 end
 
-# compute number of subplots
-function layout_args(layout::GridLayout)
-    # recursively get the size of the grid
-    n = calc_num_subplots(layout)
-    layout, n
-end
+# recursively get the size of the grid
+layout_args(layout::GridLayout) = layout, calc_num_subplots(layout)
 
 layout_args(n_override::Integer, layout::Union{AbstractVecOrMat,GridLayout}) =
     layout_args(layout)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -590,7 +590,7 @@ with(:gr, size=(400,400), type=:histogram) do
 end
 ```
 """
-function with(f::Function, args...; kw...)
+function with(f::Function, args...; scalefonts = nothing, kw...)
     newdefs = KW(kw)
 
     if :canvas in args
@@ -633,11 +633,13 @@ function with(f::Function, args...; kw...)
 
     # now set all those defaults
     default(; newdefs...)
+    scalefonts ≡ nothing || scalefontsizes(scalefonts)
 
     # call the function
     ret = f()
 
     # put the defaults back
+    scalefonts ≡ nothing || resetfontsizes()
     default(; olddefs...)
 
     # revert the backend

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,9 @@ for name in (
     "backends",
 )
     @testset "$name" begin
+        if get(ENV, "VISUAL_REGRESSION_TESTS_AUTO", "false") == "true" && name != "backends"
+            continue  # skip the majority of tests if we only want to update reference images
+        end
         gr()  # reset to default backend
         include("test_$name.jl")
     end

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -181,6 +181,7 @@ end
 
 @testset "GR - reference images" begin
     with(:gr) do
+        # NOTE: use `ENV["VISUAL_REGRESSION_TESTS_AUTO"] = true;` to automatically replace reference images
         @test backend() == Plots.GRBackend()
         @test backend_name() === :gr
         withenv("PLOTS_TEST" => true, "GKSwstype" => "nul") do

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -17,7 +17,7 @@ reference_dir(args...) =
     if (ref_dir = get(ENV, "PLOTS_REFERENCE_DIR", nothing)) !== nothing
         ref_dir
     else
-        joinpath(homedir(), ".julia", "dev", "PlotReferenceImages", args...)
+        joinpath(homedir(), ".julia", "dev", "PlotReferenceImages.jl", args...)
     end
 reference_path(backend, version) = reference_dir("Plots", string(backend), string(version))
 

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -304,6 +304,9 @@ with(:gr) do
     end
 
     @testset "legends" begin
+        @test plot([0:1 reverse(0:1)]; labels = ["a" "b"], leg = (0.5, 0.5)) isa Plot
+        @test plot([0:1 reverse(0:1)]; labels = ["a" "b"], leg = (0.5, :outer)) isa Plot
+        @test plot([0:1 reverse(0:1)]; labels = ["a" "b"], leg = (0.5, :inner)) isa Plot
         @test_logs (:warn, r"n° of legend_column.*") png(
             plot(1:2, legend_columns = 10),
             tempname(),


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/2206.
Fix https://github.com/JuliaPlots/Plots.jl/issues/4497 (and add regression tests).

It's a tough one since the `gr` code is a mess, non generic, easily breakable (some legend code paths are not tested in ref imgs), etc...

Add the ability to draw legend bounding boxes (for debugging, when using `Plots.debugplots(true)`).
Fix centering of legend boxes (`:top` and `:bottom`), and position of legend title.

These examples should cover most of the legend boxes possibilities:
```julia
julia> using Plots; Plots.debugplots(true);
julia> kw = (legend_column=-1, legend_title="title");
julia> plot([1:2 reverse(1:2)]; marker=:circle, kw...)
julia> plot(1:2, fillrange=reverse(1:2); kw...)
julia> plot(rand(100); reg = true, fill = (0, :green), kw...)
julia> hspan([1, 2, 3, 4]; kw...)
```

Supersedes https://github.com/JuliaPlots/Plots.jl/pull/4444.

Xref https://github.com/JuliaPlots/Plots.jl/issues/2423.

Added new examples to cover the issues encountered in https://github.com/JuliaPlots/Plots.jl/issues/4485 and https://github.com/JuliaPlots/Plots.jl/issues/4491:
**1.35.8 - inner - ex64**
![64_old](https://user-images.githubusercontent.com/13423344/200295773-9ad2142a-14f1-4dad-b2d7-d7ed55a1dbd0.png)

**pr - inner - ex64**
![ref64](https://github.com/JuliaPlots/PlotReferenceImages.jl/raw/master/Plots/gr/1.35.8/ref64.png)

**1.35.8 - outer - ex65**
![65_old](https://user-images.githubusercontent.com/13423344/200295808-7274ad6d-f462-4657-8063-2a14bf92afba.png)

**pr - outer - ex65**
![ref65](https://github.com/JuliaPlots/PlotReferenceImages.jl/raw/master/Plots/gr/1.35.8/ref65.png)
