### PR TITLE
Wrapping of power in PGFPlotsX labels

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -81,6 +81,8 @@ curly(obj) = "{$(string(obj))}"
 latex_formatter(formatter::Symbol) = formatter in (:plain, :latex) ? formatter : :latex
 latex_formatter(formatter::Function) = formatter
 
+labelfunc(scale::Symbol, backend::PGFPlotsXBackend) = labelfunc_tex(scale)
+
 pgfx_halign(k) = (left = "left", hcenter = "center", center = "center", right = "right")[k]
 
 function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -27,6 +27,10 @@
     @test Plots.get_labels(:engineering, float.(500:500:1500), :identity) ==
           ["500.×10^{0}", "1.00×10^{3}", "1.50×10^{3}"]
     @test Plots.get_labels(:latex, 1:3, :identity) == ["\$1\$", "\$2\$", "\$3\$"]
+    # GR is used during tests and it correctly overrides labelfunc(), but PGFPlotsX does not and will fail
+    pgfplotsx()
+    @test Plots.get_labels(:auto, 1:3, :log10) == ["10^{1}", "10^{2}", "10^{3}"]
+    gr()
     @test Plots.get_labels(:auto, 1:3, :log10) == ["10^{1}", "10^{2}", "10^{3}"]
     @test Plots.get_labels(:auto, 1:3, :log2) == ["2^{1}", "2^{2}", "2^{3}"]
     @test Plots.get_labels(:auto, 1:3, :ln) == ["e^{1}", "e^{2}", "e^{3}"]

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -27,10 +27,10 @@
     @test Plots.get_labels(:engineering, float.(500:500:1500), :identity) ==
           ["500.×10^{0}", "1.00×10^{3}", "1.50×10^{3}"]
     @test Plots.get_labels(:latex, 1:3, :identity) == ["\$1\$", "\$2\$", "\$3\$"]
-    # GR is used during tests and it correctly overrides labelfunc(), but PGFPlotsX does not and will fail
-    pgfplotsx()
-    @test Plots.get_labels(:auto, 1:3, :log10) == ["10^{1}", "10^{2}", "10^{3}"]
-    gr()
+    # GR is used during tests and it correctly overrides labelfunc(), but PGFPlotsX did not
+    with(:pgfplotsx) do
+        @test Plots.get_labels(:auto, 1:3, :log10) == ["10^{1}", "10^{2}", "10^{3}"]
+    end
     @test Plots.get_labels(:auto, 1:3, :log10) == ["10^{1}", "10^{2}", "10^{3}"]
     @test Plots.get_labels(:auto, 1:3, :log2) == ["2^{1}", "2^{2}", "2^{3}"]
     @test Plots.get_labels(:auto, 1:3, :ln) == ["e^{1}", "e^{2}", "e^{3}"]


### PR DESCRIPTION
Fixes #4676

I'd like to bring to attention that the tests for axes are not backend-agnostic - current tests are passed because GR overrided ```labelfunc```, but PGFPlotsX did not and failed.
I added a new test, but it changes the backend during a run, which I think is not good.