### PR TITLE
improve `heatmap_edges` performance

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -478,7 +478,10 @@ plotly_data(v::AbstractArray{R}) where {R<:Rational} = float(v)
 plotly_native_data(axis::Axis, a::Surface) = Surface(plotly_native_data(axis, a.surf))
 plotly_native_data(axis::Axis, data::AbstractArray) =
     if !isempty(axis[:discrete_values])
-        construct_categorical_data(data, axis)
+        map(
+            xi -> axis[:discrete_values][searchsortedfirst(axis[:continuous_values], xi)],
+            data,
+        )
     elseif axis[:formatter] in (datetimeformatter, dateformatter, timeformatter)
         plotly_convert_to_datetime(data, axis[:formatter])
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -257,7 +257,7 @@ function heatmap_edges(
     xscale::Symbol,
     y::AVec,
     yscale::Symbol,
-    z_size::Tuple{Int,Int},
+    z_size::NTuple{2,Int},
     ispolar::Bool = false,
 )
     nx, ny = length(x), length(y)
@@ -265,11 +265,14 @@ function heatmap_edges(
     # the correct check, since (4, 3) != (3, 4) and a missleading plot is produced.
     ismidpoints = prod(z_size) == (ny * nx)
     isedges = z_size == (ny - 1, nx - 1)
-    (ismidpoints || isedges) || error("""
-                                      Length of x & y does not match the size of z.
-                                      Must be either `size(z) == (length(y), length(x))` (x & y define midpoints)
-                                      or `size(z) == (length(y)+1, length(x)+1))` (x & y define edges).
-                                      """)
+    (ismidpoints || isedges) ||
+        """
+        Length of x & y does not match the size of z.
+        Must be either `size(z) == (length(y), length(x))` (x & y define midpoints)
+        or `size(z) == (length(y)+1, length(x)+1))` (x & y define edges).
+        """ |>
+        ArgumentError |>
+        throw
     (
         _heatmap_edges(Val(xscale === :identity), x, xscale, isedges, false),
         _heatmap_edges(Val(yscale === :identity), y, yscale, isedges, ispolar),  # special handle for `r` in polar plots

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1073,10 +1073,7 @@ function shape_data(series, expansion_factor = 1)
     )
 end
 
-construct_categorical_data(x::AbstractArray, axis::Axis) =
-    (map(xi -> axis[:discrete_values][searchsortedfirst(axis[:continuous_values], xi)], x))
-
-function add_triangle!(I::Int, i::Int, j::Int, k::Int, x, y, z, X, Y, Z)
+function _add_triangle!(I::Int, i::Int, j::Int, k::Int, x, y, z, X, Y, Z)
     m = 4(I - 1) + 1
     n = m + 1
     o = m + 2
@@ -1101,7 +1098,7 @@ function mesh3d_triangles(x, y, z, cns::Tuple{Array,Array,Array})
     Y = zeros(eltype(y), 4length(cj))
     Z = zeros(eltype(z), 4length(ck))
     @inbounds for I in eachindex(ci)  # connections are 0-based
-        add_triangle!(I, ci[I] + 1, cj[I] + 1, ck[I] + 1, x, y, z, X, Y, Z)
+        _add_triangle!(I, ci[I] + 1, cj[I] + 1, ck[I] + 1, x, y, z, X, Y, Z)
     end
     X, Y, Z
 end
@@ -1111,7 +1108,7 @@ function mesh3d_triangles(x, y, z, cns::AbstractVector{NTuple{3,Int}})
     Y = zeros(eltype(y), 4length(cns))
     Z = zeros(eltype(z), 4length(cns))
     @inbounds for I in eachindex(cns)  # connections are 1-based
-        add_triangle!(I, cns[I]..., x, y, z, X, Y, Z)
+        _add_triangle!(I, cns[I]..., x, y, z, X, Y, Z)
     end
     X, Y, Z
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -194,3 +194,13 @@ end
     # `CSV` produces `SentinelArrays` data
     @test scatter(ChainedVector([[1, 2], [3, 4]]), 1:4) isa Plot
 end
+
+@testset "performance" begin
+    with(:gr) do
+        pl = heatmap(rand(10, 10); xscale = :log10, yscale = :log10)
+        @test show(devnull, pl) isa Nothing
+
+        pl = plot(Shape([(1, 1), (2, 1), (2, 2), (1, 2)]); xscale = :log10, yscale = :log10)
+        @test show(devnull, pl) isa Nothing
+    end
+end


### PR DESCRIPTION
Partial improvement for https://github.com/JuliaPlots/Plots.jl/issues/4520.

```julia
using BenchmarkTools, Plots

const mat = randn(1024, 1024);

@btime show(devnull, heatmap($mat))
  35.233 ms (632 allocations: 8.10 MiB)  # PR
  35.512 ms (4670 allocations: 8.25 MiB)  # master

f(x, n = 100) = begin
    plot()
    for _ in 1:n
        heatmap!(x)
    end
end

@btime f($mat)
  2.320 s (42563 allocations: 807.30 MiB)  # PR
  2.348 s (446363 allocations: 822.83 MiB)  # master
```
