### PR TITLE
revert customization of markershapes

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1148,7 +1148,7 @@ clamp_to_eps!(ary) = (replace!(x -> x <= 0.0 ? Base.eps(Float64) : x, ary); noth
 
 @recipe function f(::Type{Val{:xerror}}, x, y, z)  # COV_EXCL_LINE
     error_style!(plotattributes)
-    markershape --> :vline
+    markershape := :vline
     xerr = error_zipit(plotattributes[:xerror])
     if z === nothing
         plotattributes[:x], plotattributes[:y] = error_coords(xerr, x, y)
@@ -1165,7 +1165,7 @@ end
 
 @recipe function f(::Type{Val{:yerror}}, x, y, z)  # COV_EXCL_LINE
     error_style!(plotattributes)
-    markershape --> :hline
+    markershape := :hline
     yerr = error_zipit(plotattributes[:yerror])
     if z === nothing
         plotattributes[:y], plotattributes[:x] = error_coords(yerr, y, x)
@@ -1182,7 +1182,7 @@ end
 
 @recipe function f(::Type{Val{:zerror}}, x, y, z)  # COV_EXCL_LINE
     error_style!(plotattributes)
-    markershape --> :hline
+    markershape := :hline
     if z !== nothing
         zerr = error_zipit(plotattributes[:zerror])
         plotattributes[:z], plotattributes[:x], plotattributes[:y] =


### PR DESCRIPTION
Short term fix #4476.

In general I think this should be customizable, but at this point its unclear whether #4489 will land and this is quick and easy.