### PR TITLE
Fix bar plot vector attribute with missing values

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -198,8 +198,12 @@ const _examples = PlotExample[
     ),
     PlotExample( # 14
         "Bar",
-        "`x` is the midpoint of the bar. (todo: allow passing of edges instead of midpoints)",
-        :(bar(randn(99))),
+        "`bar(x, y)` plots bars with heights `y` and centers at `x`.
+        `x` defaults to `eachindex(y)`.",
+        :(plot(bar(randn(10)),
+               bar([0,3,5], [1,2,6]),
+               legend=false
+        ))
     ),
     PlotExample( # 15
         "Histogram",
@@ -1235,6 +1239,15 @@ const _examples = PlotExample[
             end
         end,
     ),
+    PlotExample( # 66
+        "Bars: specifying edges and missing values",
+        "In `bar(x, y)`, `x` may be the same length as `y` to specify bar centers,
+        or one longer to specify bar edges.",
+        :(plot(bar(-5:5, randn(10)),                  # bar edges at -5:5
+               bar(-2:2, [2,-2,NaN,-1,1], color=1:5), # bar centers at -2:2, one missing value
+               legend=false
+        ))
+    ),
 ]
 
 # Some constants for PlotDocs and PlotReferenceImages
@@ -1256,6 +1269,7 @@ _backend_skips = Dict(
         63,  # twin axes unsupported
         64,  # legend pos unsupported
         65,  # legend pos unsupported
+        66,  # bar: vector-valued `color` unsupported
     ],
     :pgfplotsx => [
         6,  # images

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -200,10 +200,7 @@ const _examples = PlotExample[
         "Bar",
         "`bar(x, y)` plots bars with heights `y` and centers at `x`.
         `x` defaults to `eachindex(y)`.",
-        :(plot(bar(randn(10)),
-               bar([0,3,5], [1,2,6]),
-               legend=false
-        ))
+        :(plot(bar(randn(10)), bar([0, 3, 5], [1, 2, 6]), legend = false)),
     ),
     PlotExample( # 15
         "Histogram",
@@ -1243,10 +1240,11 @@ const _examples = PlotExample[
         "Bars: specifying edges and missing values",
         "In `bar(x, y)`, `x` may be the same length as `y` to specify bar centers,
         or one longer to specify bar edges.",
-        :(plot(bar(-5:5, randn(10)),                  # bar edges at -5:5
-               bar(-2:2, [2,-2,NaN,-1,1], color=1:5), # bar centers at -2:2, one missing value
-               legend=false
-        ))
+        :(plot(
+            bar(-5:5, randn(10)),                  # bar edges at -5:5
+            bar(-2:2, [2, -2, NaN, -1, 1], color = 1:5), # bar centers at -2:2, one missing value
+            legend = false,
+        )),
     ),
 ]
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -481,7 +481,7 @@ end
                 # Each segment is 6 elements long, including the NaN separator.
                 # One segment is created for each non-NaN element of `procy`.
                 # There is no trailing NaN, so the last repetition is dropped.
-                plotattributes[k] = @views repeat(v[valid_i]; inner = 6)[1:(end - 1)]                
+                plotattributes[k] = @views repeat(v[valid_i]; inner = 6)[1:(end - 1)]
             end
         end
         ()

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -442,8 +442,10 @@ end
     end
 
     xseg, yseg = map(_ -> Segments(), 1:2)
+    valid_i = isfinite.(procx) .& isfinite.(procy)
     for i in 1:ny
-        (yi = procy[i]) |> isnan && continue
+        valid_i[i] || continue
+        yi = procy[i]
         center = procx[i]
         hwi = _cycle(hw, i)
         fi = _cycle(fillto, i)
@@ -477,8 +479,9 @@ end
                     @warn "Indices $(eachindex(v)) of attribute `$k` do not match data indices $(eachindex(y))."
                 end
                 # Each segment is 6 elements long, including the NaN separator.
+                # One segment is created for each non-NaN element of `procy`.
                 # There is no trailing NaN, so the last repetition is dropped.
-                plotattributes[k] = @view repeat(v; inner = 6)[1:(end - 1)]
+                plotattributes[k] = @views repeat(v[valid_i]; inner = 6)[1:(end - 1)]                
             end
         end
         ()
@@ -490,8 +493,8 @@ end
     markersize := 0
     markeralpha := 0
     fillrange := nothing
-    x := x
-    y := y
+    x := procx
+    y := procy
     ()
 end
 @deps bar shape


### PR DESCRIPTION
## Description

Fixes vector attributes on bar plots with missing values.
Before:
```
plot(bar(-2:2, [2,-2,1,-1,1], color=1:5),
       bar(-2:2, [2,-2,NaN,-1,1], color=1:5))
```
![plot_27](https://user-images.githubusercontent.com/4170948/235269002-7ad98bd7-b6fb-4404-a339-c2dbbffdbee8.svg)
After:
![plot_47](https://user-images.githubusercontent.com/4170948/235269004-1547fcdb-f3e7-40e2-8028-1d5222645201.svg)


## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
