### PR TITLE
Added arbitrary legend_columns for gr

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1213,9 +1213,20 @@ function gr_get_legend_geometry(vp, sp)
         GR.selntran(1)
         GR.restorestate()
     end
-    # if !vertical && legend_column > 0 && legend_column != nseries
-    #     @warn "n° of legend_column=$legend_column is not compatible with n° of series=$nseries"
-    # end
+    # deal with layout
+    column_layout = if legend_column == -1
+        (1, has_title + nseries)
+    elseif legend_column > nseries && nseries != 0 # catch plot_title here
+        @warn "n° of legend_column=$legend_column is larger than n° of series=$nseries"
+        (1 + has_title, nseries)
+    elseif legend_column == 0
+        @warn "n° of legend_column=$legend_column. Assuming vertical layout."
+        vertical = true
+        (has_title + nseries, 1)
+    else
+        (ceil(Int64, nseries / legend_column) + has_title, legend_column)
+    end
+    println(column_layout)
 
     base_factor = width(vp) / 45  # determines legend box base width (arbitrarily based on `width`)
 
@@ -1243,17 +1254,6 @@ function gr_get_legend_geometry(vp, sp)
     base_markersize = gr_legend_marker_to_line_factor[] * span / dy  # NOTE: arbitrarily based on horizontal measures !
 
     entries = has_title + nseries  # number of legend entries
-    column_layout = if legend_column == -1
-        (1, has_title + nseries)
-    else
-        if legend_column > nseries
-            legend_column = nseries
-            @warn "n° of legend_column=$legend_column is larger than n° of series=$nseries"
-        end
-        column_layout =
-            (ceil(Int64, nseries / legend_column) + has_title, legend_column)
-    end
-    println(column_layout)
 
     # NOTE: substract `span_hspace`, since it joins labels in horizontal mode
     w = dx * column_layout[2] - space - !vertical * span_hspace

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -989,9 +989,10 @@ function gr_add_legend(sp, leg, viewport_area)
     GR.selntran(0)
     GR.setscale(0)
     vertical = leg.vertical
+    legend_rows, legend_cols = leg.column_layout
     if leg.w > 0 || leg.h > 0
         xpos, ypos = gr_legend_pos(sp, leg, viewport_area)  # position between the legend line and text (see ref(1))
-        # @show vertical leg.w leg.h leg.pad leg.span leg.entries (xpos, ypos) leg.dx leg.dy leg.textw leg.texth
+        #@show vertical leg.w leg.h leg.pad leg.span leg.entries (legend_rows, legend_cols) (xpos, ypos) leg.dx leg.dy leg.textw leg.texth
         GR.setfillintstyle(GR.INTSTYLE_SOLID)
         gr_set_fillcolor(sp[:legend_background_color])
         # ymax
@@ -1005,10 +1006,12 @@ function gr_add_legend(sp, leg, viewport_area)
         gr_set_line(1, :solid, sp[:legend_foreground_color], sp)
         GR.drawrect(xs..., ys...)  # drawing actual legend width here
         if (ttl = sp[:legend_title]) !== nothing
+            shift = legend_rows > 1 ? 0.5(legend_cols - 1) * leg.dx : 0 # shifting title to center if multi-column
             gr_set_font(legendtitlefont(sp), sp)
             _debug[] && gr_legend_bbox(xpos, ypos, leg)
-            gr_text(xpos - leg.pad - leg.space + 0.5leg.textw, ypos, string(ttl))
-            if vertical
+            gr_text(xpos - leg.pad - leg.space + 0.5leg.textw + shift, ypos, string(ttl))
+            if vertical || legend_rows != 1
+                legend_rows -= 1
                 ypos -= leg.dy
             else
                 xpos += leg.dx
@@ -1021,6 +1024,8 @@ function gr_add_legend(sp, leg, viewport_area)
 
         min_lw = DEFAULT_LINEWIDTH[] / gr_lw_clamp_factor[]
         max_lw = DEFAULT_LINEWIDTH[] * gr_lw_clamp_factor[]
+
+        nentry = 1
 
         for series in series_list(sp)
             should_add_to_legend(series) || continue
@@ -1085,7 +1090,10 @@ function gr_add_legend(sp, leg, viewport_area)
             if vertical
                 ypos -= leg.dy
             else
-                xpos += leg.dx
+                # println(string(series[:label]), " ", nentry, " ", nentry % legend_cols)
+                xpos += nentry % legend_cols == 0 ? -(legend_cols - 1) * leg.dx : leg.dx
+                ypos -= nentry % legend_cols == 0 ? leg.dy : 0
+                nentry += 1
             end
         end
     end
@@ -1205,9 +1213,9 @@ function gr_get_legend_geometry(vp, sp)
         GR.selntran(1)
         GR.restorestate()
     end
-    if !vertical && legend_column > 0 && legend_column != nseries
-        @warn "n° of legend_column=$legend_column is not compatible with n° of series=$nseries"
-    end
+    # if !vertical && legend_column > 0 && legend_column != nseries
+    #     @warn "n° of legend_column=$legend_column is not compatible with n° of series=$nseries"
+    # end
 
     base_factor = width(vp) / 45  # determines legend box base width (arbitrarily based on `width`)
 
@@ -1235,10 +1243,21 @@ function gr_get_legend_geometry(vp, sp)
     base_markersize = gr_legend_marker_to_line_factor[] * span / dy  # NOTE: arbitrarily based on horizontal measures !
 
     entries = has_title + nseries  # number of legend entries
+    column_layout = if legend_column == -1
+        (1, has_title + nseries)
+    else
+        if legend_column > nseries
+            legend_column = nseries
+            @warn "n° of legend_column=$legend_column is larger than n° of series=$nseries"
+        end
+        column_layout =
+            (ceil(Int64, nseries / legend_column) + has_title, legend_column)
+    end
+    println(column_layout)
 
     # NOTE: substract `span_hspace`, since it joins labels in horizontal mode
-    w = (vertical ? dx : dx * entries - span_hspace) - space
-    h = vertical ? dy * entries : dy
+    w = dx * column_layout[2] - space - !vertical * span_hspace
+    h = dy * column_layout[1]
 
     (
         yoffset = height(vp) / 30,
@@ -1248,6 +1267,7 @@ function gr_get_legend_geometry(vp, sp)
         has_title,
         vertical,
         entries,
+        column_layout,
         space,
         texth,
         textw,

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1226,7 +1226,7 @@ function gr_get_legend_geometry(vp, sp)
     else
         (ceil(Int64, nseries / legend_column) + has_title, legend_column)
     end
-    println(column_layout)
+    #println(column_layout)
 
     base_factor = width(vp) / 45  # determines legend box base width (arbitrarily based on `width`)
 


### PR DESCRIPTION
Since I modified the code for myself I thought it would be nice to also upload so others can use it.
Especially since it is asked quite often e.g. on [Discourse](https://discourse.julialang.org/t/plot-legend-with-multiple-columns/29195) and #2423.
For now it is just a quick hacky solution but it works with `legend_title` and without. Also it differs between `legend_column=-1` as a full horizontal version and `legend_column=nseries` where only the labels are printed horizontally but the `legend_title` is printed center-aligned above the series.

So maybe even if it is not merged it may help some people or be useful when switching to `Plots 2.0`

The following code produces the output and the figure below
```julia 
data = rand(10, 3)
leg_cols = -1:4

leg_plots(; kw...) = begin
  map((leg_col -> begin
      plot(data; marker=:circle, ticks=:none, plot_title=string("legend_columns = ", leg_col), legend_columns=leg_col, kw...)
    end), leg_cols)
end
(w, h) = Plots._plot_defaults[:size]
with(scalefonts=1, size=(w, h)) do
  plot(leg_plots()..., leg_plots(legend_title="Test")...; layout=(4, 3))
end
```

``` julia
┌ Warning: n° of legend_column=0. Assuming vertical layout.
└ @ Plots ~/.julia/dev/Plots/src/backends/gr.jl:1223
┌ Warning: n° of legend_column=4 is larger than n° of series=3
└ @ Plots ~/.julia/dev/Plots/src/backends/gr.jl:1220
┌ Warning: n° of legend_column=0. Assuming vertical layout.
└ @ Plots ~/.julia/dev/Plots/src/backends/gr.jl:1223
┌ Warning: n° of legend_column=4 is larger than n° of series=3
└ @ Plots ~/.julia/dev/Plots/src/backends/gr.jl:1220
```
![multi_colums_gr](https://user-images.githubusercontent.com/20151553/215746282-8b31abac-27bf-4826-aef2-02e897ac2d2e.svg)
