### PR TITLE
Fix delayed application of new clims in `plot!` call

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1934,7 +1934,8 @@ function _update_subplot_args(
 
     _update_subplot_colors(sp)
     _update_margins(sp)
-    colorbar_update_keys = (:clims, :colorbar, :seriestype, :marker_z, :line_z, :fill_z, :colorbar_entry)
+    colorbar_update_keys =
+        (:clims, :colorbar, :seriestype, :marker_z, :line_z, :fill_z, :colorbar_entry)
     if any(haskey.(Ref(plotattributes_in), colorbar_update_keys))
         _update_subplot_colorbars(sp)
     end

--- a/src/args.jl
+++ b/src/args.jl
@@ -1934,6 +1934,7 @@ function _update_subplot_args(
 
     _update_subplot_colors(sp)
     _update_margins(sp)
+    _update_subplot_colorbars(sp)
 
     lims_warned = false
     for letter in (:x, :y, :z)

--- a/src/args.jl
+++ b/src/args.jl
@@ -1934,7 +1934,10 @@ function _update_subplot_args(
 
     _update_subplot_colors(sp)
     _update_margins(sp)
-    _update_subplot_colorbars(sp)
+    colorbar_update_keys = (:clims, :colorbar, :seriestype, :marker_z, :line_z, :fill_z, :colorbar_entry)
+    if any(haskey.(plotattributes_in, colorbar_update_keys))
+        _update_subplot_colorbars(sp)
+    end
 
     lims_warned = false
     for letter in (:x, :y, :z)

--- a/src/args.jl
+++ b/src/args.jl
@@ -1935,7 +1935,7 @@ function _update_subplot_args(
     _update_subplot_colors(sp)
     _update_margins(sp)
     colorbar_update_keys = (:clims, :colorbar, :seriestype, :marker_z, :line_z, :fill_z, :colorbar_entry)
-    if any(haskey.(plotattributes_in, colorbar_update_keys))
+    if any(haskey.(Ref(plotattributes_in), colorbar_update_keys))
         _update_subplot_colorbars(sp)
     end
 


### PR DESCRIPTION
Added detection for colorbar limit-related attributes and call the update method from the `plot!` path.

Fixes #4490