### PR TITLE
Making PGFPlotsX use deterministic series IDs

### DIFF
--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -267,7 +267,7 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
             end
             for (series_index, series) in enumerate(series_list(sp))
                 # give each series a uuid for fillbetween
-                series_id = uuid4()
+                series_id = maximum(values(_pgfplotsx_series_ids),init=0) + 1
                 _pgfplotsx_series_ids[Symbol("$series_index")] = series_id
                 opt = series.plotattributes
                 st = series[:seriestype]

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -266,8 +266,8 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 )
             end
             for (series_index, series) in enumerate(series_list(sp))
-                # give each series a uuid for fillbetween
-                series_id = maximum(values(_pgfplotsx_series_ids),init=0) + 1
+                # give each series an id for fillbetween
+                series_id = maximum(values(_pgfplotsx_series_ids), init = 0) + 1
                 _pgfplotsx_series_ids[Symbol("$series_index")] = series_id
                 opt = series.plotattributes
                 st = series[:seriestype]


### PR DESCRIPTION
<!-- Plots is in a 2.0 transition phase. Consider (also) targeting the v2 branch with this change -->
## Description

This is a first attempt at addressing #4927 . One downside I can see is that this may impact thread-safety. It also may be a bit slower if there are many many series, but it seems like there would have to be really a lot of series for the maximum call to take a significant amount of time.

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
