### PR TITLE
use deterministic series IDs in PGFPlotsX

### DIFF
--- a/PlotsBase/ext/PGFPlotsXExt.jl
+++ b/PlotsBase/ext/PGFPlotsXExt.jl
@@ -3,7 +3,6 @@ module PGFPlotsXExt
 import PlotsBase: PlotsBase, pgfx_sanitize_string
 import LaTeXStrings: LaTeXString
 import Printf: @sprintf
-import UUIDs: uuid4
 
 import RecipesPipeline
 import PlotUtils
@@ -465,8 +464,8 @@ function (pgfx_plot::PGFPlotsXPlot)(plt::Plot{PGFPlotsXBackend})
                 )
             end
             for (series_index, series) ∈ enumerate(series_list(sp))
-                # give each series a uuid for fillbetween
-                series_id = uuid4()
+                # give each series an id for fillbetween
+                series_id = maximum(values(_pgfplotsx_series_ids), init = 0) + 1
                 _pgfplotsx_series_ids[Symbol("$series_index")] = series_id
                 opt = series.plotattributes
                 st = series[:seriestype]


### PR DESCRIPTION
<!-- Plots is in a 2.0 transition phase. Consider (also) targeting the v2 branch with this change -->
## Description

v2 version of the pull request

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
