### PR TITLE
Short-circuit `update_clims` if not necessary

### DIFF
--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -19,9 +19,9 @@ function update_clims(sp::Subplot, op = process_clims(sp[:clims]))::Tuple{Float6
         if series[:colorbar_entry]::Bool
             # Avoid calling the inner `update_clims` if at all possible; dynamic dispatch hell
             if (series[:seriestype] ∈ _z_colored_series && series[:z] !== nothing) ||
-                series[:line_z] !== nothing || 
-                series[:marker_z] !== nothing || 
-                series[:fill_z] !== nothing
+               series[:line_z] !== nothing || 
+               series[:marker_z] !== nothing || 
+               series[:fill_z] !== nothing
                 zmin, zmax = _update_clims(zmin, zmax, update_clims(series, op)...)
             else
                 zmin, zmax = _update_clims(zmin, zmax, NaN, NaN)

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -17,7 +17,15 @@ function update_clims(sp::Subplot, op = process_clims(sp[:clims]))::Tuple{Float6
     zmin, zmax = Inf, -Inf
     for series in series_list(sp)
         if series[:colorbar_entry]::Bool
-            zmin, zmax = _update_clims(zmin, zmax, update_clims(series, op)...)
+            # Avoid calling the inner `update_clims` if at all possible; dynamic dispatch hell
+            if (series[:seriestype] ∈ _z_colored_series && series[:z] !== nothing) ||
+                series[:line_z] !== nothing || 
+                series[:marker_z] !== nothing || 
+                series[:fill_z] !== nothing
+                zmin, zmax = _update_clims(zmin, zmax, update_clims(series, op)...)
+            else
+                zmin, zmax = _update_clims(zmin, zmax, NaN, NaN)
+            end
         else
             update_clims(series, op)
         end

--- a/src/colorbars.jl
+++ b/src/colorbars.jl
@@ -19,8 +19,8 @@ function update_clims(sp::Subplot, op = process_clims(sp[:clims]))::Tuple{Float6
         if series[:colorbar_entry]::Bool
             # Avoid calling the inner `update_clims` if at all possible; dynamic dispatch hell
             if (series[:seriestype] ∈ _z_colored_series && series[:z] !== nothing) ||
-               series[:line_z] !== nothing || 
-               series[:marker_z] !== nothing || 
+               series[:line_z] !== nothing ||
+               series[:marker_z] !== nothing ||
                series[:fill_z] !== nothing
                 zmin, zmax = _update_clims(zmin, zmax, update_clims(series, op)...)
             else


### PR DESCRIPTION
## Description
Partially fixes #4742 .

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
