### PR TITLE
Delete duplicated `:markercolor` document for `scatter`

### DIFF
--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -10,7 +10,6 @@ Make a scatter plot of `y` vs `x`.
 - $(_document_argument(:markersize))
 - $(_document_argument(:markercolor))
 - $(_document_argument(:markershape))
-- $(_document_argument(:markercolor))
 - $(_document_argument(:markeralpha))
 
 # Examples


### PR DESCRIPTION
Fixed this document problem:
![image](https://user-images.githubusercontent.com/62785981/209459110-521e82d9-c598-46fe-9683-4cffc38e6b58.png)
