### PR TITLE
don't overwrite custom formatter for with vline!

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1349,8 +1349,8 @@ function preprocess_attributes!(plotattributes::AKW)
     if treats_y_as_x(get(plotattributes, :seriestype, :path))
         xformatter = get(plotattributes, :xformatter, :auto)
         yformatter = get(plotattributes, :yformatter, :auto)
-        plotattributes[:xformatter] = yformatter
-        plotattributes[:yformatter] = xformatter
+        yformatter === :auto || (plotattributes[:xformatter] = yformatter)
+        xformatter === :auto || (plotattributes[:yformatter] = xformatter)
     end
 
     # handle grid args common to all axes


### PR DESCRIPTION
fix #4538
```julia
plot(rand(4) .* 10^6, rand(4) .* 10^6, xformatter=:plain, yformatter=:plain)
vline!([10^6])
```
![vline_formatter](https://user-images.githubusercontent.com/16589944/210507108-1d096460-77df-4bd3-86ac-1d46464a3ef6.png)
