### PR TITLE
ref imgs: try to checkout a tag

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Plots"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 author = ["Tom Breloff (@tbreloff)"]
-version = "1.36.6"
+version = "1.36.6-dev"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -20,14 +20,14 @@ reference_dir(args...) =
     end
 reference_path(backend, version) = reference_dir("Plots", string(backend), string(version))
 
-if !isdir(reference_dir())
-    mkpath(reference_dir())
+function checkout_reference_dir(dn::AbstractString)
+    mkpath(dn)
     local repo
     for i in 1:6
         try
             repo = LibGit2.clone(
                 "https://github.com/JuliaPlots/PlotReferenceImages.jl.git",
-                reference_dir(),
+                dn,
             )
             break
         catch err
@@ -35,13 +35,19 @@ if !isdir(reference_dir())
             sleep(20i)
         end
     end
-    try
-        tag = LibGit2.GitObject(repo, "v$(Plots._current_plots_version)")
-        hash = string(LibGit2.target(tag))
-        LibGit2.checkout!(repo, hash)
-    catch err
-        @warn err
+    if (ver = Plots._current_plots_version).prerelease |> isempty
+        try
+            tag = LibGit2.GitObject(repo, "v$ver")
+            hash = string(LibGit2.target(tag))
+            LibGit2.checkout!(repo, hash)
+        catch err
+            @warn err
+        end
     end
+end
+
+let dn = reference_dir()
+    isdir(dn) || checkout_reference_dir(dn)
 end
 
 ref_name(i) = "ref" * lpad(i, 3, '0')

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -44,6 +44,8 @@ function checkout_reference_dir(dn::AbstractString)
             @warn err
         end
     end
+    LibGit2.peel(LibGit2.head(repo)) |> println  # print some information
+    nothing
 end
 
 let dn = reference_dir()

--- a/test/test_backends.jl
+++ b/test/test_backends.jl
@@ -22,9 +22,10 @@ reference_path(backend, version) = reference_dir("Plots", string(backend), strin
 
 if !isdir(reference_dir())
     mkpath(reference_dir())
+    local repo
     for i in 1:6
         try
-            LibGit2.clone(
+            repo = LibGit2.clone(
                 "https://github.com/JuliaPlots/PlotReferenceImages.jl.git",
                 reference_dir(),
             )
@@ -33,6 +34,13 @@ if !isdir(reference_dir())
             @warn err
             sleep(20i)
         end
+    end
+    try
+        tag = LibGit2.GitObject(repo, "v$(Plots._current_plots_version)")
+        hash = string(LibGit2.target(tag))
+        LibGit2.checkout!(repo, hash)
+    catch err
+        @warn err
     end
 end
 


### PR DESCRIPTION
Otherwise, running older `Plots` versions test suite is bound to fail.
E.g. for `PkgEval`. On failure, should stay on current master.