### PR TITLE
Missing angle conversions in PGFPlotsX

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -494,7 +494,12 @@ function pgfx_add_series!(::Val{:heatmap}, axis, series_opt, series, series_func
     for arg in args
         arg[(!isfinite).(arg)] .= 0
     end
-    table = Table(["x" => ispolar(series) ? rad2deg.(args[1]) : args[1], "y" => args[2], "z" => args[3], "meta" => meta])
+    table = Table([
+        "x" => ispolar(series) ? rad2deg.(args[1]) : args[1],
+        "y" => args[2],
+        "z" => args[3],
+        "meta" => meta,
+    ])
     push!(axis, series_func(series_opt, table))
     pgfx_add_legend!(axis, series, opt)
 end

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -1005,6 +1005,8 @@ function pgfx_fillrange_series!(axis, series, series_func, i, fillrange, rng)
     opt = series.plotattributes
     args = if RecipesPipeline.is3d(series)
         opt[:x][rng], opt[:y][rng], opt[:z][rng]
+    elseif ispolar(series)
+        rad2deg.(opt[:x][rng]), opt[:y][rng]
     else
         opt[:x][rng], opt[:y][rng]
     end

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -487,13 +487,14 @@ function pgfx_add_series!(::Val{:heatmap}, axis, series_opt, series, series_func
         "mesh/rows" => length(opt[:x]),
         "mesh/cols" => length(opt[:y]),
         "point meta" => "\\thisrow{meta}",
+        "opacity" => something(get_fillalpha(series), 1.0),
     )
     args = pgfx_series_arguments(series, opt)
     meta = map(r -> any(!isfinite, r) ? NaN : r[3], zip(args...))
     for arg in args
         arg[(!isfinite).(arg)] .= 0
     end
-    table = Table(["x" => args[1], "y" => args[2], "z" => args[3], "meta" => meta])
+    table = Table(["x" => ispolar(series) ? rad2deg.(args[1]) : args[1], "y" => args[2], "z" => args[3], "meta" => meta])
     push!(axis, series_func(series_opt, table))
     pgfx_add_legend!(axis, series, opt)
 end


### PR DESCRIPTION
## Description
Fixes #3266 (fully) #1007 (partially)
Also added heatmap transparency to see axes in figures below.

<details>
<summary>Testing code</summary>

```julia
pgfplotsx()

angles = collect(range(0, 2π, length = 6))
radius = [10, 10, 10, 14, 19, 10]
plot(angles, radius, proj = :polar, fill = (0, :orange, 0.5), lc=:orange, legend=:none, 
    title="#3266", size=(300,300))

theta = range(0,2π; length=60);
rho = range(0.1, 5; length=4);
z = rho .* theta';
heatmap(theta, rho, z, proj=:polar, c=:jet, alpha=0.8, title="#1007", size=(300,300))
```
</details>

Before fix
![image](https://user-images.githubusercontent.com/66747290/227283553-df7cdca1-cb4c-4db9-931a-e7f263d83872.png) ![image](https://user-images.githubusercontent.com/66747290/227283622-12b0a18f-199b-4f07-ad9a-aec246dfeb04.png)



After fix 
![image](https://user-images.githubusercontent.com/66747290/227283180-9242b9dd-b940-443c-84f4-5cb61ddba915.png)  ![image](https://user-images.githubusercontent.com/66747290/227283275-b67a7369-9d95-4621-86a5-f837cbb76c01.png)




## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
