### PR TITLE
GR: Draw all gridlines before axis (v2)

### DIFF
--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -1585,6 +1585,8 @@ function gr_draw_axes(sp, vp)
         x_bg, y_bg = RecipesPipeline.unzip(GR.wc3towc.(area_x, area_y, area_z))
         GR.fillarea(x_bg, y_bg)
 
+        foreach(letter -> gr_draw_axis_minorgrid_3d(sp, letter, vp), (:x, :y, :z))
+        foreach(letter -> gr_draw_axis_grid_3d(sp, letter, vp), (:x, :y, :z))
         foreach(letter -> gr_draw_axis_3d(sp, letter, vp), (:x, :y, :z))
     elseif ispolar(sp)
         r = gr_set_viewport_polar(vp)
@@ -1592,10 +1594,36 @@ function gr_draw_axes(sp, vp)
         rmin, rmax = axis_limits(sp, :y)
         gr_polaraxes(rmin, rmax, sp)
     elseif sp[:framestyle] ≢ :none
+        foreach(letter -> gr_draw_axis_minorgrid(sp, letter, vp), (:x, :y))
+        foreach(letter -> gr_draw_axis_grid(sp, letter, vp), (:x, :y))
         foreach(letter -> gr_draw_axis(sp, letter, vp), (:x, :y))
     end
     GR.settransparency(1.0)
     nothing
+end
+
+function gr_draw_axis_minorgrid_3d(sp, letter, vp)
+    ax = axis_drawing_info_3d(sp, letter)
+    axis = sp[get_attr_symbol(letter, :axis)]
+    gr_draw_minorgrid(sp, axis, ax.minorgrid_segments, gr_polyline3d)
+end
+
+function gr_draw_axis_grid_3d(sp, letter, vp)
+    ax = axis_drawing_info_3d(sp, letter)
+    axis = sp[get_attr_symbol(letter, :axis)]
+    gr_draw_grid(sp, axis, ax.grid_segments, gr_polyline3d)
+end
+
+function gr_draw_axis_minorgrid(sp, letter, vp)
+    ax = axis_drawing_info(sp, letter)
+    axis = sp[get_attr_symbol(letter, :axis)]
+    gr_draw_minorgrid(sp, axis, ax.minorgrid_segments)
+end
+
+function gr_draw_axis_grid(sp, letter, vp)
+    ax = axis_drawing_info(sp, letter)
+    axis = sp[get_attr_symbol(letter, :axis)]
+    gr_draw_grid(sp, axis, ax.grid_segments)
 end
 
 function gr_draw_axis(sp, letter, vp)
@@ -1603,8 +1631,6 @@ function gr_draw_axis(sp, letter, vp)
     axis = sp[get_attr_symbol(letter, :axis)]
 
     # draw segments
-    gr_draw_grid(sp, axis, ax.grid_segments)
-    gr_draw_minorgrid(sp, axis, ax.minorgrid_segments)
     gr_draw_spine(sp, axis, ax.segments)
     gr_draw_border(sp, axis, ax.border_segments)
     gr_draw_ticks(sp, axis, ax.tick_segments)
@@ -1620,8 +1646,6 @@ function gr_draw_axis_3d(sp, letter, vp)
     axis = sp[get_attr_symbol(letter, :axis)]
 
     # draw segments
-    gr_draw_grid(sp, axis, ax.grid_segments, gr_polyline3d)
-    gr_draw_minorgrid(sp, axis, ax.minorgrid_segments, gr_polyline3d)
     gr_draw_spine(sp, axis, ax.segments, gr_polyline3d)
     gr_draw_border(sp, axis, ax.border_segments, gr_polyline3d)
     gr_draw_ticks(sp, axis, ax.tick_segments, gr_polyline3d)

--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -1603,25 +1603,25 @@ function gr_draw_axes(sp, vp)
 end
 
 function gr_draw_axis_minorgrid_3d(sp, letter, vp)
-    ax = axis_drawing_info_3d(sp, letter)
+    ax = PlotsBase.axis_drawing_info_3d(sp, letter)
     axis = sp[get_attr_symbol(letter, :axis)]
     gr_draw_minorgrid(sp, axis, ax.minorgrid_segments, gr_polyline3d)
 end
 
 function gr_draw_axis_grid_3d(sp, letter, vp)
-    ax = axis_drawing_info_3d(sp, letter)
+    ax = PlotsBase.axis_drawing_info_3d(sp, letter)
     axis = sp[get_attr_symbol(letter, :axis)]
     gr_draw_grid(sp, axis, ax.grid_segments, gr_polyline3d)
 end
 
 function gr_draw_axis_minorgrid(sp, letter, vp)
-    ax = axis_drawing_info(sp, letter)
+    ax = PlotsBase.axis_drawing_info(sp, letter)
     axis = sp[get_attr_symbol(letter, :axis)]
     gr_draw_minorgrid(sp, axis, ax.minorgrid_segments)
 end
 
 function gr_draw_axis_grid(sp, letter, vp)
-    ax = axis_drawing_info(sp, letter)
+    ax = PlotsBase.axis_drawing_info(sp, letter)
     axis = sp[get_attr_symbol(letter, :axis)]
     gr_draw_grid(sp, axis, ax.grid_segments)
 end


### PR DESCRIPTION
Same as https://github.com/JuliaPlots/Plots.jl/pull/4945, except for Plots.jl v2.

Separates grid drawing from the remainder of gr_draw_axis, so that all gridlines are drawn below the axis. Previously, y-axis gridlines were drawn after the x-axis and could overlap it.

Fixes #4202 for GR.

## Description

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
