### PR TITLE
Support removing colorbar ticks in GR and PGFPlotsX

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -605,11 +605,13 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, vp::GRViewport)
         end
     end
 
-    z_tick = 0.5GR.tick(z_min, z_max)
-    gr_set_line(1, :solid, plot_color(:black), sp)
-    (yscale = sp[:colorbar_scale]) ∈ _logScales && GR.setscale(gr_y_log_scales[yscale])
-    # signature: gr.axes(x_tick, y_tick, x_org, y_org, major_x, major_y, tick_size)
-    GR.axes(0, z_tick, x_max, z_min, 0, 1, gr_colorbar_tick_size[])
+    if _has_ticks(sp[:colorbar_ticks])
+        z_tick = 0.5GR.tick(z_min, z_max)
+        gr_set_line(1, :solid, plot_color(:black), sp)
+        (yscale = sp[:colorbar_scale]) ∈ _logScales && GR.setscale(gr_y_log_scales[yscale])
+        # signature: gr.axes(x_tick, y_tick, x_org, y_org, major_x, major_y, tick_size)
+        GR.axes(0, z_tick, x_max, z_min, 0, 1, gr_colorbar_tick_size[])
+    end
 
     title = gr_colorbar_title(sp)
     gr_set_font(title.font, sp; halign = :center, valign = :top)

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -197,8 +197,8 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
             if hascolorbar(sp)
                 formatter = latex_formatter(sp[:colorbar_formatter])
                 cticks = curly(join(get_colorbar_ticks(sp; formatter = formatter)[1], ','))
-
                 letter = sp[:colorbar] === :top ? :x : :y
+
                 colorbar_style = push!(
                     Options("$(letter)label" => sp[:colorbar_title]),
                     "$(letter)label style" => pgfx_get_colorbar_title_style(sp),

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -197,24 +197,32 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
             if hascolorbar(sp)
                 formatter = latex_formatter(sp[:colorbar_formatter])
                 cticks = curly(join(get_colorbar_ticks(sp; formatter = formatter)[1], ','))
-                colorbar_style = if sp[:colorbar] === :top
+
+                letter = sp[:colorbar] === :top ? :x : :y
+                colorbar_style = push!(
+                    Options("$(letter)label" => sp[:colorbar_title]),
+                    "$(letter)label style" => pgfx_get_colorbar_title_style(sp),
+                    "$(letter)tick" => cticks,
+                    "$(letter)ticklabel style" => pgfx_get_colorbar_ticklabel_style(sp),
+                )
+
+                if sp[:colorbar] === :top
                     push!(
-                        Options("xlabel" => sp[:colorbar_title]),
-                        "xlabel style" => pgfx_get_colorbar_title_style(sp),
+                        colorbar_style,
                         "at" => "(0.5, 1.05)",
                         "anchor" => "south",
-                        "xtick" => cticks,
                         "xticklabel pos" => "upper",
-                        "xticklabel style" => pgfx_get_colorbar_ticklabel_style(sp),
-                    )
-                else
-                    push!(
-                        Options("ylabel" => sp[:colorbar_title]),
-                        "ylabel style" => pgfx_get_colorbar_title_style(sp),
-                        "ytick" => cticks,
-                        "yticklabel style" => pgfx_get_colorbar_ticklabel_style(sp),
                     )
                 end
+
+                if !_has_ticks(sp[:colorbar_ticks])
+                    push!(
+                        colorbar_style,
+                        "$(letter)tick style" => "{draw=none}",
+                        "$(letter)ticklabels" => "{,,}",
+                    )
+                end
+
                 push!(
                     axis_opt,
                     "colorbar $(pgfx_get_colorbar_pos(sp[:colorbar]))" => nothing,


### PR DESCRIPTION
## Description
Related #4659
I also took the liberty of rearranging assembly of colorbar parameters in PGFPlotsX to reduce code redundancy (it also helped for the patch). Hope that's alright.

<details>
<summary>Testing code</summary>

```julia
testplot = (; kwargs...) -> plot([0,1]; label=:none, zcolor=[0,1], kwargs...)
plot(
    testplot(),
    testplot(; colorbar_ticks=:none)
)
```
</details>

Before fix
![image](https://user-images.githubusercontent.com/66747290/227317174-54abb7e3-63fe-4e70-acb2-c993fa8fd980.png) ![image](https://user-images.githubusercontent.com/66747290/227317249-c04a0825-1a77-4170-8f17-4cf84d9658d6.png)

After fix
![image](https://user-images.githubusercontent.com/66747290/227316894-181f265b-f4d7-4105-9af2-fd236e63cb14.png) ![image](https://user-images.githubusercontent.com/66747290/227316788-b327e179-e322-40da-8552-a35b15e849ee.png)


## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
