### PR TITLE
Adding annotations now respects vertical alignment

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -760,6 +760,11 @@
             "name": "Ryan Young",
             "orcid": "0000-0002-9454-2876",
             "type": "Other"
+        },
+        {
+            "name": "Alexander Von Moll",
+            "orcid": "0000-0002-7661-5752",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -1021,6 +1021,8 @@ function pgfx_add_annotation!(
         Options(
             get((hcenter = "", left = "right", right = "left"), val.font.halign, "") =>
                 nothing,
+            get((vcenter = "", top = "below", bottom = "above"), val.font.valign, "") =>
+                nothing,
             "color" => cstr,
             "draw opacity" => float(alpha(cstr)),  # float(...): convert N0f8
             "rotate" => val.font.rotation,


### PR DESCRIPTION
## Description
Addresses #4810

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
