### PR TITLE
fix padding with inset plots

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -534,7 +534,6 @@ const _suppress_warnings = Set{Symbol}([
     :primary,
     :smooth,
     :relative_bbox,
-    :layout_insets,
     :force_minpad,
     :x_extrema,
     :y_extrema,

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -905,6 +905,17 @@ function gr_clims(sp, args...)
     lo, hi
 end
 
+function gr_viewport_bbox(vp, sp, color)
+    GR.savestate()
+    GR.selntran(0)
+    GR.setscale(0)
+    gr_set_line(1, :solid, plot_color(color), sp)
+    GR.drawrect(vp.xmin, vp.xmax, vp.ymin, vp.ymax)
+    GR.selntran(1)
+    GR.restorestate()
+    nothing
+end
+
 function gr_display(sp::Subplot{GRBackend}, w, h, vp_canvas::GRViewport)
     _update_min_padding!(sp)
 
@@ -929,6 +940,9 @@ function gr_display(sp::Subplot{GRBackend}, w, h, vp_canvas::GRViewport)
     # draw the axes
     gr_draw_axes(sp, vp_plt)
     gr_add_title(sp, vp_plt, vp_sp)
+
+    _debug[] && gr_viewport_bbox(vp_sp, sp, :red)
+    _debug[] && gr_viewport_bbox(vp_plt, sp, :green)
 
     # this needs to be here to point the colormap to the right indices
     GR.setcolormap(1_000 + GR.COLORMAP_COOLWARM)
@@ -990,7 +1004,7 @@ function gr_add_legend(sp, leg, viewport_area)
         GR.drawrect(xs..., ys...)  # drawing actual legend width here
         if (ttl = sp[:legend_title]) !== nothing
             gr_set_font(legendtitlefont(sp), sp; halign = :center, valign = :center)
-            _debugMode[] && gr_legend_bbox(xpos, ypos, leg)
+            _debug[] && gr_legend_bbox(xpos, ypos, leg)
             gr_text(xpos - leg.pad - leg.space + 0.5leg.textw, ypos, string(ttl))
             if vertical
                 ypos -= leg.dy
@@ -1016,7 +1030,7 @@ function gr_add_legend(sp, leg, viewport_area)
             la = get_linealpha(series)
             clamped_lw = (lfps / 8) * clamp(lw, min_lw, max_lw)
             gr_set_line(clamped_lw, ls, lc, sp)  # see github.com/JuliaPlots/Plots.jl/issues/3003
-            _debugMode[] && gr_legend_bbox(xpos, ypos, leg)
+            _debug[] && gr_legend_bbox(xpos, ypos, leg)
 
             if (
                 (st === :shape || series[:fillrange] !== nothing) &&

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -290,7 +290,7 @@ py_bbox(::Nothing) = BoundingBox(0mm, 0mm)
 
 # get the bounding box of the union of the objects
 function py_bbox(v::AVec)
-    bbox_union = defaultbox
+    bbox_union = DEFAULT_BBOX[]
     for obj in v
         bbox_union += py_bbox(obj)
     end
@@ -318,7 +318,7 @@ end
 
 # bounding box: axis title
 function py_bbox_title(ax)
-    bb = defaultbox
+    bb = DEFAULT_BBOX[]
     for s in (:title, :_left_title, :_right_title)
         bb += py_bbox(getproperty(ax, s))
     end

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1338,7 +1338,7 @@ function test_examples(
     # prevent leaking variables (esp. functions) directly into Plots namespace
     Base.eval(m, quote
         using Plots
-        Plots.debugplots($debug)
+        Plots.debug!($debug)
         backend($(QuoteNode(pkgname)))
         theme(:default)
     end)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -226,7 +226,7 @@ function _plot_setup(plt::Plot, plotattributes::AKW, kw_list::Vector{KW})
             else
                 plt.layout
             end
-            sp = Subplot(backend(), parent = parent)
+            sp = Subplot(backend(); parent)
             sp.plt = plt
             push!(plt.subplots, sp)
             push!(plt.inset_subplots, sp)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -166,9 +166,7 @@ function plot!(
     for (idx, sp) in enumerate(plt.subplots)
         _initialize_subplot(plt, sp)
         serieslist = series_list(sp)
-        if sp in sp.plt.inset_subplots
-            push!(plt.inset_subplots, sp)
-        end
+        append!(plt.inset_subplots, sp.plt.inset_subplots)
         sp.plt = plt
         sp.attr[:subplot_index] = idx
         for series in serieslist
@@ -250,10 +248,7 @@ function prepare_output(plt::Plot)
     end
 
     # now another pass down, to update the bounding boxes
-    update_child_bboxes!(
-        plt.layout;
-        insets = get(plt, :layout_insets, false) ? plt.inset_subplots : (),
-    )
+    update_child_bboxes!(plt.layout)
 
     # update those bounding boxes of inset subplots
     update_inset_bboxes!(plt)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -976,9 +976,8 @@ lens!(args...; kwargs...) = plot!(args...; seriestype = :lens, kwargs...)
 export lens!
 @recipe function f(::Type{Val{:lens}}, plt::AbstractPlot)  # COV_EXCL_LINE
     sp_index, inset_bbox = plotattributes[:inset_subplots]
-    if !(width(inset_bbox) isa Measures.Length{:w,<:Real})
+    width(inset_bbox) isa Measures.Length{:w,<:Real} ||
         throw(ArgumentError("Inset bounding box needs to in relative coordinates."))
-    end
     sp = plt.subplots[sp_index]
     xscale = sp[:xaxis][:scale]
     yscale = sp[:yaxis][:scale]

--- a/src/types.jl
+++ b/src/types.jl
@@ -35,9 +35,9 @@ mutable struct Subplot{T<:AbstractBackend} <: AbstractLayout
         parent,
         Series[],
         0,
-        defaultminpad,
-        defaultbox,
-        defaultbox,
+        DEFAULT_MINPAD[],
+        DEFAULT_BBOX[],
+        DEFAULT_BBOX[],
         DefaultsDict(KW(), _subplot_defaults),
         nothing,
         nothing,
@@ -93,9 +93,9 @@ mutable struct Plot{T<:AbstractBackend} <: AbstractPlot{T}
         sp = deepcopy(osp)  # FIXME: fails `PlotlyJS` ?
         plt.layout.grid[1, 1] = sp
         # reset some attributes
-        sp.minpad = defaultminpad
-        sp.bbox = defaultbox
-        sp.plotarea = defaultbox
+        sp.minpad = DEFAULT_MINPAD[]
+        sp.bbox = DEFAULT_BBOX[]
+        sp.plotarea = DEFAULT_BBOX[]
         sp.plt = plt  # change the enclosing plot
         push!(plt.subplots, sp)
         plt

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -665,14 +665,14 @@ end
 
 # ---------------------------------------------------------------
 
-const _debugMode = Ref(false)
+const _debug = Ref(false)
 
-debugplots(on = true) = _debugMode[] = on
+debug!(on = true) = _debug[] = on
 debugshow(io, x) = show(io, x)
 debugshow(io, x::AbstractArray) = print(io, summary(x))
 
 function dumpdict(io::IO, plotattributes::AKW, prefix = "")
-    _debugMode[] || return
+    _debug[] || return
     println(io)
     prefix == "" || println(io, prefix, ":")
     for k in sort(collect(keys(plotattributes)))

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -78,7 +78,7 @@ function image_comparison_tests(
 
     imports = something(example.imports, :())
     exprs = quote
-        Plots.debugplots($debug)
+        Plots.debug!($debug)
         backend($(QuoteNode(pkg)))
         theme(:default)
         rng = StableRNG(Plots.PLOTS_SEED)
@@ -106,9 +106,7 @@ function image_comparison_facts(
 )
     for i in setdiff(1:length(Plots._examples), skip)
         if only === nothing || i in only
-            @test success(
-                image_comparison_tests(pkg, i, debug = debug, sigma = sigma, tol = tol),
-            )
+            @test success(image_comparison_tests(pkg, i; debug, sigma, tol))
         end
     end
 end

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -96,8 +96,8 @@ end
 
     @test Plots.to_pixels(1Plots.mm) isa AbstractFloat
     @test Plots.ispositive(1Plots.mm)
-    @test size(Plots.defaultbox) == (0Plots.mm, 0Plots.mm)
-    show(io, Plots.defaultbox)
+    @test size(Plots.DEFAULT_BBOX[]) == (0Plots.mm, 0Plots.mm)
+    show(io, Plots.DEFAULT_BBOX[])
     show(io, pl.layout)
 
     @test Plots.make_measure_hor(1Plots.mm) == 1Plots.mm
@@ -109,13 +109,11 @@ end
     rl = Plots.RootLayout()
     show(io, rl)
     @test parent(rl) === nothing
-    @test Plots.parent_bbox(rl) == Plots.defaultbox
-    @test Plots.bbox(rl) == Plots.defaultbox
-    @test Plots.origin(Plots.defaultbox) == (0Plots.mm, 0Plots.mm)
-    for h_anchor in (:left, :right, :hcenter)
-        for v_anchor in (:top, :bottom, :vcenter)
-            @test Plots.bbox(0, 0, 1, 1, h_anchor, v_anchor) isa Plots.BoundingBox
-        end
+    @test Plots.parent_bbox(rl) == Plots.DEFAULT_BBOX[]
+    @test Plots.bbox(rl) == Plots.DEFAULT_BBOX[]
+    @test Plots.origin(Plots.DEFAULT_BBOX[]) == (0Plots.mm, 0Plots.mm)
+    for h_anchor in (:left, :right, :hcenter), v_anchor in (:top, :bottom, :vcenter)
+        @test Plots.bbox(0, 0, 1, 1, h_anchor, v_anchor) isa Plots.BoundingBox
     end
 
     el = Plots.EmptyLayout()

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -72,7 +72,7 @@
     Plots.makekw(foo = 1, bar = 2) isa Dict
 
     ######################
-    Plots.debugplots(true)
+    Plots.debug!(true)
 
     io = PipeBuffer()
     Plots.debugshow(io, nothing)
@@ -82,7 +82,7 @@
     Plots.dumpdict(devnull, first(pl.series_list).plotattributes)
     show(devnull, pl[1][:xaxis])
 
-    Plots.debugplots(false)
+    Plots.debug!(false)
     ######################
 
     let pl = plot(1)


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/4533.

This took quite some time to fix.

Also add the ability to draw subplots and plot bounding boxes for `GR`, when `_debug[]` is set.