### PR TITLE
Add AbstractVector `Shape(x, y)` constructor

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -26,6 +26,9 @@ Construct a polygon to be plotted
 """
 Shape(verts::AVec) = Shape(RecipesPipeline.unzip(verts)...)
 Shape(s::Shape) = deepcopy(s)
+function Shape(x::AVec{X}, y::AVec{Y}) where {X,Y}
+    return Shape(convert(Vector{X}, x), convert(Vector{Y}, y))
+end
 
 get_xs(shape::Shape) = shape.x
 get_ys(shape::Shape) = shape.y

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -7,6 +7,12 @@
         @test isa(square, Shape{Int64,Float64})
         @test coords(square) isa Tuple{Vector{S},Vector{T}} where {T,S}
         @test Shape(:circle) isa Shape
+
+        xs = view([0.0, 1.0, 2.0, 1.25], 1:3)
+        ys = view([6 4 7; 9 9 9], 1, :)
+        tri = Shape(xs, ys)
+        @test isa(tri, Shape{Float64,Int64})
+        @test Plots.vertices(tri) == [(0.0, 6), (1.0, 4), (2.0, 7)]
     end
 
     @testset "Copy" begin


### PR DESCRIPTION
Added a constructor for `Shape(x, y)` where `x` and `y` are abstract vectors. Before, `Shape(x, y)` would only accept `Vector`s.