### PR TITLE
add `empty!` for `Plot`s and `Subplot`s

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -144,11 +144,16 @@ Base.size(plt::Plot) = size(plt.layout)
 Base.size(plt::Plot, i::Integer) = size(plt.layout)[i]
 Base.ndims(plt::Plot) = 2
 
+# clear out series list, but retain subplots
+Base.empty!(plt::Plot) = foreach(sp -> empty!(sp.series_list), plt.subplots)
+
 # attr(plt::Plot, k::Symbol) = plt.attr[k]
 # attr!(plt::Plot, v, k::Symbol) = (plt.attr[k] = v)
 
 Base.getindex(sp::Subplot, i::Union{Vector{<:Integer},Integer}) = series_list(sp)[i]
 Base.lastindex(sp::Subplot) = length(series_list(sp))
+
+Base.empty!(sp::Subplot) = empty!(sp.series_list)
 
 # -----------------------------------------------------------------------
 

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -139,7 +139,7 @@ end
     end
 end
 
-@testset "plot" begin
+@testset "tex_output_standalone" begin
     pl = plot(1:5)
     pl2 = plot(pl, tex_output_standalone = true)
     @test !pl[:tex_output_standalone]
@@ -189,6 +189,20 @@ end
     series = first(first(pl2.subplots).series_list)
     @test series[:x] == x2
     @test series[:y] == y2
+end
+
+@testset "Empty Plot / Subplots" begin
+    pl = plot(map(_ -> plot(1:2, [1:2 2:3]), 1:2)...)
+    empty!(pl)
+    @test length(pl.subplots) == 2
+    @test length(first(pl).series_list) == 0
+    @test length(last(pl).series_list) == 0
+
+    pl = plot(map(_ -> plot(1:2, [1:2 2:3]), 1:2)...)
+    empty!(first(pl))  # clear out only the first subplot
+    @test length(pl.subplots) == 2
+    @test length(first(pl).series_list) == 0
+    @test length(last(pl).series_list) == 2
 end
 
 @testset "Measures" begin


### PR DESCRIPTION
```julia
using BenchmarkTools, Plots

const mat = randn(512, 512)

f(x, n) = begin
  pl = plot()
  for _ in 1:n
      empty!(pl)  # clear out previous series
      heatmap!(x)
  end
  pl
end

@time display(f(mat, 100))  # warmup

@time display(f(mat, 100))
 1.255724 seconds (3.20 M allocations: 374.080 MiB, 19.67% gc time)  # PR
 32.482719 seconds (314.77 M allocations: 16.524 GiB, 8.18% gc time)  # master (without `empty!`, obviously)
```