### PR TITLE
Support transposed images

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,7 @@
 treats_y_as_x(seriestype) =
     seriestype in (:vline, :vspan, :histogram, :barhist, :stephist, :scatterhist)
 
-function replace_image_with_heatmap(z::Array{<:Colorant})
+function replace_image_with_heatmap(z::AbstractMatrix{<:Colorant})
     n, m = size(z)
     colors = palette(vec(z))
     newz = reshape(1:(n * m), n, m)


### PR DESCRIPTION
Plus any other use case when one might plot a view of an Array.

Also require 2 dimensions in the type (as expected by the function body).

This makes the following code work, which fails at the moment:

```jl
using Plots, Plotly

using PlotlyBase, PlotlyKaleido

using TestImages

plotly()

image = testimage("lighthouse")

# Uncomment the following to test the change easily:
# function Plots.replace_image_with_heatmap(z::AbstractMatrix{<:Colorant})
#     n, m = size(z)
#     colors = palette(vec(z))
#     newz = reshape(1:(n * m), n, m)
#     newz, colors
# end

Plots.plot(image')
```