### PR TITLE
support a y indexing different from x

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1197,7 +1197,7 @@ function _dinv_series(lim, scale, x, y, nsamples, weight = 100.0)
     yoffset = firstindex(y) - firstindex(x)
     for i in firstindex(x):max(1, div(min(nsamples, length(x)), 2))
         # This bound checking is probably redundant
-        (_checkbounds(x, i, j) && _checkbounds(y, i+yoffset, j+yoffset)) || continue
+        (_checkbounds(x, i, j) && _checkbounds(y, i + yoffset, j + yoffset)) || continue
         dinv += (
             inv(1 + weight * d_point(x[i], y[i + yoffset], lim, scale)) +
             inv(1 + weight * d_point(x[j], y[j + yoffset], lim, scale))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1196,8 +1196,8 @@ function _dinv_series(lim, scale, x, y, nsamples, weight = 100.0)
     yoffset = firstindex(y) - firstindex(x)
     for i in firstindex(x):max(1, div(min(nsamples, length(x)), 2))
         dinv += (
-            inv(1 + weight * d_point(x[i], y[i+yoffset], lim, scale)) +
-            inv(1 + weight * d_point(x[j], y[j+yoffset], lim, scale))
+            inv(1 + weight * d_point(x[i], y[i + yoffset], lim, scale)) +
+            inv(1 + weight * d_point(x[j], y[j + yoffset], lim, scale))
         )
         j -= 1
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1193,10 +1193,11 @@ function _dinv_series(lim, scale, x, y, nsamples, weight = 100.0)
     dinv = 0.0
     # Run from the extremes of the dataset inwards
     j = lastindex(x)
+    yoffset = firstindex(y) - firstindex(x)
     for i in firstindex(x):max(1, div(min(nsamples, length(x)), 2))
         dinv += (
-            inv(1 + weight * d_point(x[i], y[i], lim, scale)) +
-            inv(1 + weight * d_point(x[j], y[j], lim, scale))
+            inv(1 + weight * d_point(x[i], y[i+yoffset], lim, scale)) +
+            inv(1 + weight * d_point(x[j], y[j+yoffset], lim, scale))
         )
         j -= 1
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1187,6 +1187,7 @@ function d_point(x, y, lim, scale)
     isnan(d) && return 0.0
     d
 end
+_checkbounds(x, i, j) = checkbounds(Bool, x, i) && checkbounds(Bool, x, j)
 function _dinv_series(lim, scale, x, y, nsamples, weight = 100.0)
     length(x) > 0 || return +Inf
     lim = lim ./ scale
@@ -1195,6 +1196,8 @@ function _dinv_series(lim, scale, x, y, nsamples, weight = 100.0)
     j = lastindex(x)
     yoffset = firstindex(y) - firstindex(x)
     for i in firstindex(x):max(1, div(min(nsamples, length(x)), 2))
+        # This bound checking is probably redundant
+        (_checkbounds(x, i, j) && _checkbounds(y, i+yoffset, j+yoffset)) || continue
         dinv += (
             inv(1 + weight * d_point(x[i], y[i + yoffset], lim, scale)) +
             inv(1 + weight * d_point(x[j], y[j + yoffset], lim, scale))

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -208,6 +208,13 @@ end
     pl = plot!(x, x .^ 3, label = "cubic")
     @test Plots._guess_best_legend_position(:best, pl) === :topleft
 
+    x = OffsetArrays.OffsetArray(0:0.01:2, OffsetArrays.Origin(+3))
+    pl = plot(x, x, label = "linear")
+    pl = plot!(x, x .^ 2, label = "quadratic")
+    pl = plot!(x, x .^ 3, label = "cubic")
+    @test Plots._guess_best_legend_position(:best, pl) === :topleft
+
+    @test Plots._guess_best_legend_position(:best, pl) === :topleft
     x = 0:0.01:2
     pl = plot(x, -x, label = "linear")
     pl = plot!(x, -x .^ 2, label = "quadratic")


### PR DESCRIPTION
This change supports, in the `_guess_best_legend_position` function, different offsets for y and x. Aiming to address https://github.com/JuliaPlots/Plots.jl/issues/4561.

However, it seems that GR does not support those different offsets, thus the bug must be another.

