### PR TITLE
reduce runtime dispatches

### DIFF
--- a/RecipesPipeline/src/plot_recipe.jl
+++ b/RecipesPipeline/src/plot_recipe.jl
@@ -15,19 +15,18 @@ function _process_plotrecipes!(plt, kw_list)
     kw_list = KW[]
     while !isempty(still_to_process)
         next_kw = popfirst!(still_to_process)
-        _process_plotrecipe(plt, next_kw, kw_list, still_to_process)
+        if get(next_kw, :seriestype, nothing) isa Symbol
+            _process_plotrecipe(plt, next_kw, kw_list, still_to_process)
+        else
+            # seriestype was never set, or it's not a Symbol, so it can't be a plot recipe
+            push!(kw_list, next_kw)
+        end
     end
     kw_list
 end
 
 function _process_plotrecipe(plt, kw, kw_list, still_to_process)
-    if !isa(get(kw, :seriestype, nothing), Symbol)
-        # seriestype was never set, or it's not a Symbol, so it can't be a plot recipe
-        push!(kw_list, kw)
-        return
-    end
-    st = kw[:seriestype]
-    st = kw[:seriestype] = type_alias(plt, st)
+    st = kw[:seriestype] = type_alias(plt, kw[:seriestype])
     datalist = RecipesBase.apply_recipe(kw, Val{st}, plt)
     if !isnothing(datalist)
         warn_on_recipe_aliases!(plt, datalist, :plot, st)

--- a/RecipesPipeline/src/user_recipe.jl
+++ b/RecipesPipeline/src/user_recipe.jl
@@ -61,8 +61,9 @@ function _recipedata_vector(plt, plotattributes, args)
 
     # if we were passed a vector/matrix of seriestypes and there's more than one row,
     # we want to duplicate the inputs, once for each seriestype row.
+    sts = get(plotattributes, :seriestype, :path)
     isempty(args) ||
-        append!(still_to_process, _expand_seriestype_array(plotattributes, args))
+        append!(still_to_process, _expand_seriestype_array(plotattributes, args, sts))
 
     # remove subplot and axis args from plotattributes...
     # they will be passed through in the kw_list
@@ -75,22 +76,19 @@ function _recipedata_vector(plt, plotattributes, args)
     still_to_process
 end
 
-function _expand_seriestype_array(plotattributes, args)
-    @nospecialize
-    sts = get(plotattributes, :seriestype, :path)
-    if typeof(sts) <: AbstractArray
-        reset_kw!(plotattributes, :seriestype)
-        rd = Vector{RecipeData}(undef, size(sts, 1))
-        for r in axes(sts, 1)
-            dc = copy(plotattributes)
-            dc[:seriestype] = sts[r:r, :]
-            rd[r] = RecipeData(dc, args)
-        end
-        rd
-    else
-        RecipeData[RecipeData(copy(plotattributes), args)]
+function _expand_seriestype_array(plotattributes, args, sts::AbstractArray)
+    reset_kw!(plotattributes, :seriestype)
+    rd = Vector{RecipeData}(undef, size(sts, 1))
+    for r in axes(sts, 1)
+        dc = copy(plotattributes)
+        dc[:seriestype] = sts[r:r, :]
+        rd[r] = RecipeData(dc, args)
     end
+    rd
 end
+
+_expand_seriestype_array(plotattributes, args, ::Any) =
+    RecipeData[RecipeData(copy(plotattributes), args)]
 
 function _finish_userrecipe!(plt, kw_list, recipedata)
     # when the arg tuple is empty, that means there's nothing left to recursively

--- a/RecipesPipeline/src/utils.jl
+++ b/RecipesPipeline/src/utils.jl
@@ -154,7 +154,7 @@ for st in (
     @eval is3d(::Type{Val{Symbol($(string(st)))}}) = true
 end
 is3d(st::Symbol) = is3d(Val{st})
-is3d(plotattributes::AbstractDict) = is3d(get(plotattributes, :seriestype, :path))
+is3d(plotattributes::AbstractDict)::Bool = is3d(get(plotattributes, :seriestype, :path))
 
 """
     is_surface(::Type{Val{:myseriestype}})
@@ -166,7 +166,7 @@ for st in (:contour, :contourf, :contour3d, :image, :heatmap, :surface, :wirefra
     @eval is_surface(::Type{Val{Symbol($(string(st)))}}) = true
 end
 is_surface(st::Symbol) = is_surface(Val{st})
-is_surface(plotattributes::AbstractDict) =
+is_surface(plotattributes::AbstractDict)::Bool =
     is_surface(get(plotattributes, :seriestype, :path))
 
 """

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -109,7 +109,7 @@ end
 # -------------------------------------------------------------------------
 
 Base.show(io::IO, axis::Axis) = dumpdict(io, axis.plotattributes, "Axis")
-ignorenan_extrema(axis::Axis) = (ex = axis[:extrema]; (ex.emin, ex.emax))
+ignorenan_extrema(axis::Axis) = (ex = axis[:extrema]::Extrema; (ex.emin, ex.emax))
 
 const _label_func =
     Dict{Symbol,Function}(:log10 => x -> "10^$x", :log2 => x -> "2^$x", :ln => x -> "e^$x")
@@ -412,8 +412,8 @@ end
 expand_extrema!(axis::Axis, v::Number) = expand_extrema!(axis[:extrema], v)
 
 # these shouldn't impact the extrema
-expand_extrema!(axis::Axis, ::Nothing) = axis[:extrema]
-expand_extrema!(axis::Axis, ::Bool) = axis[:extrema]
+expand_extrema!(axis::Axis, ::Nothing) = axis[:extrema]::Extrema
+expand_extrema!(axis::Axis, ::Bool) = axis[:extrema]::Extrema
 
 function expand_extrema!(axis::Axis, v::Tuple{MIN,MAX}) where {MIN<:Number,MAX<:Number}
     ex = axis[:extrema]::Extrema
@@ -631,9 +631,9 @@ function axis_limits(
     letter,
     lims_factor = widen_factor(get_axis(sp, letter)),
     consider_aspect = true,
-)
+)::NTuple{2,Float64}
     axis = get_axis(sp, letter)
-    ex = axis[:extrema]
+    ex = axis[:extrema]::Extrema
     amin, amax = ex.emin, ex.emax
     lims = process_limits(axis[:lims], axis)
     lims === nothing && warn_invalid_limits(axis[:lims], letter)
@@ -683,16 +683,16 @@ function axis_limits(
     )
         aspect_ratio = aspect_ratio isa Number ? aspect_ratio : 1
         area = plotarea(sp)
-        plot_ratio = height(area) / width(area)
-        dist = amax - amin
+        plot_ratio::Float64 = height(area) / width(area)
+        dist::Float64 = amax - amin
 
         factor = if letter === :x
             ydist, = axis_limits(sp, :y, widen_factor(sp[:yaxis]), false) |> collect |> diff
-            axis_ratio = aspect_ratio * ydist / dist
+            axis_ratio = aspect_ratio * Float64(ydist) / dist
             axis_ratio / plot_ratio
         else
             xdist, = axis_limits(sp, :x, widen_factor(sp[:xaxis]), false) |> collect |> diff
-            axis_ratio = aspect_ratio * dist / xdist
+            axis_ratio = aspect_ratio * Float64(dist) / xdist
             plot_ratio / axis_ratio
         end
 
@@ -722,7 +722,7 @@ discrete_value!(plotattributes, letter::Symbol, dv) =
 
 discrete_value!(axis::Axis, dv) =
     if (cv_idx = get(axis[:discrete_map], dv, -1)) == -1
-        ex = axis[:extrema]
+        ex = axis[:extrema]::Extrema
         cv = NaNMath.max(0.5, ex.emax + 1)
         expand_extrema!(axis, cv)
         push!(axis[:discrete_values], dv)

--- a/src/components.jl
+++ b/src/components.jl
@@ -457,7 +457,7 @@ mutable struct SeriesAnnotations
     strs::AVec  # the labels/names
     font::Font
     baseshape::Union{Shape,AVec{Shape},Nothing}
-    scalefactor::Tuple
+    scalefactor::NTuple{2,Float64}
 end
 
 _text_label(lab::Tuple, font) = text(lab[1], font, lab[2:end]...)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -160,9 +160,8 @@ function RecipesPipeline.process_sliced_series_attributes!(plt::Plots.Plot, kw_l
     end
 
     # swap errors
-    err_inds =
+    for ind in
         findall(kw -> get(kw, :seriestype, :path) in (:xerror, :yerror, :zerror), kw_list)
-    for ind in err_inds
         if ind > 1 && get(kw_list[ind - 1], :seriestype, :path) === :scatter
             tmp = copy(kw_list[ind])
             kw_list[ind] = copy(kw_list[ind - 1])
@@ -183,7 +182,7 @@ function RecipesPipeline.process_sliced_series_attributes!(plt::Plots.Plot, kw_l
         end
         # convert a ribbon into a fillrange
         if rib !== nothing
-            make_fillrange_from_ribbon(kw)
+            make_fillrange_from_ribbon(kw, kw[:y], kw[:ribbon])
             # map fillrange if it's a Function
         elseif fr !== nothing && fr isa Function
             kw[:fillrange] = map(fr, kw[:x])
@@ -299,7 +298,7 @@ function _subplot_setup(plt::Plot, plotattributes::AKW, kw_list::Vector{KW})
     nothing
 end
 
-series_idx(kw_list::AVec{KW}, kw::AKW) =
+series_idx(kw_list::AVec{KW}, kw::AKW)::Int =
     Int(kw[:series_plotindex]) - Int(kw_list[1][:series_plotindex]) + 1
 
 function _add_plot_title!(plt)
@@ -311,7 +310,7 @@ function _add_plot_title!(plt)
         if plt[:plot_titleindex] == 0
             the_layout = plt.layout
             vspan = plt[:plot_titlevspan]
-            plt.layout = grid(2, 1, heights = (vspan, 1 - vspan))
+            plt.layout = grid(2, 1; heights = (vspan, 1 - vspan))
             plt.layout.grid[1, 1] =
                 subplot = Subplot(plt.backend, parent = plt.layout[1, 1])
             plt.layout.grid[2, 1] = the_layout

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -231,7 +231,7 @@ end
 function prepare_output(plt::Plot)
     _before_layout_calcs(plt)
 
-    w, h = plt.attr[:size]
+    w::Int, h::Int = plt[:size]
     plt.layout.bbox = BoundingBox(0mm, 0mm, w * px, h * px)
 
     # One pass down and back up the tree to compute the minimum padding

--- a/src/types.jl
+++ b/src/types.jl
@@ -57,7 +57,7 @@ end
 
 Extrema() = Extrema(Inf, -Inf)
 
-const SubplotMap = Dict{Any,Subplot}
+const SubplotMap = Dict{Symbol,Subplot}
 
 mutable struct Plot{T<:AbstractBackend} <: AbstractPlot{T}
     backend::T                   # the backend type
@@ -114,10 +114,9 @@ Base.isempty(wrapper::InputWrapper) = false
 attr(series::Series, k::Symbol) = series.plotattributes[k]
 attr!(series::Series, v, k::Symbol) = (series.plotattributes[k] = v)
 
-should_add_to_legend(series::Series) =
-    series.plotattributes[:primary] &&
-    series.plotattributes[:label] != "" &&
-    series.plotattributes[:seriestype] ∉ (
+should_add_to_legend(::Any) = false
+should_add_to_legend(st::Symbol) =
+    st ∉ (
         :hexbin,
         :bins2d,
         :histogram2d,
@@ -131,6 +130,10 @@ should_add_to_legend(series::Series) =
         :heatmap,
         :image,
     )
+should_add_to_legend(series::Series) =
+    series.plotattributes[:primary] &&
+    series.plotattributes[:label] != "" &&
+    should_add_to_legend(series.plotattributes[:seriestype])
 
 # -----------------------------------------------------------------------
 Base.iterate(plt::Plot) = iterate(plt.subplots)
@@ -178,7 +181,7 @@ bottompad(sp::Subplot) = sp.minpad[4]
 
 get_subplot(plt::Plot, sp::Subplot) = sp
 get_subplot(plt::Plot, i::Integer) = plt.subplots[i]
-get_subplot(plt::Plot, k) = plt.spmap[k]
+get_subplot(plt::Plot, k::Symbol) = plt.spmap[k]
 get_subplot(series::Series) = series.plotattributes[:subplot]
 
 get_subplot_index(plt::Plot, sp::Subplot) = findfirst(x -> x === sp, plt.subplots)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -401,13 +401,14 @@ function make_fillrange_side(y::AVec, rib)
 end
 
 # turn a ribbon into a fillrange
-function make_fillrange_from_ribbon(kw::AKW)
-    y, rib = kw[:y], kw[:ribbon]
+function make_fillrange_from_ribbon(kw::AKW, y, rib)
     rib = wraptuple(rib)
     rib1, rib2 = -first(rib), last(rib)
     # kw[:ribbon] = nothing
     kw[:fillrange] = make_fillrange_side(y, rib1), make_fillrange_side(y, rib2)
-    (get(kw, :fillalpha, nothing) === nothing) && (kw[:fillalpha] = 0.5)
+    get(kw, :fillalpha, nothing) === nothing || return
+    kw[:fillalpha] = 0.5
+    nothing
 end
 
 #turn tuple of fillranges to one path
@@ -609,24 +610,24 @@ makekw(; kw...) = KW(kw)
 wraptuple(x::Tuple) = x
 wraptuple(x) = (x,)
 
-trueOrAllTrue(f::Function, x::AbstractArray) = all(f, x)
-trueOrAllTrue(f::Function, x) = f(x)
+trueOrAllTrue(f::Function, x::AbstractArray)::Bool = all(f, x)
+trueOrAllTrue(f::Function, x)::Bool = f(x)
 
-allLineTypes(arg) = trueOrAllTrue(a -> get(_typeAliases, a, a) in _allTypes, arg)
-allStyles(arg) = trueOrAllTrue(a -> get(_styleAliases, a, a) in _allStyles, arg)
-allShapes(arg) = (
+allLineTypes(arg)::Bool = trueOrAllTrue(a -> get(_typeAliases, a, a) in _allTypes, arg)
+allStyles(arg)::Bool = trueOrAllTrue(a -> get(_styleAliases, a, a) in _allStyles, arg)
+allShapes(arg)::Bool = (
     trueOrAllTrue(a -> is_marker_supported(get(_markerAliases, a, a)), arg) ||
     trueOrAllTrue(a -> isa(a, Shape), arg)
 )
-allAlphas(arg) = trueOrAllTrue(
+allAlphas(arg)::Bool = trueOrAllTrue(
     a ->
         (typeof(a) <: Real && a > 0 && a < 1) || (
             typeof(a) <: AbstractFloat && (a == zero(typeof(a)) || a == one(typeof(a)))
         ),
     arg,
 )
-allReals(arg) = trueOrAllTrue(a -> typeof(a) <: Real, arg)
-allFunctions(arg) = trueOrAllTrue(a -> isa(a, Function), arg)
+allReals(arg)::Bool = trueOrAllTrue(a -> typeof(a) <: Real, arg)
+allFunctions(arg)::Bool = trueOrAllTrue(a -> isa(a, Function), arg)
 
 # ---------------------------------------------------------------
 
@@ -1134,8 +1135,9 @@ end
 # cache joined symbols so they can be looked up instead of constructed each time
 const _attrsymbolcache = Dict{Symbol,Dict{Symbol,Symbol}}()
 
-get_attr_symbol(letter::Symbol, keyword::String) = get_attr_symbol(letter, Symbol(keyword))
-get_attr_symbol(letter::Symbol, keyword::Symbol) = _attrsymbolcache[letter][keyword]
+get_attr_symbol(letter::Symbol, keyword::String)::Symbol =
+    get_attr_symbol(letter, Symbol(keyword))
+get_attr_symbol(letter::Symbol, keyword::Symbol)::Symbol = _attrsymbolcache[letter][keyword]
 
 texmath2unicode(s::AbstractString, pat = r"\$([^$]+)\$") =
     replace(s, pat => m -> UnicodeFun.to_latex(m[2:(length(m) - 1)]))


### PR DESCRIPTION
I was trying to reduce the runtime dispatch plague using `JET`:

```julia
using Plots, JET
@report_opt target_modules=(Plots,) display(plot(1:2))
```

but this only seems to increase complexity.

An idea here, would be to use `NamedTuple`s after or in `RecipesPipeline` at some point (e.g. in `prepare_output` before delegating to backends), and not a `KW = Dict{Symbol,Any}` which is horrible from a compiler pov.

I'm not sure the whole thing can be salvaged though.