### PR TITLE
remove `SnoopPrecompile` dependency

### DIFF
--- a/RecipesBase/Project.toml
+++ b/RecipesBase/Project.toml
@@ -3,11 +3,7 @@ uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 author = ["Tom Breloff (@tbreloff)"]
 version = "1.3.2"
 
-[deps]
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
-
 [compat]
-SnoopPrecompile = "1"
 julia = "1.6"
 
 [extras]

--- a/RecipesBase/src/RecipesBase.jl
+++ b/RecipesBase/src/RecipesBase.jl
@@ -1,7 +1,5 @@
 module RecipesBase
 
-using SnoopPrecompile
-
 export @recipe,
     @series,
     @userplot,
@@ -596,26 +594,4 @@ macro layout(mat::Expr)
     create_grid(mat)
 end
 
-# COV_EXCL_START
-@precompile_setup begin
-    struct __RecipesBasePrecompileType end
-    @precompile_all_calls begin
-        @layout [a b; c]
-        @layout [a{0.3w}; b{0.2h}]
-        @layout [_ ° _; ° ° °; ° ° °]
-        # @userplot __RecipesBasePrecompileType  # fails (export statements)
-        @recipe f(::__RecipesBasePrecompileType) = begin
-            @series begin
-                markershape --> :auto, :require
-                markercolor --> customcolor, :force
-                xrotation --> 5
-                zrotation --> 6, :quiet
-                fillcolor := :green
-                ones(1)
-            end
-            zeros(1)
-        end
-    end
-end
-# COV_EXCL_STOP
 end


### PR DESCRIPTION
This might be an overkill (https://github.com/timholy/SnoopCompile.jl/pull/318#issuecomment-1353079214), and can cause precompilation issues.