### PR TITLE
reset fillto for logscale barplots

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -403,6 +403,7 @@ end
 
 # create a bar plot as a filled step function
 @recipe function f(::Type{Val{:bar}}, x, y, z)  # COV_EXCL_LINE
+    ywiden --> false
     procx, procy, xscale, yscale, _ = _preprocess_barlike(plotattributes, x, y)
     nx, ny = length(procx), length(procy)
     axis = plotattributes[:subplot][isvertical(plotattributes) ? :xaxis : :yaxis]
@@ -435,9 +436,14 @@ end
     end
     if yscale in _logScales && !all(_is_positive, fillto)
         # github.com/JuliaPlots/Plots.jl/issues/4502
+        # https://github.com/JuliaPlots/Plots.jl/issues/4774
         T = float(eltype(y))
-        min_y, _ = plotattributes[:y_extrema]
-        baseline = floor_base(min_y, _logScaleBases[yscale])
+        min_y = NaNMath.minimum(y)
+        base = _logScaleBases[yscale]
+        baseline = floor_base(min_y, base)
+        if min_y == baseline
+            baseline /= base
+        end
         fillto = map(x -> _is_positive(x) ? T(x) : T(baseline), fillto)
     end
 

--- a/test/test_recipes.jl
+++ b/test/test_recipes.jl
@@ -107,35 +107,36 @@ with(:gr) do
     end
 
     @testset "parametric" begin
-        @test plot(sin, sin, cos, 0, 2π) isa Plot
-        @test plot(sin, sin, cos, collect((-2π):(π / 4):(2π))) isa Plot
+        @test plot(sin, sin, cos, 0, 2π) isa Plots.Plot
+        @test plot(sin, sin, cos, collect((-2π):(π / 4):(2π))) isa Plots.Plot
     end
 
     @testset "dict" begin
-        show(devnull, plot(Dict(1 => 2, 3 => -1)))
+        @test_nowarn show(devnull, plot(Dict(1 => 2, 3 => -1)))
     end
 
     @testset "gray image" begin
-        show(devnull, plot(rand(Gray, 2, 2)))
+        @test_nowarn show(devnull, plot(rand(Gray, 2, 2)))
     end
 
     @testset "plots_heatmap" begin
-        show(devnull, plots_heatmap(rand(RGBA, 2, 2)))
+        @test_nowarn show(devnull, plots_heatmap(rand(RGBA, 2, 2)))
     end
 
     @testset "scatter3d" begin
-        show(devnull, scatter3d(1:2, 1:2, 1:2))
+        @test_nowarn show(devnull, scatter3d(1:2, 1:2, 1:2))
     end
 
     @testset "sticks" begin
-        show(devnull, sticks(1:2, marker = :circle))
+        @test_nowarn show(devnull, sticks(1:2, marker = :circle))
     end
 
     @testset "stephist" begin
-        show(devnull, stephist([1, 2], marker = :circle))
+        @test_nowarn show(devnull, stephist([1, 2], marker = :circle))
     end
 
     @testset "bar with logscales" begin
-        show(devnull, bar([1 2 3], [0.02 125 10_000]; yscale = :log10))
+        @test_nowarn show(devnull, bar([1 2 3], [0.02 125 10_000]; yscale = :log10))
+        @test_nowarn histogram(randn(100), yscale = :log10)
     end
 end


### PR DESCRIPTION
## Description
Fix https://github.com/JuliaPlots/Plots.jl/issues/4774

@Moelf, @t-bltg this solution is a bit ugly, because it will cause bar plots with different magnitudes on different series to have different baselines, but since you don't have any information on the other series in the recipe, I don't see a clever way to do that also.

I.e.
```julia
bar([1 2 3], [0.02 125 10_000]; yscale = :log10)
```
gives
![image](https://github.com/JuliaPlots/Plots.jl/assets/18145188/ead3f59f-028b-40d0-be62-3e0e35a47816)

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
