### PR TITLE
add recipe to plot series objects

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -21,7 +21,7 @@ end
 
 @recipe function f(s::Series)
     for (k, v) in s.plotattributes
-        k == :subplot && continue
+        k in (:subplot, :yerror, :xerror, :zerror) && continue
         plotattributes[k] = v
     end
     ()

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,7 +20,7 @@ mutable struct Series
 end
 
 @recipe function f(s::Series)
-    for (k,v) in s.plotattributes
+    for (k, v) in s.plotattributes
         k == :subplot && continue
         plotattributes[k] = v
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -19,6 +19,14 @@ mutable struct Series
     plotattributes::DefaultsDict
 end
 
+@recipe function f(s::Series)
+    for (k,v) in s.plotattributes
+        k == :subplot && continue
+        plotattributes[k] = v
+    end
+    ()
+end
+
 # a single subplot
 mutable struct Subplot{T<:AbstractBackend} <: AbstractLayout
     parent::AbstractLayout

--- a/test/test_recipes.jl
+++ b/test/test_recipes.jl
@@ -1,5 +1,12 @@
 using OffsetArrays
 
+@testset "Series" begin
+    pl = plot(1:3, yerror = 1)
+    @test plot(pl[1][1])[1][1][:primary] == true
+    @test plot(pl[1][2])[1][1][:primary] == false
+    @test isequal(plot(pl[1][2])[1][1][:y], pl[1][2][:y])
+end
+
 @testset "User recipes" begin
     struct LegendPlot end
     @recipe function f(plot::LegendPlot)


### PR DESCRIPTION
<!-- Plots is in a 2.0 transition phase. Consider (also) targeting the v2 branch with this change -->
## Description

This makes debugging recipes a bit nicer since you can plot each series directly, e.g. 
```julia
using Plots
hp = histogram(randn(1000))
plot(hp[1][1])
```
## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

