### PR TITLE
fix non square `unicodeplots` layout

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -2022,6 +2022,8 @@ get_series_color(c, sp::Subplot, n::Int, seriestype) =
         like_surface(seriestype) ? cgrad() : _cycle(sp[:color_palette], n)
     elseif isa(c, Int)
         _cycle(sp[:color_palette], c)
+    else
+        c
     end |> plot_color
 
 get_series_color(c::AbstractArray, sp::Subplot, n::Int, seriestype) =

--- a/src/args.jl
+++ b/src/args.jl
@@ -1106,12 +1106,10 @@ end
 # if arg is a valid color value, then set plotattributes[csym] and return true
 function handleColors!(plotattributes::AKW, arg, csym::Symbol)
     try
-        if arg === :auto
-            plotattributes[csym] = :auto
+        plotattributes[csym] = if arg === :auto
+            :auto
         else
-            # c = colorscheme(arg)
-            c = plot_color(arg)
-            plotattributes[csym] = c
+            plot_color(arg)
         end
         return true
     catch
@@ -2019,14 +2017,12 @@ has_black_border_for_default(st::Symbol) =
 
 # converts a symbol or string into a Colorant or ColorGradient
 # and assigns a color automatically
-function get_series_color(c, sp::Subplot, n::Int, seriestype)
+get_series_color(c, sp::Subplot, n::Int, seriestype) =
     if c === :auto
-        c = like_surface(seriestype) ? cgrad() : _cycle(sp[:color_palette], n)
+        like_surface(seriestype) ? cgrad() : _cycle(sp[:color_palette], n)
     elseif isa(c, Int)
-        c = _cycle(sp[:color_palette], c)
-    end
-    plot_color(c)
-end
+        _cycle(sp[:color_palette], c)
+    end |> plot_color
 
 get_series_color(c::AbstractArray, sp::Subplot, n::Int, seriestype) =
     map(x -> get_series_color(x, sp, n, seriestype), c)
@@ -2107,7 +2103,7 @@ function _update_series_attributes!(plotattributes::AKW, plt::Plot, sp::Subplot)
     stype = plotattributes[:seriestype]
     plotattributes[:seriescolor] = scolor = get_series_color(scolor, sp, plotIndex, stype)
 
-    # update other colors
+    # update other colors (`linecolor`, `markercolor`, `fillcolor`) <- for grep
     for s in (:line, :marker, :fill)
         csym, asym = Symbol(s, :color), Symbol(s, :alpha)
         plotattributes[csym] = if plotattributes[csym] === :auto

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -151,7 +151,7 @@ end
 up_color(col::UnicodePlots.UserColorType) = col
 up_color(col::RGBA) =
     (c = convert(ARGB32, col); map(Int, (red(c).i, green(c).i, blue(c).i)))
-up_color(col) = :auto
+up_color(::Any) = :auto
 
 up_cmap(series) = map(
     c -> (red(c), green(c), blue(c)),

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -179,9 +179,7 @@ function addUnicodeSeries!(
         series[:x], series[:y]
     end
 
-    if ispolar(sp) || ispolar(series)
-        return UnicodePlots.polarplot(x, y)
-    end
+    (ispolar(sp) || ispolar(series)) && return UnicodePlots.polarplot(x, y)
 
     # special handling (src/interface)
     fix_ar = get(se_kw, :fix_ar, true)
@@ -271,27 +269,32 @@ function addUnicodeSeries!(
     up
 end
 
+function unsupported_layout_error()
+    """
+    Plots(UnicodePlots): complex nested layout is currently unsupported.
+    Consider using plain `UnicodePlots` commands and `grid` from Term.jl as an alternative.
+    """ |>
+    ArgumentError |>
+    throw
+    nothing
+end
+
 # ------------------------------------------------------------------------------------------
 
 function _show(io::IO, ::MIME"image/png", plt::Plot{UnicodePlotsBackend})
     prepare_output(plt)
     nr, nc = size(plt.layout)
-    s1 = zeros(Int, nr, nc)
-    s2 = zeros(Int, nr, nc)
+    s1, s2 = map(_ -> zeros(Int, nr, nc), 1:2)
     canvas_type = nothing
     imgs = []
     sps = 0
     for r in 1:nr, c in 1:nc
         if (l = plt.layout[r, c]) isa GridLayout && size(l) != (1, 1)
-            "Plots(UnicodePlots): complex nested layout is currently unsupported" |>
-            ArgumentError |>
-            throw
+            unsupported_layout_error()
         else
             img = UnicodePlots.png_image(plt.o[sps += 1]; pixelsize = 32)
             canvas_type = eltype(img)
-            h, w = size(img)
-            s1[r, c] = h
-            s2[r, c] = w
+            s1[r, c], s2[r, c] = size(img)
             push!(imgs, img)
         end
     end
@@ -304,8 +307,7 @@ function _show(io::IO, ::MIME"image/png", plt::Plot{UnicodePlotsBackend})
         for r in 1:nr
             n2 = 1
             for c in 1:nc
-                sp = imgs[sps += 1]
-                h, w = size(sp)
+                h, w = (sp = imgs[sps += 1]) |> size
                 img[n1:(n1 + (h - 1)), n2:(n2 + (w - 1))] = sp
                 n2 += m2[c]
             end
@@ -332,43 +334,41 @@ function _show(io::IO, ::MIME"text/plain", plt::Plot{UnicodePlotsBackend})
         end
     else
         have_color = Base.get_have_color()
-        lines_colored = Array{Union{Nothing,Vector{String}}}(undef, nr, nc)
+        lines_colored = Array{Union{Nothing,Vector{String}}}(nothing, nr, nc)
         lines_uncolored = have_color ? similar(lines_colored) : lines_colored
         l_max = zeros(Int, nr)
         w_max = zeros(Int, nc)
+        nsp = length(plt.o)
         sps = 0
         for r in 1:nr
             lmax = 0
             for c in 1:nc
                 if (l = plt.layout[r, c]) isa GridLayout && size(l) != (1, 1)
-                    "Plots(UnicodePlots): complex nested layout is currently unsupported" |>
-                    ArgumentError |>
-                    throw
+                    unsupported_layout_error()
                 else
                     if get(l.attr, :blank, false)
-                        lines_colored[r, c] = lines_uncolored[r, c] = nothing
-                    else
-                        sp = plt.o[sps += 1]
-                        colored = string(sp; color = have_color)
-                        lines_colored[r, c] = lu = lc = split(colored, '\n')
-                        if have_color
-                            uncolored = UnicodePlots.no_ansi_escape(colored)
-                            lines_uncolored[r, c] = lu = split(uncolored, '\n')
-                        end
-                        lmax = max(length(lc), lmax)
-                        w_max[c] = max(maximum(length.(lu)), w_max[c])
+                        continue
+                    elseif (sps += 1) > nsp
+                        continue
                     end
+                    colored = string(plt.o[sps]; color = have_color)
+                    lines_colored[r, c] = lu = lc = split(colored, '\n')
+                    if have_color
+                        uncolored = UnicodePlots.no_ansi_escape(colored)
+                        lines_uncolored[r, c] = lu = split(uncolored, '\n')
+                    end
+                    lmax = max(length(lc), lmax)
+                    w_max[c] = max(maximum(length.(lu)), w_max[c])
                 end
             end
             l_max[r] = lmax
         end
-        empty = String[' '^w for w in w_max]
+        empty = map(w -> ' '^w, w_max)
         for r in 1:nr
             for n in 1:l_max[r]
                 for c in 1:nc
                     pre = c == 1 ? '\0' : ' '
-                    lc = lines_colored[r, c]
-                    if lc === nothing || length(lc) < n
+                    if (lc = lines_colored[r, c]) === nothing || length(lc) < n
                         print(io, pre, empty[c])
                     else
                         lu = lines_uncolored[r, c]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -447,6 +447,7 @@ for comp in (:line, :fill, :marker)
     get_compalpha = Symbol(:get_, compalpha)
 
     @eval begin
+        # defines `get_linecolor`, `get_fillcolor` and `get_markercolor` <- for grep
         function $get_compcolor(series, cmin::Real, cmax::Real, i::Int = 1)
             c = series[$Symbol($compcolor)]  # series[:linecolor], series[:fillcolor], series[:markercolor]
             z = series[$Symbol($comp_z)]  # series[:line_z], series[:fill_z], series[:marker_z]


### PR DESCRIPTION
Master errors on:

```julia
using Plots; unicodeplots()
plot(plot(1:2), plot(3:4), plot(4:5))
```