### PR TITLE
Fix PGFPlotsX axis mirror in box framestyle

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -1258,6 +1258,11 @@ function pgfx_axis!(opt::Options, sp::Subplot, letter)
         )
     end
 
+    # allow axis mirroring with :box framestyle
+    if framestyle in (:box,)
+        push!(opt, "$(letter)ticklabel pos" => (axis[:mirror] ? "right" : "left"))
+    end
+
     if framestyle === :zerolines
         gs = pgfx_linestyle(pgfx_thickness_scaling(sp), axis[:foreground_color_border], 1)
         push!(


### PR DESCRIPTION
Fixes #4634 
Testing code:
```julia
using Plots 

pgfplotsx()

plot(
    plot(0:1, 0:1, title="default"                                                         ),
    plot(0:1, 0:1, title="xmirror, nobox",  xmirror=true                                   ),
    plot(0:1, 0:1, title="ymirror, nobox",                  ymirror=true                   ),
    plot(0:1, 0:1, title="xymirror, nobox", xmirror=true,   ymirror=true                   ),
    plot(0:1, 0:1, title="box",                                             framestyle=:box),
    plot(0:1, 0:1, title="xmirror, box",    xmirror=true,                   framestyle=:box),
    plot(0:1, 0:1, title="ymirror, box",                    ymirror=true,   framestyle=:box),
    plot(0:1, 0:1, title="xymirror, box",   xmirror=true,   ymirror=true,   framestyle=:box),
    layout=(2,4), legend=:none, xticks=[0,1], yticks=[0,1]
)
```
Before fix
![nofix](https://user-images.githubusercontent.com/66747290/224174443-3fae2170-b273-44ef-ad04-0f168fbeef34.png)
After fix
![with-fix](https://user-images.githubusercontent.com/66747290/224174500-3bc74b5f-2c30-4f2d-b896-07772d46b767.png)