### PR TITLE
GR: draw gridlines below all axes

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1407,6 +1407,8 @@ function gr_draw_axes(sp, vp)
         x_bg, y_bg = RecipesPipeline.unzip(GR.wc3towc.(area_x, area_y, area_z))
         GR.fillarea(x_bg, y_bg)
 
+        foreach(letter -> gr_draw_axis_minorgrid_3d(sp, letter, vp), (:x, :y, :z))
+        foreach(letter -> gr_draw_axis_grid_3d(sp, letter, vp), (:x, :y, :z))
         foreach(letter -> gr_draw_axis_3d(sp, letter, vp), (:x, :y, :z))
     elseif ispolar(sp)
         r = gr_set_viewport_polar(vp)
@@ -1414,10 +1416,36 @@ function gr_draw_axes(sp, vp)
         rmin, rmax = axis_limits(sp, :y)
         gr_polaraxes(rmin, rmax, sp)
     elseif sp[:framestyle] !== :none
+        foreach(letter -> gr_draw_axis_minorgrid(sp, letter, vp), (:x, :y))
+        foreach(letter -> gr_draw_axis_grid(sp, letter, vp), (:x, :y))
         foreach(letter -> gr_draw_axis(sp, letter, vp), (:x, :y))
     end
     GR.settransparency(1.0)
     nothing
+end
+
+function gr_draw_axis_minorgrid_3d(sp, letter, vp)
+    ax = axis_drawing_info_3d(sp, letter)
+    axis = sp[get_attr_symbol(letter, :axis)]
+    gr_draw_minorgrid(sp, axis, ax.minorgrid_segments, gr_polyline3d)
+end
+
+function gr_draw_axis_grid_3d(sp, letter, vp)
+    ax = axis_drawing_info_3d(sp, letter)
+    axis = sp[get_attr_symbol(letter, :axis)]
+    gr_draw_grid(sp, axis, ax.grid_segments, gr_polyline3d)
+end
+
+function gr_draw_axis_minorgrid(sp, letter, vp)
+    ax = axis_drawing_info(sp, letter)
+    axis = sp[get_attr_symbol(letter, :axis)]
+    gr_draw_minorgrid(sp, axis, ax.minorgrid_segments)
+end
+
+function gr_draw_axis_grid(sp, letter, vp)
+    ax = axis_drawing_info(sp, letter)
+    axis = sp[get_attr_symbol(letter, :axis)]
+    gr_draw_grid(sp, axis, ax.grid_segments)
 end
 
 function gr_draw_axis(sp, letter, vp)
@@ -1425,8 +1453,6 @@ function gr_draw_axis(sp, letter, vp)
     axis = sp[get_attr_symbol(letter, :axis)]
 
     # draw segments
-    gr_draw_grid(sp, axis, ax.grid_segments)
-    gr_draw_minorgrid(sp, axis, ax.minorgrid_segments)
     gr_draw_spine(sp, axis, ax.segments)
     gr_draw_border(sp, axis, ax.border_segments)
     gr_draw_ticks(sp, axis, ax.tick_segments)
@@ -1442,8 +1468,6 @@ function gr_draw_axis_3d(sp, letter, vp)
     axis = sp[get_attr_symbol(letter, :axis)]
 
     # draw segments
-    gr_draw_grid(sp, axis, ax.grid_segments, gr_polyline3d)
-    gr_draw_minorgrid(sp, axis, ax.minorgrid_segments, gr_polyline3d)
     gr_draw_spine(sp, axis, ax.segments, gr_polyline3d)
     gr_draw_border(sp, axis, ax.border_segments, gr_polyline3d)
     gr_draw_ticks(sp, axis, ax.tick_segments, gr_polyline3d)


### PR DESCRIPTION
## Description

GR currently plots all components of the x-axis first, and then the y-axis (and possibly z). Since horizontal gridlines belong to the y-axis, if there's a tick at the low end of `xrange`, the corresponding gridline will cover the x-axis (see issue https://github.com/JuliaPlots/Plots.jl/issues/4202).

This fixes the issue for GR by splitting `gr_draw_axis` into three stages, so that we first draw all minor gridlines, then all major gridlines, and the rest of the axis on top.

With the change, a few image tests would need to be updated, in which the x-axis colour is now no longer affected by the (transparent) overlapping gridline -- as far as I can see, no visible changes. I assume that this is done separately in https://github.com/JuliaPlots/PlotReferenceImages.jl/?

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
