### PR TITLE
enable more precompilation on Windows

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -2005,6 +2005,8 @@ for (mime, fmt) in (
     @eval function _show(io::IO, ::MIME{Symbol($mime)}, plt::Plot{GRBackend})
         dpi_factor = $fmt == "png" ? plt[:dpi] / Plots.DPI : 1
         filepath = tempname() * "." * $fmt
+        # workaround  windows bug github.com/JuliaLang/julia/issues/46989
+        touch(filepath)
         GR.emergencyclosegks()
         withenv(
             "GKS_FILEPATH" => filepath,

--- a/src/init.jl
+++ b/src/init.jl
@@ -145,8 +145,6 @@ if bool_env("PLOTS_PRECOMPILE", "true") && bool_env("JULIA_PKG_PRECOMPILE_AUTO",
                         show(devnull, pl)
                         # FIXME: pgfplotsx requires bug
                         backend_name() === :pgfplotsx && return
-                        # FIXME: windows bug github.com/JuliaLang/julia/issues/46989
-                        Sys.iswindows() && return
                         showable(MIME"image/png"(), pl) && savefig(pl, "$fn.png")
                         showable(MIME"application/pdf"(), pl) && savefig(pl, "$fn.pdf")
                         nothing


### PR DESCRIPTION
This works around JuliaLang/julia/issues/46989 and give good speedups on 1.9.0:

Before:

```julia
julia> @time (p = plot(rand(2,2)); display(p))
  3.102817 seconds (9.33 M allocations: 580.555 MiB, 3.48% gc time, 141.40% compilation time: <1% of which was recompilation)
```

After:

```julia
julia> @time (p = plot(rand(2,2)); display(p))
  0.190534 seconds (75.80 k allocations: 4.387 MiB, 93.92% compilation time: 7% of which was recompilation)
```
