### PR TITLE
Singleargustrip

### DIFF
--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -287,21 +287,32 @@ getaxisunit(a::Axis) = getaxisunit(a[:guide])
 #==============
 Fix annotations
 ===============#
-Plots.locate_annotation(
-    sp::Subplot,
-    x::MissingOrQuantity,
-    y::MissingOrQuantity,
-    label::PlotText,
-) = (_ustrip(x), _ustrip(y), label)
-Plots.locate_annotation(
-    sp::Subplot,
-    x::MissingOrQuantity,
-    y::MissingOrQuantity,
-    z::MissingOrQuantity,
-    label::PlotText,
-) = (_ustrip(x), _ustrip(y), _ustrip(z), label)
-Plots.locate_annotation(sp::Subplot, rel::NTuple{N,<:MissingOrQuantity}, label) where {N} =
-    Plots.locate_annotation(sp, _ustrip.(rel), label)
+function Plots.locate_annotation(
+        sp::Subplot,
+        x::MissingOrQuantity,
+        y::MissingOrQuantity,
+        label::PlotText,
+    )
+    xunit = getaxisunit(sp.attr[:xaxis])
+    yunit = getaxisunit(sp.attr[:yaxis])
+    (_ustrip(xunit, x), _ustrip(yunit, y), label)
+end
+function Plots.locate_annotation(
+        sp::Subplot,
+        x::MissingOrQuantity,
+        y::MissingOrQuantity,
+        z::MissingOrQuantity,
+        label::PlotText,
+    )
+    xunit = getaxisunit(sp.attr[:xaxis])
+    yunit = getaxisunit(sp.attr[:yaxis])
+    zunit = getaxisunit(sp.attr[:zaxis])
+    (_ustrip(xunit, x), _ustrip(yunit, y), _ustrip(zunit, z), label)
+end
+function Plots.locate_annotation(sp::Subplot, rel::NTuple{N,<:MissingOrQuantity}, label) where {N}
+    units = getaxisunit(sp.attr[:xaxis], sp.attr[:yaxis], sp.attr[:zaxis])
+    Plots.locate_annotation(sp, _ustrip.(zip(units, rel)), label)
+end
 
 #==================#
 # ticks and limits #

--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -288,28 +288,32 @@ getaxisunit(a::Axis) = getaxisunit(a[:guide])
 Fix annotations
 ===============#
 function Plots.locate_annotation(
-        sp::Subplot,
-        x::MissingOrQuantity,
-        y::MissingOrQuantity,
-        label::PlotText,
-    )
+    sp::Subplot,
+    x::MissingOrQuantity,
+    y::MissingOrQuantity,
+    label::PlotText,
+)
     xunit = getaxisunit(sp.attr[:xaxis])
     yunit = getaxisunit(sp.attr[:yaxis])
     (_ustrip(xunit, x), _ustrip(yunit, y), label)
 end
 function Plots.locate_annotation(
-        sp::Subplot,
-        x::MissingOrQuantity,
-        y::MissingOrQuantity,
-        z::MissingOrQuantity,
-        label::PlotText,
-    )
+    sp::Subplot,
+    x::MissingOrQuantity,
+    y::MissingOrQuantity,
+    z::MissingOrQuantity,
+    label::PlotText,
+)
     xunit = getaxisunit(sp.attr[:xaxis])
     yunit = getaxisunit(sp.attr[:yaxis])
     zunit = getaxisunit(sp.attr[:zaxis])
     (_ustrip(xunit, x), _ustrip(yunit, y), _ustrip(zunit, z), label)
 end
-function Plots.locate_annotation(sp::Subplot, rel::NTuple{N,<:MissingOrQuantity}, label) where {N}
+function Plots.locate_annotation(
+    sp::Subplot,
+    rel::NTuple{N,<:MissingOrQuantity},
+    label,
+) where {N}
     units = getaxisunit(sp.attr[:xaxis], sp.attr[:yaxis], sp.attr[:zaxis])
     Plots.locate_annotation(sp, _ustrip.(zip(units, rel)), label)
 end

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -370,7 +370,8 @@ end
 @testset "Annotate" begin
     pl = plot([0, 1]u"s", [0, 1]u"m")
     annotate!(pl, [0.25]u"s", [0.5]u"m", text("annotation"))
-    @test show(devnull, pl) isa Nothing
+    savefig(pl, testfile)
+    @test length(pl.subplots[1].attr[:annotations]) == 1
 end
 
 @testset "AbstractProtectedString" begin


### PR DESCRIPTION
## Description

There was a bug hiding behind a test that didn't actually render the part that was supposed to be tested. Annotations with unitful coordinates used a non-working version of `_ustrip`. This fixes that.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
