### PR TITLE
use === instead of == to compare Symbols

### DIFF
--- a/RecipesBase/src/RecipesBase.jl
+++ b/RecipesBase/src/RecipesBase.jl
@@ -73,10 +73,10 @@ _is_arrow_tuple(expr::Expr) =
     expr.head ≡ :tuple &&
     !isempty(expr.args) &&
     isa(expr.args[1], Expr) &&
-    expr.args[1].head == :(-->)
+    expr.args[1].head === :(-->)
 
-_equals_symbol(x::Symbol, sym::Symbol) = x == sym
-_equals_symbol(x::QuoteNode, sym::Symbol) = x.value == sym
+_equals_symbol(x::Symbol, sym::Symbol) = x === sym
+_equals_symbol(x::QuoteNode, sym::Symbol) = x.value === sym
 _equals_symbol(x, sym::Symbol) = false
 
 # build an apply_recipe function header from the recipe function header
@@ -112,7 +112,7 @@ function create_kw_body(func_signature::Expr)
     if isa(arg1, Expr) && arg1.head ≡ :parameters
         for kwpair in arg1.args
             k, v = kwpair.args
-            if isa(k, Expr) && k.head == :(::)
+            if isa(k, Expr) && k.head === :(::)
                 k = k.args[1]
                 @warn """
                 Type annotations on keyword arguments not currently supported in recipes.
@@ -163,14 +163,14 @@ function process_recipe_body!(expr::Expr)
 
             # the unused operator `:=` will mean force: `x := 5` is equivalent to `x --> 5, force`
             # note: this means "x is defined as 5"
-            if e.head == :(:=)
+            if e.head === :(:=)
                 force = true
                 e.head = :(-->)
             end
 
             # we are going to recursively swap out `a --> b, flags...` commands
             # note: this means "x may become 5"
-            if e.head == :(-->)
+            if e.head === :(-->)
                 k, v = e.args
                 if isa(k, Symbol)
                     k = QuoteNode(k)


### PR DESCRIPTION
I found invalidations from loading both RecipesBase.jl and SciMLBase.jl using the beta of Julia 1.9:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("SciMLBase"); Pkg.develop("RecipesBase")

julia> using SnoopCompileCore; invalidations = @snoopr(using RecipesBase, SciMLBase); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
[...]
 inserting ==(retcode::SciMLBase.ReturnCode.T, s::Symbol) @ SciMLBase ~/.julia/packages/SciMLBase/QqtZA/src/retcodes.jl:348 invalidated:
   backedges: 1: superseding ==(x, y) @ Base Base.jl:127 with MethodInstance for ==(::Any, ::Symbol) (12 children)
```

I fixed invalidations by using `===` instead of `==` when comparing to a `Symbol`, which is also recommended in the docstring of `Symbol`:
```julia
help?> Symbol
search: Symbol
[...]
  Symbols are immutable and should be compared using ===. The implementation re-uses the same object for all
  Symbols with the same name, so comparison tends to be efficient (it can just compare pointers).
[...]
```
