### PR TITLE
Fix border ticks of framestyle :box

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -886,6 +886,21 @@ function axis_drawing_info(sp, letter)
                 grid_factor_2d[] / ax_length,
                 ax[:tick_direction] !== :none,
             )
+            if sp[:framestyle] === :box
+                add_major_or_minor_segments_2d(
+                    sp,
+                    ax,
+                    oax,
+                    reverse(oas),
+                    oamM,
+                    first(ticks),
+                    ax[:grid],
+                    tick_segments,
+                    grid_segments,
+                    grid_factor_2d[] / ax_length,
+                    ax[:tick_direction] !== :none,
+                )
+            end
 
             # add minor grid segments
             if ax[:minorticks] ∉ (:none, nothing, false) || ax[:minorgrid]
@@ -902,10 +917,25 @@ function axis_drawing_info(sp, letter)
                     grid_factor_2d[] / 2ax_length,
                     true,
                 )
+                if sp[:framestyle] === :box
+                    add_major_or_minor_segments_2d(
+                        sp,
+                        ax,
+                        oax,
+                        reverse(oas),
+                        oamM,
+                        minor_ticks,
+                        ax[:minorgrid],
+                        tick_segments,
+                        minorgrid_segments,
+                        grid_factor_2d[] / 2ax_length,
+                        true,
+                    )
+                end
             end
         end
     end
-
+    
     (
         ticks = ticks,
         segments = segments,

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -935,7 +935,7 @@ function axis_drawing_info(sp, letter)
             end
         end
     end
-    
+
     (
         ticks = ticks,
         segments = segments,


### PR DESCRIPTION
## Description

As mentioned in Issue #2218 , when using the GR backend with attribute `framestyle = :box`, there are no ticks presents on the opposite side of border (border depends on attribute `mirror`). And PR #4488 has not solved the problem and closed the previous issue. 

Here I'm providing another small PR trying to fix the problem, which just add missing segements when drawing the plot with attribute `framestyle = :box`.

Also mentioned by @BeastyBlacksmith in the issue, the behaviour of `:box` should be like that. However I'm not sure whether it is better to provides some attribute switches to control whether those ticks should be placed on the opposite side.

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [x] Does it work on log scales?
- [x] Does it work in layouts?
- [x] Does it work in recipes?
- [x] Does it work with multiple series in one call?
