### PR TITLE
Add bounds check in expand_extrema

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -456,7 +456,7 @@ function expand_extrema!(sp::Subplot, plotattributes::AKW)
             letter !== :z &&
             plotattributes[:seriestype] === :straightline &&
             any(series[:seriestype] !== :straightline for series in series_list(sp)) &&
-            length(data) > 2 &&
+            length(data) > 1 &&
             data[1] != data[2]
         )
             data = [NaN]

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -456,6 +456,7 @@ function expand_extrema!(sp::Subplot, plotattributes::AKW)
             letter !== :z &&
             plotattributes[:seriestype] === :straightline &&
             any(series[:seriestype] !== :straightline for series in series_list(sp)) &&
+            length(data) > 2 &&
             data[1] != data[2]
         )
             data = [NaN]


### PR DESCRIPTION
## Description
Closes #4717
Theoretically could still fail since here `data` can be `nothing` and `length(nothing)` fails. Though it does not look like an `isnothing` check is required.
## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
