### PR TITLE
Fix yunit bug

### DIFF
--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -66,7 +66,9 @@ end
 # Recipe for vectors of vectors
 @recipe function f(::Type{T}, x::T) where {T<:AVec{<:AVec{<:MissingOrQuantity}}}  # COV_EXCL_LINE
     axisletter = plotattributes[:letter]   # x, y, or z
-    map(x -> fixaxis!(plotattributes, x, axisletter), x)
+    unitsymbol = Symbol(axisletter, :unit)
+    axisunit = pop!(plotattributes, unitsymbol, _unit(eltype(first(x))))
+    map(x -> (plotattributes[unitsymbol] = axisunit; fixaxis!(plotattributes, x, axisletter)), x)
 end
 
 # Recipe for bare units

--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -68,7 +68,12 @@ end
     axisletter = plotattributes[:letter]   # x, y, or z
     unitsymbol = Symbol(axisletter, :unit)
     axisunit = pop!(plotattributes, unitsymbol, _unit(eltype(first(x))))
-    map(x -> (plotattributes[unitsymbol] = axisunit; fixaxis!(plotattributes, x, axisletter)), x)
+    map(
+        x -> (
+            plotattributes[unitsymbol] = axisunit; fixaxis!(plotattributes, x, axisletter)
+        ),
+        x,
+    )
 end
 
 # Recipe for bare units

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -42,6 +42,7 @@ end
     @testset "yunit" begin
         @test yguide(plot(y, yunit = cm)) == "cm"
         @test yseries(plot(y, yunit = cm)) ≈ ustrip.(cm, y)
+        @test plot([copy(y), copy(y)], yunit = cm) |> pl -> yseries(pl, 1) ≈ yseries(pl, 2)
     end
 
     @testset "ylims" begin # Using all(lims .≈ lims) because of uncontrolled type conversions?


### PR DESCRIPTION
Fix #4731 

## Description

While plotting a `Vector{Quantity}`, the unit is removed from the attributes dict and stored in the label. When plotting a `Vector{Vector{Quantity}}` the dict was reused before the label updated. This way, we put the unit back in the dict before every vector is plotted.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
