### PR TITLE
support plotting offset images

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1309,7 +1309,7 @@ function clamp_greys!(mat::AMat{<:Gray})
 end
 
 @recipe function f(mat::AMat{<:Gray})  # COV_EXCL_LINE
-    n, m = map(a -> range(0.5, stop = a.stop + 0.5), axes(mat))
+    n, m = map(a -> range(first(a) - 0.5, stop = last(a) + 0.5), axes(mat))
 
     if is_seriestype_supported(:image)
         seriestype := :image
@@ -1328,7 +1328,7 @@ end
 
 # images - colors
 @recipe function f(mat::AMat{T}) where {T<:Colorant}  # COV_EXCL_LINE
-    n, m = map(a -> range(0.5, stop = a.stop + 0.5), axes(mat))
+    n, m = map(a -> range(first(a) - 0.5, stop = last(a) + 0.5), axes(mat))
 
     if is_seriestype_supported(:image)
         seriestype := :image

--- a/test/test_recipes.jl
+++ b/test/test_recipes.jl
@@ -51,6 +51,21 @@ end
     @test length(sticks) == 1
 end
 
+@testset "offset images" begin
+    img = OffsetMatrix(rand(RGB{Colors.N0f8}, 11, 11), -5:5, -5:5)
+    plt = plot(img)
+    @test length(plt) == 1
+
+    plt = plot(Gray.(img))
+    @test length(plt) == 1
+
+    data = OffsetMatrix(rand(11, 11), -5:5, -5:5)
+    @test_broken begin
+        plt = plot(data)
+        length(plt) == 1
+    end
+end
+
 # NOTE: the following test seems to trigger these deprecated warnings:
 # WARNING: importing deprecated binding Colors.RGB1 into PlotUtils.
 # WARNING: importing deprecated binding Colors.RGB1 into Plots.


### PR DESCRIPTION
`plot(::OffsetMatrix{<:Colorant})` currently fails, because the recipe
assumes all axes are one-based. I wasn't sure how to add a test for
this, so I'd appreciate any pointers.
