### PR TITLE
Filtering "missing" tick labels

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -748,6 +748,12 @@
             "name": "Puripant Ruchikachorn",
             "type": "Other",
             "orcid": "0000-0002-2721-6915"
+        },
+        {
+            "name": "Ivan Boikov",
+            "affiliation": "Thales Research & Technology",
+            "orcid": "0000-0002-1901-0159",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -203,6 +203,9 @@ end
 function get_labels(formatter::Function, scaled_ticks, scale)
     sf, invsf, _ = scale_inverse_scale_func(scale)
     fticks = map(formatter ∘ invsf, scaled_ticks)
+    # extrema can extend outside the region where Categorical tick values are defined
+    #   CategoricalArrays's recipe gives "missing" label to those
+    filter!(!ismissing, fticks)
     eltype(fticks) <: Number && return get_labels(:auto, map(sf, fticks), scale)
     return fticks
 end


### PR DESCRIPTION
## Description
Closes #4715 
With 10 items in a ```CategoricalArray``` spacing between ticks becomes smaller than the padding and a new tick is squeezed in. Its value is not defined however and the ```CategoricalArrays.jl``` recipe gives out a ```missing``` tick label, on which a label formatter chokes.

Feels like a band-aid rather than a solution though.

<details>
<summary>Test code</summary>

```julia
using Plots, CategoricalArrays
plot(
    bar(categorical(collect(1:9)), collect(1:9)),
    bar(categorical(collect(1:10)), collect(1:10);); 
    size=(4,1).*100
)
```
</details>

![image](https://user-images.githubusercontent.com/66747290/230224066-22217728-72d0-4a58-a9e5-7cbb5bdc8ae6.png)


## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
