### PR TITLE
Rotated tick label alignment in PGFPlotsX

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -793,12 +793,17 @@ pgfx_get_title_pos(s::Symbol) = get(
 
 function pgfx_get_ticklabel_style(sp, axis)
     cstr = plot_color(axis[:tickfontcolor])
-    return Options(
+    opt = Options(
         "font" => pgfx_font(axis[:tickfontsize], pgfx_thickness_scaling(sp)),
         "color" => cstr,
         "draw opacity" => alpha(cstr),
         "rotate" => axis[:tickfontrotation],
     )
+    # aligning rotated tick labels to ticks
+    if mod(axis[:rotation], 90) > 0 # 0 and ±90 already look good with the default anchor
+        push!(opt, "anchor" => axis === sp[:xaxis] ? "north east" : "south east")
+    end
+    return opt
 end
 
 function pgfx_get_colorbar_ticklabel_style(sp)

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -806,7 +806,12 @@ function pgfx_get_ticklabel_style(sp, axis)
         elseif axis === sp[:yaxis]
             push!(opt, "anchor" => axis[:rotation] < 45 ? "north west" : "north east")
         else
-            push!(opt, "anchor" => axis[:rotation] == 0 ? "east" : axis[:rotation] < 90 ? "south east" : "south")
+            push!(
+                opt,
+                "anchor" =>
+                    axis[:rotation] == 0 ? "east" :
+                    axis[:rotation] < 90 ? "south east" : "south",
+            )
         end
     else
         if mod(axis[:rotation], 90) > 0 # 0 and ±90 already look good with the default anchor

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -800,8 +800,18 @@ function pgfx_get_ticklabel_style(sp, axis)
         "rotate" => axis[:tickfontrotation],
     )
     # aligning rotated tick labels to ticks
-    if mod(axis[:rotation], 90) > 0 # 0 and ±90 already look good with the default anchor
-        push!(opt, "anchor" => axis === sp[:xaxis] ? "north east" : "south east")
+    if RecipesPipeline.is3d(sp)
+        if axis === sp[:xaxis]
+            push!(opt, "anchor" => axis[:rotation] < 60 ? "north east" : "east")
+        elseif axis === sp[:yaxis]
+            push!(opt, "anchor" => axis[:rotation] < 45 ? "north west" : "north east")
+        else
+            push!(opt, "anchor" => axis[:rotation] == 0 ? "east" : axis[:rotation] < 90 ? "south east" : "south")
+        end
+    else
+        if mod(axis[:rotation], 90) > 0 # 0 and ±90 already look good with the default anchor
+            push!(opt, "anchor" => axis === sp[:xaxis] ? "north east" : "south east")
+        end
     end
     return opt
 end


### PR DESCRIPTION
## Description
Changes anchor of tick labels rotated at (0..90) angles to better match GR. There's still a difference and I'm afraid that a closer implementation would only unnecessarily increase complexity.
Fixes #4388 

<details>
<summary>Testing code</summary>

```julia
pgfplotsx()
function testplot(; kwargs...)
    plot("xlabel " .* string.(0:5), "ylabel " .* string.(0:5); 
    legend=:none, grid=:none, kwargs...)
end
function testplot3(; kwargs...)
    plot("xlabel " .* string.(0:5), "ylabel " .* string.(0:5), "zlabel " .* string.(0:5); 
    legend=:none, grid=:none, kwargs...)
end
plot([testplot(; rotation=rot) for rot in [0,15,45,90]]...,
     [testplot3(; rotation=rot) for rot in [0,15,45,90]]...; 
     layout=(2,4), margin=0Plots.mm, size=(4,2).*200)
```
</details>

Before fix
![before-fix](https://user-images.githubusercontent.com/66747290/227198204-90e421b2-ba0c-4509-8efb-db6ab0354e63.png)

Reference GR image
![gr](https://user-images.githubusercontent.com/66747290/227198428-78cefc47-0263-40c2-a33f-c820ea372845.png)

After fix
![after-fix](https://user-images.githubusercontent.com/66747290/227198375-0da50792-212b-4881-a9ef-0a5b76f8fb45.png)


## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
