### PR TITLE
Fixed logic of warning on dimension mismatch

### DIFF
--- a/RecipesPipeline/src/utils.jl
+++ b/RecipesPipeline/src/utils.jl
@@ -150,6 +150,7 @@ for st in (
     :volume,
     :wireframe,
     :mesh3d,
+    :spy
 )
     @eval is3d(::Type{Val{Symbol($(string(st)))}}) = true
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -418,7 +418,7 @@ end
     end
 
     # compute half-width of bars
-    bw = plotattributes[:bar_width]
+    bw = pop_kw!(plotattributes, :bar_width)
     hw = if bw === nothing
         0.5_bar_width * if nx > 1
             ignorenan_minimum(filter(x -> x > 0, diff(sort(procx))))
@@ -426,7 +426,12 @@ end
             1
         end
     else
-        map(i -> 0.5_cycle(bw, i), eachindex(procx))
+        bw isa AVec && eachindex(bw) != eachindex(procx) && @warn("""
+            Indices of `bar_width` attribute ($(eachindex(bw))) do not match data indices ($(eachindex(procx))).
+            Bar widths will be repeated cyclically.
+            """
+        )
+        bw ./ 2
     end
 
     # make fillto a vector... default fills to 0
@@ -490,8 +495,8 @@ end
     markersize := 0
     markeralpha := 0
     fillrange := nothing
-    x := x
-    y := y
+    x := procx
+    y := procy
     ()
 end
 @deps bar shape

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -69,10 +69,9 @@ struct NaNSegmentsIterator
 end
 
 function iter_segments(args...)
-    tup = Plots.wraptuple(args)
-    n1 = minimum(map(firstindex, tup))
-    n2 = maximum(map(lastindex, tup))
-    NaNSegmentsIterator(tup, n1, n2)
+    i = eachindex(first(args))
+    all(eachindex(a) == i for a in args) || @warn "Inconsistent indices of plot args: $(eachindex.(args))"
+    NaNSegmentsIterator(args, first(i), last(i))
 end
 
 "floor number x in base b, note this is different from using Base.round(...; base=b) !"
@@ -93,6 +92,8 @@ end
 function series_segments(series::Series, seriestype::Symbol = :path; check = false)
     x, y, z = series[:x], series[:y], series[:z]
     (x === nothing || isempty(x)) && return UnitRange{Int}[]
+
+    warn_on_attr_dim_mismatch(series, eachindex(x))
 
     args = RecipesPipeline.is3d(series) ? (x, y, z) : (x, y)
     nan_segments = collect(iter_segments(args...))
@@ -125,21 +126,16 @@ function series_segments(series::Series, seriestype::Symbol = :path; check = fal
     else
         (SeriesSegment(r, 1) for r in nan_segments)
     end
-
-    warn_on_attr_dim_mismatch(series, x, y, z, segments)
     segments
 end
 
-function warn_on_attr_dim_mismatch(series, x, y, z, segments)
-    isempty(segments) && return
-    seg_range = UnitRange(
-        minimum(map(seg -> first(seg.range), segments)),
-        maximum(map(seg -> last(seg.range), segments)),
-    )
+function warn_on_attr_dim_mismatch(series, indices)
+
+    # TODO a more precise set of attributes that is relevant here?
     for attr in _segmenting_vector_attributes
-        if (v = get(series, attr, nothing)) isa AVec && eachindex(v) != seg_range
-            @warn "Indices $(eachindex(v)) of attribute `$attr` does not match data indices $seg_range."
-            if any(v -> !isnothing(v) && any(isnan, v), (x, y, z))
+        if (v = get(series, attr, nothing)) isa AVec && eachindex(v) != indices
+            @warn "Indices $(eachindex(v)) of attribute `$attr` does not match data indices $indices."
+            if any(v -> !isnothing(v) && any(isnan, v), (series[:x], series[:y], series[:z]))
                 @info """Data contains NaNs or missing values, and indices of `$attr` vector do not match data indices.
                     If you intend elements of `$attr` to apply to individual NaN-separated segments in the data,
                     pass each segment in a separate vector instead, and use a row vector for `$attr`. Legend entries

--- a/test/test_animations.jl
+++ b/test/test_animations.jl
@@ -43,7 +43,7 @@ end
         circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
     end when i % 5 == 0 fps = 10
 
-    @test_throws LoadError macroexpand(
+    @test_throws ErrorException macroexpand(
         @__MODULE__,
         quote
             @gif for i in 1:n

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -26,12 +26,13 @@ end
         dsp = TextDisplay(IOContext(IOBuffer(), :color => true))
 
         @testset "plot" begin
-            for pl in [
+            @test_nowarn for pl in [
                 histogram([1, 0, 0, 0, 0, 0]),
                 plot([missing]),
                 plot([missing, missing]),
                 plot(fill(missing, 10)),
                 plot([missing; 1:4]),
+                plot([missing; 1:4], color=1:5),
                 plot([fill(missing, 10); 1:4]),
                 plot([1 1; 1 missing]),
                 plot(["a" "b"; missing "d"], [1 2; 3 4]),

--- a/test/test_pgfplotsx.jl
+++ b/test/test_pgfplotsx.jl
@@ -335,11 +335,12 @@ with(:pgfplotsx) do
     end
 
     @testset "Markers and Paths" begin
+        cycle_upto(itr, n) = collect(Iterators.take(Iterators.cycle(itr), n))
         pl = plot(
             5 .- ones(9),
-            markershape = [:utriangle, :rect],
+            markershape = cycle_upto([:utriangle, :rect], 9),
             markersize = 8,
-            color = [:red, :black],
+            color = cycle_upto([:red, :black], 9),
         )
         axis_contents = first(get_pgf_axes(pl)).contents
         plots = filter(x -> x isa PGFPlotsX.Plot, axis_contents)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -157,7 +157,7 @@ end
     @test segments([nan10; 1:5]) == [11:15]
     @test segments([1:5; nan10]) == [1:5]
     @test segments([nan10; 1:5; nan10; 1:5; nan10]) == [11:15, 26:30]
-    @test segments([NaN; 1], 1:10) == [2:2, 4:4, 6:6, 8:8, 10:10]
+    @test segments(repeat([NaN; 1], 5), 1:10) == [2:2, 4:4, 6:6, 8:8, 10:10]
     @test segments([nan10; 1:15], [1:15; nan10]) == [11:15]
 end
 


### PR DESCRIPTION
## Description

Fixes spurious warnings when `missing`/`NaN` is at the start or end of input vector, as in
```
plot([missing; 1:4], color=1:5)
```
Adds stricter checks with warnings in other cases. Tests pass even when these warnings are changed to errors, but I kept them as warnings to be less breaking.

`warn_on_attr_dim_mismatch` really shouldn't have anything to do with segments, so maybe it should be called from elsewhere in the pipeline, but I'm not sure where.

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
