### PR TITLE
Added error messages in grid function for invalid values for heights and widths

### DIFF
--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -215,24 +215,24 @@ function GridLayout(
     heights = nothing,
     kw...,
 )
-# Check the values for heights and widths if values are provided
-if heights !== nothing && widths !== nothing
-    if sum(heights) != 1 
-    error("The sum of heights must be 1!")
-end
-if sum(widths) != 1
-    error("The sum of widths must be 1!")
-end
-if all(x -> 0 < x < 1, widths) == false 
-    error("Values for widths must be in the range (0, 1)!")
-end
-if all(x -> 0 < x < 1, heights) == false
-    error("Values for heights must be in the range (0, 1)!")
-end
-else
-    heights = zeros(dims[1])
-    widths = zeros(dims[2])
-end
+    # Check the values for heights and widths if values are provided
+    if heights !== nothing && widths !== nothing
+        if sum(heights) != 1
+            error("The sum of heights must be 1!")
+        end
+        if sum(widths) != 1
+            error("The sum of widths must be 1!")
+        end
+        if all(x -> 0 < x < 1, widths) == false
+            error("Values for widths must be in the range (0, 1)!")
+        end
+        if all(x -> 0 < x < 1, heights) == false
+            error("Values for heights must be in the range (0, 1)!")
+        end
+    else
+        heights = zeros(dims[1])
+        widths = zeros(dims[2])
+    end
     grid = Matrix{AbstractLayout}(undef, dims...)
     layout = GridLayout(
         parent,
@@ -245,12 +245,11 @@ end
         # convert(Vector{Float64}, heights),
         KW(kw),
     )
-     for i in eachindex(grid)
+    for i in eachindex(grid)
         grid[i] = EmptyLayout(layout)
     end
     layout
 end
-
 
 Base.size(layout::GridLayout) = size(layout.grid)
 Base.length(layout::GridLayout) = length(layout.grid)

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -211,10 +211,28 @@ grid(args...; kw...) = GridLayout(args...; kw...)
 function GridLayout(
     dims...;
     parent = RootLayout(),
-    widths = zeros(dims[2]),
-    heights = zeros(dims[1]),
+    widths = nothing,
+    heights = nothing,
     kw...,
 )
+# Check the values for heights and widths if values are provided
+if heights !== nothing && widths !== nothing
+    if sum(heights) != 1 
+    error("The sum of heights must be 1!")
+end
+if sum(widths) != 1
+    error("The sum of widths must be 1!")
+end
+if all(x -> 0 < x < 1, widths) == false 
+    error("Values for widths must be in the range (0, 1)!")
+end
+if all(x -> 0 < x < 1, heights) == false
+    error("Values for heights must be in the range (0, 1)!")
+end
+else
+    heights = zeros(dims[1])
+    widths = zeros(dims[2])
+end
     grid = Matrix{AbstractLayout}(undef, dims...)
     layout = GridLayout(
         parent,
@@ -227,11 +245,12 @@ function GridLayout(
         # convert(Vector{Float64}, heights),
         KW(kw),
     )
-    for i in eachindex(grid)
+     for i in eachindex(grid)
         grid[i] = EmptyLayout(layout)
     end
     layout
 end
+
 
 Base.size(layout::GridLayout) = size(layout.grid)
 Base.length(layout::GridLayout) = length(layout.grid)


### PR DESCRIPTION
Fix #4212 
The `grid` function (`GridLayout`) now throws error messages when heights and widths of the grid are not correctly set. This ensures that users receive informative feedback when specifying incorrect values, making it easier to correct issues related to grid dimensions.

I added error messages for the following conditions:
- The sum of heights is not equal to 1.
- The sum of widths is not equal to 1.
- Widths values are not in the range (0, 1).
- Heights values are not in the range (0, 1).

I have tested these changes by providing incorrect values for heights and widths, ensuring that the error messages are triggered as expected. Additionally, I have confirmed that the function continues to work correctly with valid input and with no input at all (standard values).