### PR TITLE
Fix warning for failed integration with PlotlyBase & PlotlyKaleide

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -593,7 +593,7 @@ function _initialize_backend(pkg::PlotlyBackend)
         _runtime_init(pkg)
     catch err
         if err isa ArgumentError
-            @warn "Failed to load integration with PlotlyBase & PlotlyKaleide." exception =
+            @warn "Failed to load integration with PlotlyBase & PlotlyKaleido." exception =
                 (err, catch_backtrace())
         else
             rethrow(err)

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -592,9 +592,12 @@ function _initialize_backend(pkg::PlotlyBackend)
         _post_imports(pkg)
         _runtime_init(pkg)
     catch err
-        err isa ArgumentError ||
+        if err isa ArgumentError
             @warn "Failed to load integration with PlotlyBase & PlotlyKaleide." exception =
                 (err, catch_backtrace())
+        else
+            rethrow(err)
+        end
         # NOTE: `plotly` is special in the way that it does not require dependencies for displaying a plot
         # as a result, we cannot rely on the `@require` mechanism for loading glue code
         # this is why it must be done here.


### PR DESCRIPTION
When one of these two packages is not installed, an `ArgumentError` is thrown. As the code was doing `err isa ArgumentError || @warn ...`, nothing is warned and the user does not see any error or warning.
With the current PR, when one of the packages is not in the environment or is not installed, the correct warning is displayed.
Moreover, other errors are rethrown instead of ignored