### PR TITLE
Make plotly colorbar size scale with plot size

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -549,8 +549,7 @@ function plotly_series(plt::Plot, series::Series)
         st in (:path, :scatter, :scattergl, :straightline) &&
         (isa(series[:fillrange], AbstractVector) || isa(series[:fillrange], Tuple))
 
-    _, y_domain = plotly_domain(sp)
-    plotattributes_out[:colorbar] = KW(:title => sp[:colorbar_title], :y => mean(y_domain), :len => diff(y_domain)[1])
+    plotattributes_out[:colorbar] = plotly_colorbar(sp)
 
     if is_2tuple(clims)
         plotattributes_out[:zmin], plotattributes_out[:zmax] = clims
@@ -711,6 +710,18 @@ function plotly_series(plt::Plot, series::Series)
 
     [merge(plotattributes_out, series[:extra_kwargs])]
 end
+
+
+function plotly_colorbar(sp::Subplot)
+    _, y_domain = plotly_domain(sp)
+    plot_attribute = KW(
+        :title => sp[:colorbar_title],
+        :y => mean(y_domain),
+        :len => diff(y_domain)[1]
+    )
+    return plot_attribute
+end
+
 
 function plotly_series_shapes(plt::Plot, series::Series, clims)
     segments = series_segments(series; check = true)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -549,7 +549,8 @@ function plotly_series(plt::Plot, series::Series)
         st in (:path, :scatter, :scattergl, :straightline) &&
         (isa(series[:fillrange], AbstractVector) || isa(series[:fillrange], Tuple))
 
-    plotattributes_out[:colorbar] = KW(:title => sp[:colorbar_title])
+    _, y_domain = plotly_domain(sp)
+    plotattributes_out[:colorbar] = KW(:title => sp[:colorbar_title], :y => mean(y_domain), :len => diff(y_domain)[1])
 
     if is_2tuple(clims)
         plotattributes_out[:zmin], plotattributes_out[:zmax] = clims


### PR DESCRIPTION
Closes #4547 

These changes improve the default positioning of the colorbars
```julia
using Plots
data = rand(3, 3);
heatmap(data)
```

<img width="50%" src="https://user-images.githubusercontent.com/4917419/204726660-39a014b2-1386-47a2-87d9-ec2c1d483be6.png">

and also allow the colorbar size to scale with plot size
```julia
heatmap(data, colorbar=:right, tickfont=30, xlabel="test")
```

<img width="50%" src="https://user-images.githubusercontent.com/4917419/204727209-4f0c4352-fc71-4d06-9dd1-6e44f92b2d16.png">
