### PR TITLE
don't write nans into zlims

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -557,7 +557,7 @@ function plotly_series(plt::Plot, series::Series)
 
     plotattributes_out[:colorbar] = plotly_colorbar(sp)
 
-    if is_2tuple(clims)
+    if is_2tuple(clims) && all(!isnan, clims)
         plotattributes_out[:zmin], plotattributes_out[:zmax] = clims
     end
 

--- a/test/test_plotly.jl
+++ b/test/test_plotly.jl
@@ -1,3 +1,4 @@
+using Plots, Test
 with(:plotly) do
     @testset "Basic" begin
         @test backend() == Plots.PlotlyBackend()
@@ -5,6 +6,7 @@ with(:plotly) do
         pl = plot(rand(10))
         @test pl isa Plot
         @test_nowarn Plots.plotly_series(plot())
+        @test !isnan(Plots.plotly_series(pl)[1][:zmax])
     end
 
     @testset "Contours" begin


### PR DESCRIPTION
Thats an issue since JSON does not allow NaNs, JSON.jl used to convert them to `nul`, but JSON3.jl does not.

Ref: https://github.com/quinnj/JSON3.jl/pull/51
Ref: https://github.com/plotly/Dash.jl/issues/160