### PR TITLE
Macro fps support

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -268,6 +268,11 @@ Example:
     push!(p, 1, sin(x))
   end
 ```
+This macro supports additional parameters, that may be added after the main loop body.
+- Add `fps=n` with positive Integer n, to specify the desired frames per second.
+- Add `every n` with positive Integer n, to take only one frame every nth iteration.
+- Add `when <cond>` where `<cond>` is an Expression resulting in a Boolean, to take a 
+    frame only when `<cond>` returns `true`. Is incompatible with `every`.
 """
 macro gif(forloop::Expr, args...)
     _animate(forloop, args...; type = :gif)
@@ -284,6 +289,11 @@ Example:
     push!(p, 1, sin(x))
   end
 ```
+This macro supports additional parameters, that may be added after the main loop body.
+- Add `fps=n` with positive Integer n, to specify the desired frames per second.
+- Add `every n` with positive Integer n, to take only one frame every nth iteration.
+- Add `when <cond>` where `<cond>` is an Expression resulting in a Boolean, to take a 
+    frame only when `<cond>` returns `true`. Is incompatible with `every`.
 """
 macro apng(forloop::Expr, args...)
     _animate(forloop, args...; type = :apng)
@@ -301,6 +311,11 @@ anim = @animate for x=0:0.1:5
 end
 gif(anim)
 ```
+This macro supports additional parameters, that may be added after the main loop body.
+- Add `fps=n` with positive Integer n, to specify the desired frames per second.
+- Add `every n` with positive Integer n, to take only one frame every nth iteration.
+- Add `when <cond>` where `<cond>` is an Expression resulting in a Boolean, to take a 
+    frame only when `<cond>` returns `true`. Is incompatible with `every`.
 """
 macro animate(forloop::Expr, args...)
     _animate(forloop, args...)

--- a/src/animation.jl
+++ b/src/animation.jl
@@ -220,11 +220,7 @@ function _animate(forloop::Expr, args...; type::Symbol = :none)
         elseif arg isa Expr && arg.head == Symbol("=")
             #specification of type <kwarg> = <spec>
             lhs, rhs = arg.args
-            if lhs in (:fps,)
-                push!(animationsKwargs, :($lhs = $rhs))
-            else
-                error("Parameter $(lhs) not supported")
-            end
+            push!(animationsKwargs, :($lhs = $rhs))
         else
             error("Parameter specification not understood: $(arg)")
         end

--- a/test/test_animations.jl
+++ b/test/test_animations.jl
@@ -39,6 +39,28 @@ end
         circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
     end when i % 5 == 0
 
+    @gif for i in 1:n
+        circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
+    end when i % 5 == 0 fps = 10
+
+    @test_throws ErrorException macroexpand(
+        @__MODULE__,
+        quote
+            @gif for i in 1:n
+                circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
+            end when i % 5 == 0 every 10 # cannot use every and when together
+        end,
+    )
+
+    @test_throws ErrorException macroexpand(
+        @__MODULE__,
+        quote
+            @gif for i in 1:n
+                circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
+            end asdf = bla #asdf is not allowed
+        end,
+    )
+
     anim = Plots.@apng for i in 1:n
         circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
     end every 5

--- a/test/test_animations.jl
+++ b/test/test_animations.jl
@@ -43,7 +43,7 @@ end
         circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
     end when i % 5 == 0 fps = 10
 
-    @test_throws ErrorException macroexpand(
+    @test_throws LoadError macroexpand(
         @__MODULE__,
         quote
             @gif for i in 1:n
@@ -52,12 +52,12 @@ end
         end,
     )
 
-    @test_throws ErrorException macroexpand(
+    @test_nowarn macroexpand(
         @__MODULE__,
         quote
             @gif for i in 1:n
                 circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
-            end asdf = bla #asdf is not allowed
+            end asdf = bla #asdf is allowed
         end,
     )
 


### PR DESCRIPTION
Hello.

I rewrote the `_animate` function, so that the animation macros `@gif`, `@animate`  and `@apng` support an extra fps-parameter. 
This includes some restructuring which could make possible future parameter additions somewhat simpler. 

I also added Documentation for these macros to properly communicate this functionality.