### PR TITLE
Fix unitful axes with empty guides

### DIFF
--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -226,12 +226,12 @@ append_unit_if_needed!(attr, key, u::Unitful.Units) =
 append_unit_if_needed!(attr, key, label::ProtectedString, u) = nothing
 append_unit_if_needed!(attr, key, label::UnitfulString, u) = nothing
 append_unit_if_needed!(attr, key, label::Nothing, u) =
-    attr[key] = UnitfulString(string(u), u)
-append_unit_if_needed!(attr, key, label::S, u) where {S<:AbstractString} =
-    if !isempty(label)
-        attr[key] =
-            UnitfulString(S(format_unit_label(label, u, get(attr, :unitformat, :round))), u)
-    end
+    (attr[key] = UnitfulString(string(u), u))
+function append_unit_if_needed!(attr, key, label::S, u) where {S<:AbstractString}
+    isempty(label) && return attr[key] = UnitfulString(label, u)
+    return attr[key] =
+        UnitfulString(S(format_unit_label(label, u, get(attr, :unitformat, :round))), u)
+end
 
 #=============================================
 Surround unit string with specified delimiters

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -32,7 +32,9 @@ end
     @testset "ylabel" begin
         @test yguide(plot(y, ylabel = "hello")) == "hello (m)"
         @test yguide(plot(y, ylabel = P"hello")) == "hello"
-        @test yguide(plot(y, ylabel = "")) == ""
+        pl = plot(y, ylabel = "")
+        @test yguide(pl) == ""
+        @test yguide(plot!(pl, -y)) == ""
         pl = plot(y; ylabel = "hello")
         plot!(pl, -y)
         @test yguide(pl) == "hello (m)"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -81,7 +81,7 @@
     pl = plot(1:2)
     Plots.dumpdict(devnull, first(pl.series_list).plotattributes)
     show(devnull, pl[1][:xaxis])
-    
+
     # bounding boxes
     with(:gr) do
         show(devnull, plot(1:2))


### PR DESCRIPTION
Before UnitfulRecipes was merged into Plots, one could achieve an empty plot label for a unitful axis like this:
```julia
plot(randn(5)u"m"; yguide="")
```

Thanks to a bug which meant that you could plot unitful data on unitless axes, we didn't notice or care that this empty label actually didn't contain a unit at all.
After merging UnitfulRecipes into Plots, this bug was fixed, and this would error out:

```julia
plot(randn(5)u"m"; yguide="")
plot!(randn(5)u"m") # ERROR:  and m are not dimensionally compatible.
```

With this PR, that works.