### PR TITLE
Add missing Animation constructor

### DIFF
--- a/src/animation.jl
+++ b/src/animation.jl
@@ -13,7 +13,7 @@ struct Animation
     frames::Vector{String}
 end
 
-Animation() = Animation(convert(String, mktempdir()), String[])
+Animation(dir = convert(String, mktempdir())) = Animation(dir, String[])
 
 """
     frame(animation[, plot])


### PR DESCRIPTION
## Description

This adds a constructor `Animation(dir)` in addition to the two existing ones `Animation()` and `Animation(dir, frames)`.
The docstring already mentions `Animation(dir)` as an option (see #4568).

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
