### PR TITLE
Add svg+xml generation to precompile setup

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -110,6 +110,9 @@ include(_path(backend_name()))
                     end
                     showable(MIME"image/png"(), pl) && savefig(pl, "$fn.png")
                     showable(MIME"application/pdf"(), pl) && savefig(pl, "$fn.pdf")
+                    if showable(MIME"image/svg+xml"(), pl)
+                        show(IOBuffer(), MIME"image/svg+xml"(), pl)
+                    end
                     nothing
                 end
                 $func()


### PR DESCRIPTION
I think this speeds up first plot in VScode and Jupyter a bit more, subjectively.