### PR TITLE
issue 4773 -- `suptitle` and `sgtitle` aliases for `plot_title`…

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -754,6 +754,12 @@
             "affiliation": "Thales Research & Technology",
             "orcid": "0000-0002-1901-0159",
             "type": "Other"
+        },
+        {
+            "affiliation": "Brandeis University",
+            "name": "Ryan Young",
+            "orcid": "0000-0002-9454-2876",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/args.jl
+++ b/src/args.jl
@@ -609,6 +609,7 @@ add_aliases(
     :legtitle,
 )
 add_aliases(:legend_title_font_pointsize, :legendtitlefontsize)
+add_aliases(:plot_title, :suptitle, :sgtitle)
 # margin
 add_aliases(:left_margin, :leftmargin)
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -609,7 +609,8 @@ add_aliases(
     :legtitle,
 )
 add_aliases(:legend_title_font_pointsize, :legendtitlefontsize)
-add_aliases(:plot_title, :suptitle, :sgtitle)
+add_aliases(:plot_title, :suptitle, :subplot_grid_title, :sgtitle,
+            :plot_grid_title)
 # margin
 add_aliases(:left_margin, :leftmargin)
 


### PR DESCRIPTION
## Description

These aliases make finding the `plot_title` feature easier for Python and Matlab veterans respectively.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
