### PR TITLE
Do not include plotly.jl twice

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -534,7 +534,7 @@ _post_imports(::PlotlyBackend) = @eval begin
     const PlotlyKaleido = Main.PlotlyKaleido
     # FIXME: in Plots `2.0`, `plotly` backend should be re-named to `plotlybase`
     # so that we can trigger include on `@require` instead of this
-    include(_path(:plotly))
+    CURRENT_BACKEND.sym === :plotly || include(_path(:plotly))
     include(_path(:plotlybase))
 end
 function _initialize_backend(pkg::PlotlyBackend)
@@ -553,7 +553,9 @@ function _initialize_backend(pkg::PlotlyBackend)
         # NOTE: `plotly` is special in the way that it does not require dependencies for displaying a plot
         # as a result, we cannot rely on the `@require` mechanism for loading glue code
         # this is why it must be done here.
-        @eval include(_path(:plotly))
+        if CURRENT_BACKEND.sym !== :plotly
+            @eval include(_path(:plotly))
+        end
     end
 end
 

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -534,7 +534,7 @@ _post_imports(::PlotlyBackend) = @eval begin
     const PlotlyKaleido = Main.PlotlyKaleido
     # FIXME: in Plots `2.0`, `plotly` backend should be re-named to `plotlybase`
     # so that we can trigger include on `@require` instead of this
-    CURRENT_BACKEND.sym === :plotly || include(_path(:plotly))
+    PLOTS_DEFAULT_BACKEND == "plotly" || include(_path(:plotly))
     include(_path(:plotlybase))
 end
 function _initialize_backend(pkg::PlotlyBackend)
@@ -553,9 +553,7 @@ function _initialize_backend(pkg::PlotlyBackend)
         # NOTE: `plotly` is special in the way that it does not require dependencies for displaying a plot
         # as a result, we cannot rely on the `@require` mechanism for loading glue code
         # this is why it must be done here.
-        if CURRENT_BACKEND.sym !== :plotly
-            @eval include(_path(:plotly))
-        end
+        PLOTS_DEFAULT_BACKEND == "plotly" || @eval include(_path(:plotly))
     end
 end
 

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1,7 +1,5 @@
 # https://plot.ly/javascript/getting-started
 
-is_subplot_supported(::PlotlyBackend) = true
-# is_string_supported(::PlotlyBackend) = true
 _plotly_framestyle(style::Symbol) =
     if style in (:box, :axes, :zerolines, :grid, :none)
         style


### PR DESCRIPTION
At the moment when setting `:plotly` as the default backend (using Preferences) one gets quite a few warning of the type
```
WARNING: Method definition is_subplot_supported(Plots.PlotlyBackend) in module Plots at /home/stephan/.julia/dev/Plots/src/backends/plotly.jl:4 overwritten on the same line (check for duplicate calls to `include`).
  ** incremental compilation may be fatally broken for this module **
```
They are the result of `src/backend/plotly.jl` being included twice. The following commit is a workaround that seems to fix this. 