### PR TITLE
Fix logarithmic units

### DIFF
--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -377,3 +377,18 @@ end
     @test ncodeunits(str) == 4
     @test codeunit(str) == UInt8
 end
+
+@testset "Logunits plots" begin
+    u = (1:3)u"B"
+    v = (1:3)u"dB"
+    x = (1:3)u"dBV"
+    y = (1:3)u"V"
+    pl = plot(u, x)
+    @test pl isa Plot
+    @test xguide(pl) == "B"
+    @test yguide(pl) == "dBV"
+    @test plot!(pl, v, y) isa Plot
+    pl = plot(v, y)
+    @test pl isa Plot
+    @test plot!(pl, u, x) isa Plot
+end


### PR DESCRIPTION
## Description
Closes #4700 

Partially based off of work by @ykonter (who is not in zenodo, as far as I can tell). Creates underscored extensions of Unitful's `unit` and `ustrip` to deal with logarithmic units.

This is not perfect, note how the y axis in the example doesn't rescale on the `plot!` call. But there is more than one interpretation of what that call should do anyway, so perhaps good enough should be left good enough here.

## Example
```julia
julia> plot((1:10)u"dBm", (1:10)u"dB"; seriestype=:scatter)

julia> plot!((1:10)u"mW", (1:10); seriestype=:scatter)
```
![logunits](https://user-images.githubusercontent.com/6677110/227778404-66c8c1b8-c4b4-4898-8fb9-33afcbc545a2.png)


## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
