### PR TITLE
multiply `legend_font_pointsize` by `line_width`

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -2053,12 +2053,14 @@ ensure_gradient!(plotattributes::AKW, csym::Symbol, asym::Symbol) =
             cgrad(alpha = plotattributes[asym])
     end
 
-_replace_linewidth(plotattributes::AKW) =
+const DEFAULT_LINEWIDTH = Ref(1)
+
 # get a good default linewidth... 0 for surface and heatmaps
+_replace_linewidth(plotattributes::AKW) =
     if plotattributes[:linewidth] === :auto
-        plotattributes[:linewidth] = (
-            get(plotattributes, :seriestype, :path) in (:surface, :heatmap, :image) ? 0 : 1
-        )
+        plotattributes[:linewidth] =
+            (get(plotattributes, :seriestype, :path) ∉ (:surface, :heatmap, :image)) *
+            DEFAULT_LINEWIDTH[]
     end
 
 function _slice_series_args!(plotattributes::AKW, plt::Plot, sp::Subplot, commandIndex::Int)

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1006,7 +1006,10 @@ function gr_add_legend(sp, leg, viewport_area)
             st = series[:seriestype]
             clims = gr_clims(sp, series)
             lc = get_linecolor(series, clims)
-            gr_set_line(lfps / 8, get_linestyle(series), lc, sp)
+            lw = get_linewidth(series)
+            ls = get_linestyle(series)
+            la = get_linealpha(series)
+            gr_set_line(lfps * lw / 8, ls, lc, sp)  # see github.com/JuliaPlots/Plots.jl/issues/3003
             _debugMode[] && gr_legend_bbox(xpos, ypos, leg)
 
             if (
@@ -1026,16 +1029,15 @@ function gr_add_legend(sp, leg, viewport_area)
                 x, y = [l, r, r, l, l], [b, b, t, t, b]
                 gr_set_transparency(fc, get_fillalpha(series))
                 gr_polyline(x, y, GR.fillarea)
-                lc = get_linecolor(series, clims)
-                gr_set_transparency(lc, get_linealpha(series))
-                gr_set_line(get_linewidth(series), get_linestyle(series), lc, sp)
+                gr_set_transparency(lc, la)
+                gr_set_line(lw, ls, lc, sp)
                 st === :shape && gr_polyline(x, y)
             end
 
             max_markersize = Inf
             if st in (:path, :straightline, :path3d)
                 max_markersize = leg.base_markersize
-                gr_set_transparency(lc, get_linealpha(series))
+                gr_set_transparency(lc, la)
                 filled = series[:fillrange] !== nothing && series[:ribbon] === nothing
                 GR.polyline(xpos .+ [lft, rgt], ypos .+ (filled ? [top, top] : [0, 0]))
             end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -980,8 +980,8 @@ function gr_add_legend(sp, leg, viewport_area)
         # |
         # |
         # o ----- xmax
-        xs, ys = (xpos - leg.pad - leg.span, xpos + leg.w + leg.pad),
-        (ypos - leg.h, ypos + leg.dy)
+        xs = xpos - leg.pad - leg.span, xpos + leg.w + leg.pad
+        ys = ypos - leg.h, ypos + leg.dy
         # xmin, xmax, ymin, ymax
         GR.fillrect(xs..., ys...)  # allocating white space for actual legend width here
         gr_set_line(1, :solid, sp[:legend_foreground_color], sp)
@@ -1009,7 +1009,8 @@ function gr_add_legend(sp, leg, viewport_area)
             lw = get_linewidth(series)
             ls = get_linestyle(series)
             la = get_linealpha(series)
-            gr_set_line(lfps * lw / 8, ls, lc, sp)  # see github.com/JuliaPlots/Plots.jl/issues/3003
+            clamped_lw = (lfps / 8) * clamp(lw, 0.5, 10)  # arbitrarily clamped
+            gr_set_line(clamped_lw, ls, lc, sp)  # see github.com/JuliaPlots/Plots.jl/issues/3003
             _debugMode[] && gr_legend_bbox(xpos, ypos, leg)
 
             if (
@@ -1030,7 +1031,7 @@ function gr_add_legend(sp, leg, viewport_area)
                 gr_set_transparency(fc, get_fillalpha(series))
                 gr_polyline(x, y, GR.fillarea)
                 gr_set_transparency(lc, la)
-                gr_set_line(lw, ls, lc, sp)
+                gr_set_line(clamped_lw, ls, lc, sp)
                 st === :shape && gr_polyline(x, y)
             end
 

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -965,6 +965,8 @@ gr_legend_bbox(xpos, ypos, leg) = GR.drawrect(
     ypos + 0.5leg.dy,
 )
 
+const gr_lw_clamp_factor = Ref(5)
+
 function gr_add_legend(sp, leg, viewport_area)
     sp[:legend_position] ∈ (:none, :inline) && return
     GR.savestate()
@@ -1001,6 +1003,9 @@ function gr_add_legend(sp, leg, viewport_area)
         lft, rgt, bot, top = -leg.space - leg.span, -leg.space, -0.4leg.dy, 0.4leg.dy
         lfps = sp[:legend_font_pointsize]
 
+        min_lw = DEFAULT_LINEWIDTH[] / gr_lw_clamp_factor[]
+        max_lw = DEFAULT_LINEWIDTH[] * gr_lw_clamp_factor[]
+
         for series in series_list(sp)
             should_add_to_legend(series) || continue
             st = series[:seriestype]
@@ -1009,7 +1014,7 @@ function gr_add_legend(sp, leg, viewport_area)
             lw = get_linewidth(series)
             ls = get_linestyle(series)
             la = get_linealpha(series)
-            clamped_lw = (lfps / 8) * clamp(lw, 0.5, 10)  # arbitrarily clamped
+            clamped_lw = (lfps / 8) * clamp(lw, min_lw, max_lw)
             gr_set_line(clamped_lw, ls, lc, sp)  # see github.com/JuliaPlots/Plots.jl/issues/3003
             _debugMode[] && gr_legend_bbox(xpos, ypos, leg)
 


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/3003.

The inconsistency should be fixed.

Needs new reference images. Maybe we need some non-linearity or flag here to revert to non-scaling of legend line width. TBD.

PR
![ref1](https://user-images.githubusercontent.com/13423344/202904711-02c0ed90-daad-4808-aa7d-cf0e7d440f58.png)

master
https://docs.juliaplots.org/dev/gallery/gr/generated/gr-ref1/#gr_demo_1
