### PR TITLE
Move warning about plotlybase png rendering to error

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -583,7 +583,7 @@ function _initialize_backend(pkg::PlotlyBackend)
         _post_imports(pkg)
         _runtime_init(pkg)
     catch err
-        err isa ArgumentError || @warn "Failed to load integration with PlotlyBase & PlotlyKaleide." err
+        err isa ArgumentError || @warn "Failed to load integration with PlotlyBase & PlotlyKaleide." exception=(err,catch_backtrace())
         # NOTE: `plotly` is special in the way that it does not require dependencies for displaying a plot
         # as a result, we cannot rely on the `@require` mechanism for loading glue code
         # this is why it must be done here.

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -583,7 +583,9 @@ function _initialize_backend(pkg::PlotlyBackend)
         _post_imports(pkg)
         _runtime_init(pkg)
     catch err
-        err isa ArgumentError || @warn "Failed to load integration with PlotlyBase & PlotlyKaleide." exception=(err,catch_backtrace())
+        err isa ArgumentError ||
+            @warn "Failed to load integration with PlotlyBase & PlotlyKaleide." exception =
+                (err, catch_backtrace())
         # NOTE: `plotly` is special in the way that it does not require dependencies for displaying a plot
         # as a result, we cannot rely on the `@require` mechanism for loading glue code
         # this is why it must be done here.
@@ -591,8 +593,14 @@ function _initialize_backend(pkg::PlotlyBackend)
     end
     @static if isdefined(Base.Experimental, :register_error_hint)
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
-            if exc.f === _show && length(argtypes) == 3 && argtypes[2] <: MIME"image/png" && argtypes[3] <: Plot{PlotlyBackend}
-                println(io, "\n\nTip: For saving/rendering as png with the `Plotly` backend `PlotlyBase` and `PlotlyKaleido` need to be installed.")
+            if exc.f === _show &&
+               length(argtypes) == 3 &&
+               argtypes[2] <: MIME"image/png" &&
+               argtypes[3] <: Plot{PlotlyBackend}
+                println(
+                    io,
+                    "\n\nTip: For saving/rendering as png with the `Plotly` backend `PlotlyBase` and `PlotlyKaleido` need to be installed.",
+                )
             end
         end
     end

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -589,6 +589,13 @@ function _initialize_backend(pkg::PlotlyBackend)
         # this is why it must be done here.
         PLOTS_DEFAULT_BACKEND == "plotly" || @eval include(_path(:plotly))
     end
+    @static if isdefined(Base.Experimental, :register_error_hint)
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+            if exc.f === _show && length(argtypes) == 3 && argtypes[2] <: MIME"image/png" && argtypes[3] <: Plot{PlotlyBackend}
+                println(io, "\n\nTip: For saving/rendering as png with the `Plotly` backend `PlotlyBase` and `PlotlyKaleido` need to be installed.")
+            end
+        end
+    end
 end
 
 const _plotly_attr = merge_with_base_supported([

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -583,7 +583,7 @@ function _initialize_backend(pkg::PlotlyBackend)
         _post_imports(pkg)
         _runtime_init(pkg)
     catch err
-        @warn "For saving to png with the `Plotly` backend `PlotlyBase` and `PlotlyKaleido` need to be installed." err
+        err isa ArgumentError || @warn "Failed to load integration with PlotlyBase & PlotlyKaleide." err
         # NOTE: `plotly` is special in the way that it does not require dependencies for displaying a plot
         # as a result, we cannot rely on the `@require` mechanism for loading glue code
         # this is why it must be done here.


### PR DESCRIPTION
Before this PR, you would always see a *warning* about rendering to png when using the plotly backend.

<img width="623" alt="Scherm­afbeelding 2023-04-27 om 22 01 06" src="https://user-images.githubusercontent.com/6933510/234977691-4b1dcbf1-f204-4df1-819c-096430b5197b.png">

Not so nice, and confusing for many users!

An easy improvement would be to change this to `@info`, but in this PR, I used the super powerful [`Base.Experimental.register_error_hint`](https://docs.julialang.org/en/v1/base/base/#Base.Experimental.register_error_hint) feature to move this "warning" to when it becomes relevant: when you try to render to png!

After this PR, the warning message is gone when calling `plotly()`, and it **magically appears in the error message**!

```julia
julia> using Plots

julia> plotly()
Plots.PlotlyBackend()

julia> p = plot(1:10);

julia> repr(MIME"image/png"(), p)
ERROR: MethodError: no method matching _show(::IOBuffer, ::MIME{Symbol("image/png")}, ::Plots.Plot{Plots.PlotlyBackend})

Tip: For saving/rendering as png with the `Plotly` backend `PlotlyBase` and `PlotlyKaleido` need to be installed.

Closest candidates are:
  _show(::IO, ::MIME{Symbol("image/png")}, ::Plots.Plot{Plots.GRBackend}) at ~/.julia/packages/Plots/etZYh/src/backends/gr.jl:2041
  _show(::IO, ::MIME{Symbol("application/vnd.plotly.v1+json")}, ::Plots.Plot{Plots.PlotlyBackend}) at ~/.julia/packages/Plots/etZYh/src/backends/plotly.jl:1131
  _show(::IO, ::MIME{Symbol("text/html")}, ::Plots.Plot{Plots.PlotlyBackend}) at ~/.julia/packages/Plots/etZYh/src/backends/plotly.jl:1134
  ...
Stacktrace:
...

julia> 
```