### PR TITLE
Fix colorbar positioning when multiple subplots are present

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -81,6 +81,12 @@ function plotly_domain(sp::Subplot)
     pcts = plotly_apply_aspect_ratio(sp, sp.plotarea, pcts)
     x_domain = [pcts[1], pcts[1] + pcts[3]]
     y_domain = [pcts[2], pcts[2] + pcts[4]]
+    if hascolorbar(sp)
+        subplot_width = pcts[3]
+        colorbar_fractional_size = 0.25
+        colorbar_width = subplot_width * colorbar_fractional_size
+        x_domain[2] = x_domain[2] - colorbar_width
+    end
     x_domain, y_domain
 end
 
@@ -712,9 +718,13 @@ function plotly_series(plt::Plot, series::Series)
 end
 
 function plotly_colorbar(sp::Subplot)
-    _, y_domain = plotly_domain(sp)
-    plot_attribute =
-        KW(:title => sp[:colorbar_title], :y => mean(y_domain), :len => diff(y_domain)[1])
+    x_domain, y_domain = plotly_domain(sp)
+    plot_attribute = KW(
+        :title => sp[:colorbar_title],
+        :y => mean(y_domain),
+        :len => diff(y_domain)[1],
+        :x => x_domain[2],
+    )
     return plot_attribute
 end
 


### PR DESCRIPTION
Closes #2691

Contour plot example:
```julia
data1 = rand(3,3);
data2 = rand(3,3) .+ 10;
p1 = contour(data1, colorbar=:right)
p2 = contour(data2, colorbar=:right)
plot(p1, p2)
```

Left: before
Right: after
<img width="40%" src="https://user-images.githubusercontent.com/4917419/205794155-3aad949c-bada-49cf-824e-3d72c572ecd0.png">  <img width="39.9%" src="https://user-images.githubusercontent.com/4917419/205794280-c02d9d22-1f5d-4ab2-ad8b-5c55f6d00be9.png">



Heatmap example:
```julia
data1 = rand(3,3);
data2 = rand(3,3) .+ 10;
p1 = heatmap(data1, colorbar=:right)
p2 = heatmap(data2, colorbar=:right)
plot(p1, p2)
```

Left: before
Right: after
<img width="40%" src="https://user-images.githubusercontent.com/4917419/205794514-eaf73325-6eec-4d49-8d1b-e828092ffe86.png">  <img width="39.8%" src="https://user-images.githubusercontent.com/4917419/205794540-3ca9cecb-d2bb-4d46-a6d5-b11d67edbc38.png">

