### PR TITLE
Add :unitformat to _base_supported_args

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -315,6 +315,7 @@ const _base_supported_args = [
     :show_empty_bins,
     :z_order,
     :permute,
+    :unitformat,
 ]
 
 function merge_with_base_supported(v::AVec)


### PR DESCRIPTION
This prevents `:unitformat` from getting into `extra_kwargs`
and crashing the PGFPlotsX backend.