### PR TITLE
Fix offset array hist

### DIFF
--- a/src/backends/pythonplot.jl
+++ b/src/backends/pythonplot.jl
@@ -1229,10 +1229,10 @@ function _before_layout_calcs(plt::Plot{PythonPlotBackend})
         # link axes
         x_ax_link, y_ax_link = xaxis.sps[1].o, yaxis.sps[1].o
         if Bool(ax != x_ax_link)  # twinx
-            ax.get_shared_x_axes().join(ax, x_ax_link)
+            ax.sharey(y_ax_link)
         end
         if Bool(ax != y_ax_link)  # twiny
-            ax.get_shared_y_axes().join(ax, y_ax_link)
+            ax.sharex(x_ax_link)
         end
     end  # for sp in pl.subplots
     _py_drawfig(fig)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -194,14 +194,16 @@ function make_steps(x::AbstractArray, st, even)
     n = length(x)
     n == 0 && return zeros(0)
     newx = zeros(2n - (even ? 0 : 1))
-    newx[1] = x[1]
+    xstartindex = firstindex(x)
+    newx[1] = x[xstartindex]
     for i in 2:n
+        xindex = xstartindex - 1 + i
         idx = 2i - 1
         if st === :mid
-            newx[idx] = newx[idx - 1] = (x[i] + x[i - 1]) / 2
+            newx[idx] = newx[idx - 1] = (x[xindex] + x[xindex - 1]) / 2
         else
-            newx[idx] = x[i]
-            newx[idx - 1] = x[st === :pre ? i : i - 1]
+            newx[idx] = x[xindex]
+            newx[idx - 1] = x[st === :pre ? xindex : xindex - 1]
         end
     end
     even && (newx[end] = x[end])

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -141,7 +141,7 @@ end
 @testset "Twinx" begin
     pl = plot(1:10, margin = 2Plots.cm)
     twpl = twinx(pl)
-    pl! = plot!(twinx(), -(1:10))
+    pl! = plot!(twpl, -(1:10))
     @test twpl[:right_margin] == 2Plots.cm
     @test twpl[:left_margin] == 2Plots.cm
     @test twpl[:top_margin] == 2Plots.cm

--- a/test/test_recipes.jl
+++ b/test/test_recipes.jl
@@ -45,6 +45,13 @@ end
     @test Plots.ylims(vsp) == (-2, 5)
 end
 
+@testset "steps offset" begin
+    data = OffsetArray(rand(11), -5:5)
+    plot(data, linetype = :steppre)
+    plot(data, linetype = :stepmid)
+    plot(data, linetype = :steppost)
+end
+
 @testset "offset axes" begin
     tri = OffsetVector(vcat(1:5, 4:-1:1), 11:19)
     sticks = plot(tri, seriestype = :sticks)


### PR DESCRIPTION
## Description
Fixing [this](https://github.com/JuliaPlots/Plots.jl/issues/4855) probably wouldn't work with like star wars arrays or some weird thing but at least it should work with linear arrays
## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [x] PR includes or updates tests?
- [ ] PR includes or updates documentation?
