### PR TITLE
switch to lowercase 'plotly' require.js dependency

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1071,10 +1071,10 @@ function plotly_html_body(plt, style = nothing)
         requirejs_prefix = """
             requirejs.config({
                 paths: {
-                    Plotly: '$(plotly_no_ext)'
+                    plotly: '$(plotly_no_ext)'
                 }
             });
-            require(['Plotly'], function (Plotly) {
+            require(['plotly'], function (Plotly) {
         """
         requirejs_suffix = "});"
     end


### PR DESCRIPTION
Plots.jl makes the RequiresJS dependency uppercase 'Plotly' but [plotly.py](https://github.com/plotly/plotly.py/blob/2b6ec1e16bebe260dfc673db869805f7ceb86e00/packages/python/plotly/plotly/io/_html.py#L269) and [PlotlyJS](https://github.com/sglyon/PlotlyBase.jl/blob/master/src/output.jl#L29) have it lowercase 'plotly'. If you export figures from each of them and try to splice them into the same parent document, it makes it really hard to resolve the dependency (since to my very noob knowledge, you can't load the same library under two different names). This PR makes Plots.jl consistent with the others. 

Have not tested extensively beyond my simple cases so someone that knows what they're doing should definitely verify this. 

