### PR TITLE
fix tick formatter with functions returning numerical values

### DIFF
--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -20,6 +20,29 @@
     @test Plots.labelfunc_tex(:log10)(1) == "10^{1}"
     @test Plots.labelfunc_tex(:log2)(1) == "2^{1}"
     @test Plots.labelfunc_tex(:ln)(1) == "e^{1}"
+
+    @test Plots.get_labels(:auto, 1:3, :identity) == ["1", "2", "3"]
+    @test Plots.get_labels(:scientific, float.(500:500:1500), :identity) ==
+          ["5.00×10^{2}", "1.00×10^{3}", "1.50×10^{3}"]
+    @test Plots.get_labels(:engineering, float.(500:500:1500), :identity) ==
+          ["500.×10^{0}", "1.00×10^{3}", "1.50×10^{3}"]
+    @test Plots.get_labels(:latex, 1:3, :identity) == ["\$1\$", "\$2\$", "\$3\$"]
+    @test Plots.get_labels(:auto, 1:3, :log10) == ["10^{1}", "10^{2}", "10^{3}"]
+    @test Plots.get_labels(:auto, 1:3, :log2) == ["2^{1}", "2^{2}", "2^{3}"]
+    @test Plots.get_labels(:auto, 1:3, :ln) == ["e^{1}", "e^{2}", "e^{3}"]
+    @test Plots.get_labels(:latex, 1:3, :log10) ==
+          ["\$10^{1}\$", "\$10^{2}\$", "\$10^{3}\$"]
+    @test Plots.get_labels(:latex, 1:3, :log2) == ["\$2^{1}\$", "\$2^{2}\$", "\$2^{3}\$"]
+    @test Plots.get_labels(:latex, 1:3, :ln) == ["\$e^{1}\$", "\$e^{2}\$", "\$e^{3}\$"]
+
+    @test Plots.get_labels(x -> 1e3x, 1:3, :identity) == ["1000", "2000", "3000"]
+    @test Plots.get_labels(x -> 1e3x, 1:3, :log10) == ["10^{4}", "10^{5}", "10^{6}"]
+    @test Plots.get_labels(x -> 8x, 1:3, :log2) == ["2^{4}", "2^{5}", "2^{6}"]
+    @test Plots.get_labels(x -> ℯ * x, 1:3, :ln) == ["e^{2}", "e^{3}", "e^{4}"]
+    @test Plots.get_labels(x -> string(x, " MB"), 1:3, :identity) ==
+          ["1.0 MB", "2.0 MB", "3.0 MB"]
+    @test Plots.get_labels(x -> string(x, " MB"), 1:3, :log10) ==
+          ["10.0 MB", "100.0 MB", "1000.0 MB"]
 end
 
 @testset "Showaxis" begin


### PR DESCRIPTION
Some recent changes introduced a bug when providing a function that returns numerical values to the axis formatter:
```julia
julia> plot(1:10, yformatter=y -> 1e3y)
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: MethodError: Cannot `convert` an object of type Float64 to an object of type String
Closest candidates are:
  convert(::Type{String}, ::String) at essentials.jl:218
  convert(::Type{T}, ::T) where T<:AbstractString at strings/basic.jl:231
  convert(::Type{T}, ::AbstractString) where T<:AbstractString at strings/basic.jl:232
  ...
Stacktrace:
   [1-8] ⋮ internal
       @ Base, Unknown
     [9] convert(#unused#::Type{Vector{String}}, a::Vector{Float64})
       @ Base ./array.jl:617
    [10] optimal_ticks_and_labels(ticks::Nothing, alims::Tuple{Float64, Float64}, scale::Symbol, formatter::Function)
       @ Plots ~/.julia/dev/Plots/src/axes.jl:199
    [11] get_ticks(::Symbol, ::Vector{Float64}, ::Vector{Any}, ::Tuple{Float64, Float64}, ::Vararg{Any})
       @ Plots ~/.julia/dev/Plots/src/axes.jl:301
    [12] get_ticks(sp::Plots.Subplot{Plots.GRBackend}, axis::Plots.Axis; update::Bool, formatter::Function)
       @ Plots ~/.julia/dev/Plots/src/axes.jl:222
    [13] get_ticks(sp::Plots.Subplot{Plots.GRBackend}, axis::Plots.Axis)
       @ Plots ~/.julia/dev/Plots/src/axes.jl:206
```

With this PR we get again
![formatter_new](https://user-images.githubusercontent.com/16589944/210501329-55559a31-74fa-444c-99b8-395ab0c01f67.png)

Furthermore, this PR improves (imho) the combination of log scale and latex formatter
```julia
plot(1:10, yscale=:log10, yformatter=:latex)
```
Before:
![formatter_log_latex_old](https://user-images.githubusercontent.com/16589944/210501512-cf7d7cda-93f4-4bb1-a66f-60092dbb1cc7.png)

Now:
![formatter_log_latex_new](https://user-images.githubusercontent.com/16589944/210501635-603b78ba-9c57-4a18-8482-868738849fed.png)

