### PR TITLE
better error message for size

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -233,7 +233,7 @@ function prepare_output(plt::Plot)
 
     _wh = plt.attr[:size]
     if length(_wh) != 2
-        throw(ArgumentError("size have length = 2, got size = $_wh"))
+        throw(ArgumentError("size must have length = 2, got size = $_wh"))
     end
     w, h = _wh
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -233,7 +233,7 @@ function prepare_output(plt::Plot)
 
     _wh = plt.attr[:size]
     if length(_wh) != 2
-        throw(ArgumentError("size must be of length 2, got size = $_wh"))
+        throw(ArgumentError("size have length = 2, got size = $_wh"))
     end
     w, h = _wh
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -231,7 +231,12 @@ end
 function prepare_output(plt::Plot)
     _before_layout_calcs(plt)
 
-    w, h = plt.attr[:size]
+    _wh = plt.attr[:size]
+    if length(_wh) != 2
+        throw(ArgumentError("size must be of length 2, got size = $_wh"))
+    end
+    w, h = _wh
+
     plt.layout.bbox = BoundingBox(0mm, 0mm, w * px, h * px)
 
     # One pass down and back up the tree to compute the minimum padding

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -233,7 +233,7 @@ function prepare_output(plt::Plot)
 
     _wh = plt.attr[:size]
     if length(_wh) != 2
-        throw(ArgumentError("size must have length = 2, got size = $_wh"))
+        throw(ArgumentError("plot size must have length = 2, got size = $_wh"))
     end
     w, h = _wh
 

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -112,6 +112,8 @@ end
 @testset "size error handling" begin
     plt = plot(size = ())
     @test_throws ArgumentError savefig(plt, tempname())
-    plt = plot(size = ())
+    plt = plot(size = (1))
+    @test_throws ArgumentError savefig(plt, tempname())
+    plt = plot(size = (1,2,3))
     @test_throws ArgumentError savefig(plt, tempname())
 end

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -110,11 +110,9 @@ end
 end
 
 @testset "size error handling" begin
-    plt = plot(size=())
-    @test_throws ArgumentError plot(plt) 
-    @test_throws ArgumentError savefig(plt, "foo.png")
-    plt = plot(size=(1))
-    @test_throws ArgumentError plot(plt) 
-    @test_throws ArgumentError savefig(plt, "foo.png")
+    plt = plot(size=());
+    @test_throws ArgumentError savefig(plt, tempname())
+    plt = plot(size=());
+    @test_throws ArgumentError savefig(plt, tempname())
 end
     

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -115,4 +115,3 @@ end
     plt = plot(size = ())
     @test_throws ArgumentError savefig(plt, tempname())
 end
-    

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -110,9 +110,9 @@ end
 end
 
 @testset "size error handling" begin
-    plt = plot(size=());
+    plt = plot(size = ())
     @test_throws ArgumentError savefig(plt, tempname())
-    plt = plot(size=());
+    plt = plot(size = ())
     @test_throws ArgumentError savefig(plt, tempname())
 end
     

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -108,3 +108,13 @@ end
         Plots._show(io, MIME("text/html"), pl)
     end
 end
+
+@testset "size error handling" begin
+    plt = plot(size=())
+    @test_throws ArgumentError plot(plt) 
+    @test_throws ArgumentError savefig(plt, "foo.png")
+    plt = plot(size=())
+    @test_throws ArgumentError plot(plt) 
+    @test_throws ArgumentError savefig(plt, "foo.png")
+end
+    

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -114,6 +114,6 @@ end
     @test_throws ArgumentError savefig(plt, tempname())
     plt = plot(size = (1))
     @test_throws ArgumentError savefig(plt, tempname())
-    plt = plot(size = (1,2,3))
+    plt = plot(size = (1, 2, 3))
     @test_throws ArgumentError savefig(plt, tempname())
 end

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -113,7 +113,7 @@ end
     plt = plot(size=())
     @test_throws ArgumentError plot(plt) 
     @test_throws ArgumentError savefig(plt, "foo.png")
-    plt = plot(size=())
+    plt = plot(size=(1))
     @test_throws ArgumentError plot(plt) 
     @test_throws ArgumentError savefig(plt, "foo.png")
 end


### PR DESCRIPTION
## Description

If the size parameter of the plot is provided in the wrong format, provide a sensible error message. Current the behavior does not provide an indication on where the input problem is:

```julia
julia> using Plots

julia> plot(size=())
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: BoundsError: attempt to access Tuple{} at index [1]
Stacktrace:
  [1] indexed_iterate
    @ Base ./tuple.jl:92 [inlined]
  [2] indexed_iterate(t::Tuple{}, i::Int64)
    @ Base ./tuple.jl:92
  [3] prepare_output(plt::Plots.Plot{Plots.GRBackend})
    @ Plots ~/.julia/packages/Plots/sxUvK/src/plot.jl:234
  [4] display(::Plots.PlotsDisplay, plt::Plots.Plot{Plots.GRBackend})
    @ Plots ~/.julia/packages/Plots/sxUvK/src/output.jl:168
  [5] display(x::Any)
    @ Base.Multimedia ./multimedia.jl:340
  [6] #invokelatest#2
    @ Base ./essentials.jl:887 [inlined]
  [7] invokelatest
    @ Base ./essentials.jl:884 [inlined]
  [8] print_response(errio::IO, response::Any, show_value::Bool, have_color::Bool, specialdisplay::Union{…})
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:315
  [9] (::REPL.var"#57#58"{REPL.LineEditREPL, Pair{Any, Bool}, Bool, Bool})(io::Any)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:284
 [10] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:569
 [11] print_response(repl::REPL.AbstractREPL, response::Any, show_value::Bool, have_color::Bool)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:282
 [12] (::REPL.var"#do_respond#80"{…})(s::REPL.LineEdit.MIState, buf::Any, ok::Bool)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:911
 [13] #invokelatest#2
    @ Base ./essentials.jl:887 [inlined]
 [14] invokelatest
    @ Base ./essentials.jl:884 [inlined]
 [15] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/LineEdit.jl:2656
 [16] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:1312
 [17] (::REPL.var"#62#68"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:386
Some type information was truncated. Use `show(err)` to see complete types.
```
which when in the middle of a larger script can be really hard to track, as the error only manifest when the figure is being shown or saved. 

With this change, we get:

```julia
julia> plot(size=())
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: ArgumentError: plot size must have length = 2, got size = ()
Stacktrace:
```

and

```julia
julia> plt = plot(size = ());

julia> savefig(plt, "teste.png")
ERROR: ArgumentError: plot size must have length = 2, got size = ()
```

Which are much more clear.

## Description

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ X ] PR includes or updates tests?
- [ ] PR includes or updates documentation?


## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)


