### PR TITLE
Transparent background in GR and PGFPlotsX

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1786,7 +1786,7 @@ function fg_color(plotattributes::AKW)
     fg = get(plotattributes, :foreground_color, :auto)
     if fg === :auto
         bg = plot_color(get(plotattributes, :background_color, :white))
-        fg = isdark(bg) ? colorant"white" : colorant"black"
+        fg = alpha(bg) > 0 && isdark(bg) ? colorant"white" : colorant"black"
     else
         plot_color(fg)
     end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -337,6 +337,9 @@ gr_z_axislims(sp::Subplot) = axis_limits(sp, :z)
 gr_xy_axislims(sp::Subplot) = gr_x_axislims(sp)..., gr_y_axislims(sp)...
 
 function gr_fill_viewport(vp::GRViewport, c)
+    if alpha(c) == 0
+        return nothing
+    end
     GR.savestate()
     GR.selntran(0)
     GR.setscale(0)

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -104,6 +104,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 "/tikz/background rectangle/.style" => Options(
                     # "draw" => "black",
                     "fill" => cstr,
+                    "fill opacity" => alpha(cstr),
                     "draw opacity" => alpha(cstr),
                 ),
                 "show background rectangle" => nothing,


### PR DESCRIPTION
## Description
- Use the default color palette (dark) with a fully transparent background. 
I imagine it's reasonable, since we can't know what colorscheme a user wants with such a background.
- Allow full transparency in GR's PDFs and PNGs.
- Allow full and partial transparency in PGFPlotsX's PDFs.

Related issues #2725 #2899, but won't close, since it's a partial fix.

<details><summary>Code to generate images</summary>
<p>

```Julia
using Plots

function test_plot(; kwargs...)
    plot([0,1], [0,1]; xticks=[0,1], yticks=[0,1], legend=:top, kwargs...)
    plot!(Shape(0.3 .+ [0,0.3,0.3,0], 0.3 .+ [0,0,0.2,0.2]))
end
function gen_files(; backend="", kwargs...)
    test_plot(; kwargs...);
    savefig(backend * "-default.pdf")
    savefig(backend * "-default.png")
    test_plot(; background=:transparent, kwargs...);
    savefig(backend * "-transparent.pdf")
    savefig(backend * "-transparent.png")
    for alpha in 0:0.25:1.0
        test_plot(; background=RGBA{Float64}(0.0, 0.0, 0.5, alpha), kwargs...);
        name = backend * "-" * string(alpha)
        savefig(name * ".pdf")
        savefig(name * ".png")
    end
end
gr()
gen_files(; backend="gr", size=(4,3).*28)
pgfplotsx()
gen_files(; backend="pgfx", size=(4,3).*45)
```
</p>
</details>
<details><summary>and I check transparency with LaTeX</summary>
<p>

```LaTeX

\documentclass{article}
\usepackage{geometry}
\geometry{a4paper, left=5mm, right=0mm, top=5mm, bottom=0mm} 

\usepackage{graphics}
\usepackage{xcolor}
\usepackage{float}
\usepackage[pages=some]{background}
\usepackage{lipsum}

\backgroundsetup{scale=1, color=black, opacity=0.8, 
    contents={%
        \includegraphics[width=\paperwidth,height=\paperheight]{example-image}
    }%
}

\begin{document}
\pagecolor{lightgray}
\BgThispage
\section{GR}
\begin{figure}[H]
    \includegraphics{gr-default.pdf}
    \includegraphics{gr-default.png}
    \includegraphics{gr-transparent.pdf}
    \includegraphics{gr-transparent.png}
    \caption{Default PDF, PNG, :transparent PDF, PNG}
\end{figure}
\begin{figure}[H]
    \includegraphics{gr-0.0.pdf}
    \includegraphics{gr-0.25.pdf}
    \includegraphics{gr-0.5.pdf}
    \includegraphics{gr-0.75.pdf}
    \includegraphics{gr-1.0.pdf}
    \caption{Blue w/ alpha 0.00, 0.25, 0.50, 0.75 and 1.00 (PDF)}
\end{figure}
\begin{figure}[H]
    \includegraphics{gr-0.0.png}
    \includegraphics{gr-0.25.png}
    \includegraphics{gr-0.5.png}
    \includegraphics{gr-0.75.png}
    \includegraphics{gr-1.0.png}
    \caption{Blue w/ alpha 0.00, 0.25, 0.50, 0.75 and 1.00 (PNG)}
\end{figure}

\section{PGFPlotsX}
\begin{figure}[H]
    \includegraphics{pgfx-default.pdf}
    \includegraphics{pgfx-default.png}
    \includegraphics{pgfx-transparent.pdf}
    \includegraphics{pgfx-transparent.png}
    \caption{Default PDF, PNG, :transparent PDF, PNG}
\end{figure}
\begin{figure}[H]
    \includegraphics{pgfx-0.0.pdf}
    \includegraphics{pgfx-0.25.pdf}
    \includegraphics{pgfx-0.5.pdf}
    \includegraphics{pgfx-0.75.pdf}
    \includegraphics{pgfx-1.0.pdf}
    \caption{Blue w/ alpha 0.00, 0.25, 0.50, 0.75 and 1.00 (PDF)}
\end{figure}
\begin{figure}[H]
    \includegraphics{pgfx-0.0.png}
    \includegraphics{pgfx-0.25.png}
    \includegraphics{pgfx-0.5.png}
    \includegraphics{pgfx-0.75.png}
    \includegraphics{pgfx-1.0.png}
    \caption{Blue w/ alpha 0.00, 0.25, 0.50, 0.75 and 1.00 (PNG)}
\end{figure}

\end{document}
```
</p>
</details>

<details><summary>Before fix (beware, it's hideous!):</summary>
<p>

![image](https://user-images.githubusercontent.com/66747290/224829833-a6ff0efa-0fa7-45e9-87a2-42ba0f0c8a9f.png)

</p>
</details>

<details><summary>After fix:</summary>
<p>

![image](https://user-images.githubusercontent.com/66747290/224830117-8ad2e251-9b8b-4307-bb65-84198568da34.png)

</p>
</details>


### GR
I can't find the issue with a partial transparency in GR's PDFs.  I tried using the C library directly and it works. Really strange. 
<details>
<p>

```C
#include "gr/include/gr.h"
int main(void) {  
    gr_axes(gr_tick(0, 1), gr_tick(0, 1), 0, 0, 1, 1, -0.01);

    // fill background akin to how Plots.jl does
    gr_setfillintstyle(1);  
    gr_setfillcolorind(2);
    gr_settransparency(0.1);
    gr_fillrect(0.0, 1.0, 0.0, 1.0);

    double x[] = {0, 0.2, 0.4, 0.6, 0.8, 1.0};
    double y[] = {0.3, 0.5, 0.4, 0.2, 0.6, 0.7};
    gr_settransparency(1.0);
    gr_polyline(6, x, y);

    gr_setfillcolorind(3);
    gr_settransparency(0.5);
    gr_fillrect(0.0, 0.5, 0.0, 0.5);

    gr_setfillcolorind(4);
    gr_settransparency(0.5);
    gr_fillrect(0.3, 0.8, 0.3, 0.8);

    return 0;
}
```
```Bash
export GKS_FILEPATH="test.pdf"
export GKSwstype="pdf"
./main
```
![image](https://user-images.githubusercontent.com/66747290/224827777-542145d9-4e9e-4ed0-9573-fd4487e6f37f.png)

</p>
</details>

### PGFPlotsX
PGFPlotsX is using ```pdftocairo``` or ```pdftoppm``` for generating PNGs. 
https://github.com/KristofferC/PGFPlotsX.jl/blob/366ccffcca413b5861c381564134855d823fb2c2/src/build.jl#L140
- ```pdftocairo``` draws transparent regions as white by default, but it can be overridden with ```-transp``` flag - it would require keyword passing to PGFPlotsX
- ```pdftoppm``` does not have such flag, but I've never used it, so can't tell what's default.


## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)