### PR TITLE
[RecipesBase] Use interpolation instead of qualification to drop dependance on the namespace of RecipesBase users

### DIFF
--- a/RecipesBase/src/RecipesBase.jl
+++ b/RecipesBase/src/RecipesBase.jl
@@ -123,7 +123,7 @@ function create_kw_body(func_signature::Expr)
             push!(
                 cleanup_body.args,
                 :(
-                    $is_key_supported($(QuoteNode(k))) ||
+                    $RecipesBase.is_key_supported($(QuoteNode(k))) ||
                     delete!(plotattributes, $(QuoteNode(k)))
                 ),
             )

--- a/RecipesBase/src/RecipesBase.jl
+++ b/RecipesBase/src/RecipesBase.jl
@@ -181,16 +181,16 @@ function process_recipe_body!(expr::Expr)
                     :(plotattributes[$k] = $v)
                 else
                     # if the user has set this keyword, use theirs
-                    :($is_explicit(plotattributes, $k) || (plotattributes[$k] = $v))
+                    :($RecipesBase.is_explicit(plotattributes, $k) || (plotattributes[$k] = $v))
                 end
 
                 expr.args[i] = if quiet
                     # quietly ignore keywords which are not supported
-                    :($is_key_supported($k) ? $set_expr : nothing)
+                    :($RecipesBase.is_key_supported($k) ? $set_expr : nothing)
                 elseif require
                     # error when not supported by the backend
                     :(
-                        $is_key_supported($k) ? $set_expr :
+                        $RecipesBase.is_key_supported($k) ? $set_expr :
                         error(
                             "In recipe: required keyword ",
                             $k,
@@ -296,10 +296,10 @@ macro recipe(funcexpr::Expr)
             @nospecialize
             $kw_body
             $cleanup_body
-            series_list = $RecipeData[]
+            series_list = $RecipesBase.RecipeData[]
             func_return = $func_body
             func_return === nothing ||
-                push!(series_list, $RecipeData(plotattributes, $wrap_tuple(func_return)))
+                push!(series_list, $RecipeData(plotattributes, $RecipesBase.wrap_tuple(func_return)))
             series_list
         end |> esc,
     )
@@ -333,7 +333,7 @@ macro series(expr::Expr)
     esc(quote
         let plotattributes = copy(plotattributes)
             args = $expr
-            push!(series_list, $RecipeData(plotattributes, $wrap_tuple(args)))
+            push!(series_list, $RecipesBase.RecipeData(plotattributes, $RecipesBase.wrap_tuple(args)))
             nothing
         end
     end)
@@ -370,10 +370,10 @@ function _userplot(expr::Expr)
         quote
             $expr
             export $funcname, $funcname2
-            Core.@__doc__ $funcname(args...; kw...) = $plot($typename(args); kw...)
-            Core.@__doc__ $funcname2(args...; kw...) = $plot!($typename(args); kw...)
-            Core.@__doc__ $funcname2(plt::$AbstractPlot, args...; kw...) =
-                $plot!(plt, $typename(args); kw...)
+            Core.@__doc__ $funcname(args...; kw...) = $RecipesBase.plot($typename(args); kw...)
+            Core.@__doc__ $funcname2(args...; kw...) = $RecipesBase.plot!($typename(args); kw...)
+            Core.@__doc__ $funcname2(plt::$RecipesBase.AbstractPlot, args...; kw...) =
+                $RecipesBase.plot!(plt, $typename(args); kw...)
         end,
     )
 end
@@ -418,9 +418,9 @@ macro shorthands(funcname::Symbol)
         quote
             export $funcname, $funcname2
             Core.@__doc__ $funcname(args...; kw...) =
-                $plot(args...; kw..., seriestype = $(Meta.quot(funcname)))
+                $RecipesBase.plot(args...; kw..., seriestype = $(Meta.quot(funcname)))
             Core.@__doc__ $funcname2(args...; kw...) =
-                $plot!(args...; kw..., seriestype = $(Meta.quot(funcname)))
+                $RecipesBase.plot!(args...; kw..., seriestype = $(Meta.quot(funcname)))
         end,
     )
 end

--- a/RecipesBase/src/RecipesBase.jl
+++ b/RecipesBase/src/RecipesBase.jl
@@ -298,10 +298,8 @@ macro recipe(funcexpr::Expr)
             $cleanup_body
             series_list = $RecipeData[]
             func_return = $func_body
-            func_return === nothing || push!(
-                series_list,
-                $RecipeData(plotattributes, $wrap_tuple(func_return)),
-            )
+            func_return === nothing ||
+                push!(series_list, $RecipeData(plotattributes, $wrap_tuple(func_return)))
             series_list
         end |> esc,
     )
@@ -332,18 +330,13 @@ end
 ```
 """
 macro series(expr::Expr)
-    esc(
-        quote
-            let plotattributes = copy(plotattributes)
-                args = $expr
-                push!(
-                    series_list,
-                    $RecipeData(plotattributes, $wrap_tuple(args)),
-                )
-                nothing
-            end
-        end,
-    )
+    esc(quote
+        let plotattributes = copy(plotattributes)
+            args = $expr
+            push!(series_list, $RecipeData(plotattributes, $wrap_tuple(args)))
+            nothing
+        end
+    end)
 end
 
 # --------------------------------------------------------------------------
@@ -377,10 +370,8 @@ function _userplot(expr::Expr)
         quote
             $expr
             export $funcname, $funcname2
-            Core.@__doc__ $funcname(args...; kw...) =
-                $plot($typename(args); kw...)
-            Core.@__doc__ $funcname2(args...; kw...) =
-                $plot!($typename(args); kw...)
+            Core.@__doc__ $funcname(args...; kw...) = $plot($typename(args); kw...)
+            Core.@__doc__ $funcname2(args...; kw...) = $plot!($typename(args); kw...)
             Core.@__doc__ $funcname2(plt::$AbstractPlot, args...; kw...) =
                 $plot!(plt, $typename(args); kw...)
         end,

--- a/RecipesBase/src/RecipesBase.jl
+++ b/RecipesBase/src/RecipesBase.jl
@@ -299,7 +299,7 @@ macro recipe(funcexpr::Expr)
             series_list = $RecipesBase.RecipeData[]
             func_return = $func_body
             func_return === nothing ||
-                push!(series_list, $RecipeData(plotattributes, $RecipesBase.wrap_tuple(func_return)))
+                push!(series_list, $RecipesBase.RecipeData(plotattributes, $RecipesBase.wrap_tuple(func_return)))
             series_list
         end |> esc,
     )

--- a/RecipesBase/src/RecipesBase.jl
+++ b/RecipesBase/src/RecipesBase.jl
@@ -87,7 +87,7 @@ function get_function_def(func_signature::Expr, args::Vector)
     elseif func_signature.head ≡ :call
         func = Expr(
             :call,
-            $apply_recipe,
+            :($RecipesBase.apply_recipe),
             esc.([:(plotattributes::AbstractDict{Symbol,Any}); args])...,
         )
         if isa(front, Expr) && front.head ≡ :curly

--- a/RecipesBase/test/runtests.jl
+++ b/RecipesBase/test/runtests.jl
@@ -1,6 +1,6 @@
 # Run tests with `import RecipesBase as RB` instead of `using RecipesBase`
 # or `import RecipesBase` to test that macros do not depend on the
-# namespace of the emeclosing scope.
+# namespace of the enclosing scope.
 import RecipesBase as RB
 using StableRNGs
 using Test

--- a/RecipesBase/test/runtests.jl
+++ b/RecipesBase/test/runtests.jl
@@ -1,13 +1,13 @@
-# Run tests with `import RecipesBase` instead of `using RecipesBase` to test
-# that objects like `AbstractPlot` are properly prefixed with `RecipesBase.` in
-# the macros.
-import RecipesBase
+# Run tests with `import RecipesBase as RB` instead of `using RecipesBase`
+# or `import RecipesBase` to test that macros do not depend on the
+# namespace of the emeclosing scope.
+import RecipesBase as RB
 using StableRNGs
 using Test
 
 const KW = Dict{Symbol,Any}
 
-RecipesBase.is_key_supported(k::Symbol) = true
+RB.is_key_supported(k::Symbol) = true
 
 for t in map(i -> Symbol(:T, i), 1:5)
     @eval struct $t end
@@ -15,33 +15,33 @@ end
 
 struct Dummy end
 
-RecipesBase.@recipe function plot(t::Dummy, args...) end
+RB.@recipe function plot(t::Dummy, args...) end
 
 @testset "coverage" begin
-    @test !RecipesBase.group_as_matrix(nothing)
-    @test RecipesBase.apply_recipe(KW(:foo => 1)) == ()
+    @test !RB.group_as_matrix(nothing)
+    @test RB.apply_recipe(KW(:foo => 1)) == ()
 
-    @test RecipesBase.to_symbol(:x) ≡ :x
-    @test RecipesBase.to_symbol(QuoteNode(:x)) ≡ :x
+    @test RB.to_symbol(:x) ≡ :x
+    @test RB.to_symbol(QuoteNode(:x)) ≡ :x
 
-    @test RecipesBase._equals_symbol(:x, :x)
-    @test RecipesBase._equals_symbol(QuoteNode(:x), :x)
-    @test !RecipesBase._equals_symbol(nothing, :x)
+    @test RB._equals_symbol(:x, :x)
+    @test RB._equals_symbol(QuoteNode(:x), :x)
+    @test !RB._equals_symbol(nothing, :x)
 
-    @test RecipesBase.gettypename(:x) ≡ :x
-    @test RecipesBase.gettypename(:(Foo{T})) ≡ :Foo
+    @test RB.gettypename(:x) ≡ :x
+    @test RB.gettypename(:(Foo{T})) ≡ :Foo
 
-    RecipesBase.recipetype(::Val{:Dummy}, args...) = nothing
-    @test RecipesBase.recipetype(:Dummy, 1:10) isa Nothing
-    @test_throws ErrorException RecipesBase.recipetype(:NotDefined)
+    RB.recipetype(::Val{:Dummy}, args...) = nothing
+    @test RB.recipetype(:Dummy, 1:10) isa Nothing
+    @test_throws ErrorException RB.recipetype(:NotDefined)
 end
 
 @testset "layout" begin
     grid(x, y) = (x, y)  # fake `grid` function for `Plots`
-    @test RecipesBase.@layout([a b; c]) isa Matrix
-    @test RecipesBase.@layout([a{0.3w}; b{0.2h}]) isa Matrix
-    @test RecipesBase.@layout([a{0.3w} [grid(3, 3); b{0.2h}]]) isa Matrix
-    @test RecipesBase.@layout([_ ° _; ° ° °; ° ° °]) isa Matrix
+    @test RB.@layout([a b; c]) isa Matrix
+    @test RB.@layout([a{0.3w}; b{0.2h}]) isa Matrix
+    @test RB.@layout([a{0.3w} [grid(3, 3); b{0.2h}]]) isa Matrix
+    @test RB.@layout([_ ° _; ° ° °; ° ° °]) isa Matrix
 end
 
 @testset "@recipe" begin
@@ -53,15 +53,15 @@ end
         # this is similar to how Plots would call the method
         plotattributes = KW(:customcolor => :red)
 
-        data_list = RecipesBase.apply_recipe(plotattributes, T(), 2)
+        data_list = RB.apply_recipe(plotattributes, T(), 2)
         @test data_list[1].args == (rand(StableRNG(1), 10, 2),)
         @test plotattributes == expect
     end
 
     @testset "simple parametric type" begin
-        @test_throws MethodError RecipesBase.apply_recipe(KW(), T1())
+        @test_throws MethodError RB.apply_recipe(KW(), T1())
 
-        RecipesBase.@recipe function plot(
+        RB.@recipe function plot(
             t::T1,
             n::N = 1;
             customcolor = :green,
@@ -86,9 +86,9 @@ end
     end
 
     @testset "parametric type with where" begin
-        @test_throws MethodError RecipesBase.apply_recipe(KW(), T2())
+        @test_throws MethodError RB.apply_recipe(KW(), T2())
 
-        RecipesBase.@recipe function plot(
+        RB.@recipe function plot(
             t::T2,
             n::N = 1;
             customcolor = :green,
@@ -113,9 +113,9 @@ end
     end
 
     @testset "parametric type with double where" begin
-        @test_throws MethodError RecipesBase.apply_recipe(KW(), T3())
+        @test_throws MethodError RB.apply_recipe(KW(), T3())
 
-        RecipesBase.@recipe function plot(
+        RB.@recipe function plot(
             t::T3,
             n::N = 1,
             m::M = 0.0;
@@ -141,9 +141,9 @@ end
     end
 
     @testset "manual access of plotattributes" begin
-        @test_throws MethodError RecipesBase.apply_recipe(KW(), T4())
+        @test_throws MethodError RB.apply_recipe(KW(), T4())
 
-        RecipesBase.@recipe function plot(t::T4, n = 1; customcolor = :green)
+        RB.@recipe function plot(t::T4, n = 1; customcolor = :green)
             :markershape --> :auto, :require
             :markercolor --> customcolor, :force
             :xrotation --> 5
@@ -167,9 +167,9 @@ end
     end
 
     @testset "no force" begin
-        @test_throws MethodError RecipesBase.apply_recipe(KW(), T5())
+        @test_throws MethodError RB.apply_recipe(KW(), T5())
 
-        RecipesBase.@recipe function plot(t::T5, n::Integer = 1)
+        RB.@recipe function plot(t::T5, n::Integer = 1)
             customcolor --> :notred
             rand(StableRNG(1), 10, n)
         end
@@ -179,7 +179,7 @@ end
 end  # @testset "@recipe"
 
 # Can't do this inside a test-set, because it creates a struct.
-RecipesBase.@userplot MyPlot
+RB.@userplot MyPlot
 
 @testset "@userplot" begin
     @test typeof(myplot) <: Function

--- a/RecipesBase/test/runtests.jl
+++ b/RecipesBase/test/runtests.jl
@@ -61,11 +61,7 @@ end
     @testset "simple parametric type" begin
         @test_throws MethodError RB.apply_recipe(KW(), T1())
 
-        RB.@recipe function plot(
-            t::T1,
-            n::N = 1;
-            customcolor = :green,
-        ) where {N<:Integer}
+        RB.@recipe function plot(t::T1, n::N = 1; customcolor = :green) where {N<:Integer}
             :markershape --> :auto, :require
             :markercolor --> customcolor, :force
             :xrotation --> 5
@@ -88,11 +84,7 @@ end
     @testset "parametric type with where" begin
         @test_throws MethodError RB.apply_recipe(KW(), T2())
 
-        RB.@recipe function plot(
-            t::T2,
-            n::N = 1;
-            customcolor = :green,
-        ) where {N<:Integer}
+        RB.@recipe function plot(t::T2, n::N = 1; customcolor = :green) where {N<:Integer}
             :markershape --> :auto, :require
             :markercolor --> customcolor, :force
             :xrotation --> 5


### PR DESCRIPTION
We can't assume that folks will have RecipesBase in their namespace.

Fixes #4557