### PR TITLE
Fix floating point equality comparison in layouts

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -770,6 +770,11 @@
             "name": "Syver Døving Agdestein",
             "orcid": "0000-0002-1589-2916", 
             "type": "Other"
+        },
+        {
+            "affiliation": "The Alan Turing Institute",
+            "name": "Penelope Yong",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -216,23 +216,18 @@ function GridLayout(
     kw...,
 )
     # Check the values for heights and widths if values are provided
+    all_between_one(xs) = all(x -> 0 < x < 1, xs)
     if heights !== nothing
-        if sum(heights) != 1
-            error("The sum of heights must be 1!")
-        end
-        if all(x -> 0 < x < 1, heights) == false
-            error("Values for heights must be in the range (0, 1)!")
-        end
+        sum(heights) ≈ 1 || error("The heights provided ($(heights)) must sum to 1.")
+        all_between_one(heights) ||
+            error("The heights provided ($(heights)) must be in the range (0, 1).")
     else
         heights = zeros(dims[1])
     end
     if widths !== nothing
-        if sum(widths) != 1
-            error("The sum of widths must be 1!")
-        end
-        if all(x -> 0 < x < 1, widths) == false
-            error("Values for widths must be in the range (0, 1)!")
-        end
+        sum(widths) ≈ 1 || error("The widths provided ($(widths)) must sum to 1.")
+        all_between_one(widths) ||
+            error("The widths provided ($(widths)) must be in the range (0, 1).")
     else
         widths = zeros(dims[2])
     end

--- a/test/test_layouts.jl
+++ b/test/test_layouts.jl
@@ -65,6 +65,17 @@ end
     @test_throws ErrorException plot(map(_ -> plot(1:2), 1:5)...; layout = grid(2, 2))
 end
 
+@testset "Allowed grid widths/heights" begin
+    @test_nowarn grid(2, 1, heights = [0.5, 0.5])
+    @test_nowarn grid(4, 1, heights = [0.3, 0.3, 0.3, 0.1])
+    @test_nowarn grid(1, 2, widths = [0.5, 0.5])
+    @test_nowarn grid(1, 4, widths = [0.3, 0.3, 0.3, 0.1])
+    @test_throws ErrorException grid(2, 1, heights = [0.5, 0.4])
+    @test_throws ErrorException grid(4, 1, heights = [1.5, -0.5])
+    @test_throws ErrorException grid(1, 2, widths = [0.5, 0.4])
+    @test_throws ErrorException grid(1, 4, widths = [1.5, -0.5])
+end
+
 @testset "Invalid viewport" begin
     # github.com/JuliaPlots/Plots.jl/issues/2804
     pl = plot(1, layout = (10, 2))


### PR DESCRIPTION
## Description

Fixes #4971 by using an approximate equality check.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [x] PR includes or updates tests?
- [ ] PR includes or updates documentation?
