### PR TITLE
Add layout test - Add `png` warning on failing font

### DIFF
--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -164,6 +164,9 @@ end
         pl = plot(map(plot, 1:4)..., layout = (2, 2))
         @test show(io, pl) isa Nothing
 
+        pl = plot(map(plot, 1:3)..., layout = (2, 2))
+        @test show(io, pl) isa Nothing
+
         pl = plot(map(plot, 1:2)..., layout = @layout([° _; _ °]))
         @test show(io, pl) isa Nothing
 

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -41,7 +41,9 @@ end
 
 with(:unicodeplots) do
     @test_save :txt
-    @test_save :png
+    if Plots.UnicodePlots.get_font_face() ≢ nothing
+        @test_save :png
+    end
 end
 
 with(:plotlyjs) do


### PR DESCRIPTION
Add missing test after https://github.com/JuliaPlots/Plots.jl/pull/4510.

Add warning on png export failure (for `PkgEval`), restrict png tests.