### PR TITLE
restore inset bbox

### DIFF
--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -385,7 +385,18 @@ end
 # to absolute canvas coordinates, relative to the parent's plotarea
 update_inset_bboxes!(plt::Plot) =
     for sp in plt.inset_subplots
-        plotarea!(sp, Measures.resolve(plotarea(parent(sp)), sp[:relative_bbox]))
+        p_area = Measures.resolve(plotarea(sp.parent), sp[:relative_bbox])
+        plotarea!(sp, p_area)
+        # NOTE: `lens` example, `pgfplotsx` for non-regression
+        bbox!(
+            sp,
+            bbox(
+                left(p_area) - leftpad(sp),
+                top(p_area) - toppad(sp),
+                width(p_area) + leftpad(sp) + rightpad(sp),
+                height(p_area) + toppad(sp) + bottompad(sp),
+            ),
+        )
     end
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/4586.

Also fixes the `twin` and `lens` examples:

![pgf_twin](https://user-images.githubusercontent.com/13423344/206296447-2f681f06-0751-43bc-b0a6-88a70719d452.png)

![lens](https://user-images.githubusercontent.com/13423344/206297580-95f88c5d-ee82-4410-a18a-0b38b519ac83.png)
