### PR TITLE
`gaston`: general improvements

### DIFF
--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -502,16 +502,15 @@ function gaston_set_ticks!(axesconf, ticks, letter, maj_min, add)
 end
 
 function gaston_set_legend!(axesconf, sp, any_label)
-    leg = sp[:legend_position]
-    if sp[:legend_position] ∉ (:none, :inline) && any_label
-        leg === :best && (leg = :topright)
+    if (lp = sp[:legend_position]) ∉ (:none, :inline) && any_label
+        leg_str = string(_guess_best_legend_position(lp, sp))
 
         push!(
             axesconf,
-            "set key " * (occursin("outer", string(leg)) ? "outside" : "inside"),
+            "set key " * (occursin("outer", leg_str) ? "outside" : "inside"),
         )
         for position in ("top", "bottom", "left", "right")
-            occursin(position, string(leg)) && push!(axesconf, "set key $position")
+            occursin(position, leg_str) && push!(axesconf, "set key $position")
         end
         push!(axesconf, "set key $(gaston_font(legendfont(sp), rot=false, align=false))")
         if sp[:legend_title] !== nothing

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -374,11 +374,15 @@ function gaston_parse_axes_args(
     for letter in (:x, :y, :z)
         (letter === :z && dims == 2) && continue
         axis = sp.attr[get_attr_symbol(letter, :axis)]
-        # label names
-        push!(
-            axesconf,
-            "set $(letter)label '$(axis[:guide])' $(gaston_font(guidefont(axis)))",
-        )
+
+        # guide labels
+        guide_font = guidefont(axis)
+        if letter === :y && dims == 2
+            # vertical by default (consistency witht other backends)
+            guide_font = font(guide_font; rotation = guide_font.rotation + 90)
+        end
+        push!(axesconf, "set $(letter)label '$(axis[:guide])' $(gaston_font(guide_font))")
+
         mirror = axis[:mirror] ? "mirror" : "nomirror"
 
         logscale, base = if axis[:scale] === :identity

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -505,10 +505,7 @@ function gaston_set_legend!(axesconf, sp, any_label)
     if (lp = sp[:legend_position]) ∉ (:none, :inline) && any_label
         leg_str = string(_guess_best_legend_position(lp, sp))
 
-        push!(
-            axesconf,
-            "set key " * (occursin("outer", leg_str) ? "outside" : "inside"),
-        )
+        push!(axesconf, "set key " * (occursin("outer", leg_str) ? "outside" : "inside"))
         for position in ("top", "bottom", "left", "right")
             occursin(position, leg_str) && push!(axesconf, "set key $position")
         end

--- a/src/backends/gaston.jl
+++ b/src/backends/gaston.jl
@@ -505,10 +505,23 @@ function gaston_set_legend!(axesconf, sp, any_label)
     if (lp = sp[:legend_position]) ∉ (:none, :inline) && any_label
         leg_str = string(_guess_best_legend_position(lp, sp))
 
-        push!(axesconf, "set key " * (occursin("outer", leg_str) ? "outside" : "inside"))
-        for position in ("top", "bottom", "left", "right")
-            occursin(position, leg_str) && push!(axesconf, "set key $position")
+        pos = occursin("outer", leg_str) ? "outside " : "inside "
+        pos *= if occursin("top", leg_str)
+            "top "
+        elseif occursin("bottom", leg_str)
+            "bottom "
+        else
+            "center "
         end
+        pos *= if occursin("left", leg_str)
+            "left "
+        elseif occursin("right", leg_str)
+            "right "
+        else
+            "center "
+        end
+        pos *= sp[:legend_column] == 1 ? "vertical" : "horizontal"
+        push!(axesconf, "set key $pos")
         push!(axesconf, "set key $(gaston_font(legendfont(sp), rot=false, align=false))")
         if sp[:legend_title] !== nothing
             # NOTE: cannot use legendtitlefont(sp) as it will override legendfont

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -679,10 +679,8 @@ function gr_display(plt::Plot, dpi_factor = 1)
     # fill in the viewport_canvas background
     gr_fill_viewport(vp_canvas, plt[:background_color_outside])
 
-    # subplots:
-    for sp in plt.subplots
-        gr_display(sp, w * px, h * px, vp_canvas)
-    end
+    # subplots
+    foreach(sp -> gr_display(sp, w * px, h * px, vp_canvas), plt.subplots)
 
     GR.updatews()
     nothing

--- a/src/components.jl
+++ b/src/components.jl
@@ -582,7 +582,7 @@ annotations(anns::AVec) = anns
 annotations(anns) = Any[anns]
 annotations(::Nothing) = []
 
-_annotationfont(sp::Subplot) = Plots.font(;
+_annotationfont(sp::Subplot) = font(;
     family = sp[:annotationfontfamily],
     pointsize = sp[:annotationfontsize],
     halign = sp[:annotationhalign],

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1310,8 +1310,8 @@ _backend_skips = Dict(
         31,  # animations
         49,  # TODO: support polar
         50,  # TODO: 1D data not supported for pm3d
-        60,  # :perspective projection unsupported
-        62,  # fillstyle
+        # 60,  # :perspective projection unsupported
+        # 62,  # fillstyle
         63,  # un-identified bug
     ],
 )

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1306,13 +1306,10 @@ _backend_skips = Dict(
         65,  # legend pos unsupported
     ],
     :gaston => [
-        2,   # animations
-        31,  # animations
+        31,  # animations - needs github.com/mbaz/Gaston.jl/pull/178
         49,  # TODO: support polar
-        50,  # TODO: 1D data not supported for pm3d
-        # 60,  # :perspective projection unsupported
-        # 62,  # fillstyle
-        63,  # un-identified bug
+        60,  # :perspective projection unsupported
+        62,  # fillstyle
     ],
 )
 _backend_skips[:plotly] = _backend_skips[:plotlyjs]
@@ -1338,7 +1335,7 @@ function test_examples(
     pkgname::Symbol,
     i::Integer;
     debug = false,
-    disp = true,
+    disp = false,
     rng = nothing,
     callback = nothing,
 )
@@ -1368,14 +1365,14 @@ end
 
 # generate all plots and create a dict mapping idx --> plt
 """
-test_examples(pkgname[, idx]; debug=false, disp=true, sleep=nothing, skip=[], only=nothing, callback=nothing)
+test_examples(pkgname[, idx]; debug=false, disp=false, sleep=nothing, skip=[], only=nothing, callback=nothing)
 
 Run the `idx` test example for a given backend, or all examples if `idx` is not specified.
 """
 function test_examples(
     pkgname::Symbol;
     debug = false,
-    disp = true,
+    disp = false,
     sleep = nothing,
     skip = [],
     only = nothing,

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -1309,7 +1309,6 @@ _backend_skips = Dict(
         31,  # animations - needs github.com/mbaz/Gaston.jl/pull/178
         49,  # TODO: support polar
         60,  # :perspective projection unsupported
-        62,  # fillstyle
     ],
 )
 _backend_skips[:plotly] = _backend_skips[:plotlyjs]

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -49,19 +49,6 @@ function reference_file(backend, i, version)
     return reffn
 end
 
-# replace `f(args...)` with `f(rng, args...)` for `f ∈ (rand, randn)`
-replace_rand(ex) = ex
-
-function replace_rand(ex::Expr)
-    expr = Expr(ex.head)
-    foreach(arg -> push!(expr.args, replace_rand(arg)), ex.args)
-    if Meta.isexpr(ex, :call) && ex.args[1] ∈ (:rand, :randn, :(Plots.fakedata))
-        pushfirst!(expr.args, ex.args[1])
-        expr.args[2] = :rng
-    end
-    expr
-end
-
 function image_comparison_tests(
     pkg::Symbol,
     idx::Int;
@@ -82,7 +69,7 @@ function image_comparison_tests(
         backend($(QuoteNode(pkg)))
         theme(:default)
         rng = StableRNG(Plots.PLOTS_SEED)
-        $(replace_rand(example.exprs))
+        $(Plots.replace_rand(example.exprs))
     end
     @debug imports exprs
 


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/3962.

- fix default `y` label orientation.
- use `_guess_best_legend_position` introduced in https://github.com/JuliaPlots/Plots.jl/pull/4536;
- fix legend positions;
- fix axis mirror;
- fix border and framestyle;
- fix empty legend entries;
- fix marker fill;
- implement hatched fillstyle;
- fix surface plots.