### PR TITLE
Performance improvements to heatmap path

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -737,7 +737,7 @@ zvalues(
 # -----------------------------------------------------------------------
 
 function expand_extrema!(a::Axis, surf::Surface)
-    ex = a[:extrema]
+    ex = a[:extrema]::Extrema
     for vi in surf.surf
         expand_extrema!(ex, vi)
     end


### PR DESCRIPTION
Partially addresses #4520 

Type inferrence is often a big issue here:
```
const mat = randn(512, 512);
function f(x, n)
    plot()
    for _ in 1:n
        heatmap!(x)
    end
end
@btime f(mat, 100)

Master: 1.151 s (26455855 allocations: 614.24 MiB)
Adding one type annotation to `expand_extrema!(a::Axis, Surf::Surface)`: 546.681 ms (241455 allocations: 214.24 MiB)
```

