### PR TITLE
Use data URL for local plotly asset

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1055,7 +1055,7 @@ html_body(plt::Plot{PlotlyBackend}) = plotly_html_body(plt)
 
 plotly_url() =
     if _use_local_dependencies[]
-        "file:///" * _plotly_local_file_path[]
+        _plotly_data_url()
     else
         "https://cdn.plot.ly/$_plotly_min_js_filename"
     end

--- a/src/init.jl
+++ b/src/init.jl
@@ -4,7 +4,7 @@ import Base64
 
 const _plotly_local_file_path = Ref{Union{Nothing,String}}(nothing)
 const _plotly_data_url_cached = Ref{Union{Nothing,String}}(nothing)
-_plotly_data_url() = 
+_plotly_data_url() =
     if _plotly_data_url_cached[] === nothing
         _plotly_data_url_cached[] = "data:text/javascript;base64,$(Base64.base64encode(read(_plotly_local_file_path)))"
     else

--- a/src/init.jl
+++ b/src/init.jl
@@ -4,7 +4,8 @@ import Base64
 
 const _plotly_local_file_path = Ref{Union{Nothing,String}}(nothing)
 const _plotly_data_url_cached = Ref{Union{Nothing,String}}(nothing)
-_plotly_data_url() = if _plotly_data_url_cached[] === nothing
+_plotly_data_url() = 
+    if _plotly_data_url_cached[] === nothing
         _plotly_data_url_cached[] = "data:text/javascript;base64,$(Base64.base64encode(read(_plotly_local_file_path)))"
     else
         _plotly_data_url_cached[]

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,7 +1,14 @@
 using Scratch
 using REPL
+import Base64
 
 const _plotly_local_file_path = Ref{Union{Nothing,String}}(nothing)
+const _plotly_data_url_cached = Ref{Union{Nothing,String}}(nothing)
+_plotly_data_url() = if _plotly_data_url_cached[] === nothing
+        _plotly_data_url_cached[] = "data:text/javascript;base64,$(Base64.base64encode(read(_plotly_local_file_path)))"
+    else
+        _plotly_data_url_cached[]
+    end
 # use fixed version of Plotly instead of the latest one for stable dependency
 # see github.com/JuliaPlots/Plots.jl/pull/2779
 const _plotly_min_js_filename = "plotly-2.6.3.min.js"


### PR DESCRIPTION
Currently, when including the `plotly.min.js` locally in HTML, this is done using a `file://` URL. Importing scripts using a file URL is only allowed in browsers if the page origin is also a file URL, i.e. if you open `file://...something.html`.

This PR uses Base64 to include the script using a data URL, which is supported in all environments, including `http` and `https` origins. This means that the plotly backend can be used with `_use_local_dependencies[]` in web-based IDEs like Pluto and other web sites.

Fix #4854, depends on #4862