### PR TITLE
Adding uparrow as a predefined marker and creating unfilled markershapes

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -775,6 +775,10 @@
             "affiliation": "The Alan Turing Institute",
             "name": "Penelope Yong",
             "type": "Other"
+        },
+        {
+            "name": "Leon Becker",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -822,6 +822,9 @@ alignment(symb) =
     end
 
 # --------------------------------------------------------------------------------------
+function gr_get_markershape(s::Symbol)
+    s in gr_markertypes ? s : Shape(s)
+end
 
 function gr_set_gradient(c)
     grad = _as_gradient(c)
@@ -1263,7 +1266,7 @@ function gr_add_legend(sp, leg, viewport_area)
 
             if (msh = series[:markershape]) ≢ :none
                 msz = max(first(series[:markersize]), 0)
-                msh = msh in gr_markertypes ? msh : Shape(msh)
+                msh = gr_get_markershape.(msh)
                 msw = max(first(series[:markerstrokewidth]), 0)
                 mfac = 0.8 * lfps / (msz + 0.5 * msw + 1e-20)
                 gr_draw_marker(
@@ -2048,7 +2051,7 @@ function gr_draw_markers(
         ms = get_thickness_scaling(series) * _cycle(msize, i)
         msw = get_thickness_scaling(series) * _cycle(strokewidth, i)
         shape = _cycle(shapes, i)
-        shape = shape in gr_markertypes ? shape : Shape(shape)
+        shape = gr_get_markershape.(shape)
         for j ∈ rng
             gr_draw_marker(
                 series,

--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -1263,6 +1263,7 @@ function gr_add_legend(sp, leg, viewport_area)
 
             if (msh = series[:markershape]) ≢ :none
                 msz = max(first(series[:markersize]), 0)
+                msh = msh in gr_markertypes ? msh : Shape(msh)
                 msw = max(first(series[:markerstrokewidth]), 0)
                 mfac = 0.8 * lfps / (msz + 0.5 * msw + 1e-20)
                 gr_draw_marker(
@@ -2047,6 +2048,7 @@ function gr_draw_markers(
         ms = get_thickness_scaling(series) * _cycle(msize, i)
         msw = get_thickness_scaling(series) * _cycle(strokewidth, i)
         shape = _cycle(shapes, i)
+        shape = shape in gr_markertypes ? shape : Shape(shape)
         for j ∈ rng
             gr_draw_marker(
                 series,

--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -227,6 +227,7 @@ const gr_markertypes = (
     vline = -30,
     hline = -31,
 )
+const gr_marker_keys = keys(gr_markertypes)
 const gr_haligns = (
     left = GR.TEXT_HALIGN_LEFT,
     hcenter = GR.TEXT_HALIGN_CENTER,
@@ -823,7 +824,7 @@ alignment(symb) =
 
 # --------------------------------------------------------------------------------------
 function gr_get_markershape(s::Symbol)
-    s in gr_markertypes ? s : Shape(s)
+    s in gr_marker_keys ? s : Shape(s)
 end
 
 function gr_set_gradient(c)

--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -2052,7 +2052,9 @@ function gr_draw_markers(
         ms = get_thickness_scaling(series) * _cycle(msize, i)
         msw = get_thickness_scaling(series) * _cycle(strokewidth, i)
         shape = _cycle(shapes, i)
-        shape = gr_get_markershape.(shape)
+        if !(shape isa Shape)
+            shape = gr_get_markershape.(shape)
+        end
         for j ∈ rng
             gr_draw_marker(
                 series,

--- a/PlotsBase/src/Commons/Commons.jl
+++ b/PlotsBase/src/Commons/Commons.jl
@@ -61,6 +61,7 @@ using ..ColorTypes: alpha
 using ..RecipesBase
 using ..Statistics
 using ..NaNMath
+using ..Unzip
 using ..Printf
 
 const width = Measures.width

--- a/PlotsBase/src/Commons/attrs.jl
+++ b/PlotsBase/src/Commons/attrs.jl
@@ -164,6 +164,8 @@ const _shape_keys = Symbol[
     :hline,
     :+,
     :x,
+    :uparrow,
+    :downarrow,
 ]
 
 const _all_markers = vcat(:none, :auto, _shape_keys)  # sort(collect(keys(_shapes))))

--- a/PlotsBase/src/Commons/attrs.jl
+++ b/PlotsBase/src/Commons/attrs.jl
@@ -144,7 +144,6 @@ const _styleAliases = Dict{Symbol,Symbol}(
 const _shape_keys = Symbol[
     :circle,
     :rect,
-    :star5,
     :diamond,
     :hexagon,
     :cross,
@@ -157,6 +156,7 @@ const _shape_keys = Symbol[
     :heptagon,
     :octagon,
     :star4,
+    :star5,
     :star6,
     :star7,
     :star8,

--- a/PlotsBase/src/Shapes.jl
+++ b/PlotsBase/src/Shapes.jl
@@ -135,6 +135,8 @@ const _shapes = KW(
     :star6     => makestar(6),
     :star7     => makestar(7),
     :star8     => makestar(8),
+    :uparrow   => Shape([(-1.5,-3), (0,0), (1.5,-3)]), 
+    :downarrow => Shape([(-1.5, 3), (0, 0), (1.5, 3)]), 
 )
 
 Shape(k::Symbol) = deepcopy(_shapes[k])

--- a/PlotsBase/src/Shapes.jl
+++ b/PlotsBase/src/Shapes.jl
@@ -47,6 +47,9 @@ function Shape(x::AVec{X}, y::AVec{Y}) where {X,Y}
     return Shape(convert(Vector{X}, x), convert(Vector{Y}, y))
 end
 
+# make it broadcast like a scalar
+Base.Broadcast.broadcastable(shape::Shape) = Ref(shape)
+
 get_xs(shape::Shape) = shape.x
 get_ys(shape::Shape) = shape.y
 vertices(shape::Shape) = collect(zip(shape.x, shape.y))

--- a/PlotsBase/src/Shapes.jl
+++ b/PlotsBase/src/Shapes.jl
@@ -135,8 +135,8 @@ const _shapes = KW(
     :star6     => makestar(6),
     :star7     => makestar(7),
     :star8     => makestar(8),
-    :uparrow   => Shape([(-1.5,-3), (0,0), (1.5,-3)]), 
-    :downarrow => Shape([(-1.5, 3), (0, 0), (1.5, 3)]), 
+    :uparrow   => Shape([(-1.3,-1), (0, 1.5), (0,-1.5), (0, 1.5), (1.3,-1)]), 
+    :downarrow => Shape([(-1.3, 1), (0, -1.5), (0,1.5), (0, -1.5),(1.3, 1)]), 
 )
 
 Shape(k::Symbol) = deepcopy(_shapes[k])

--- a/PlotsBase/src/recipes.jl
+++ b/PlotsBase/src/recipes.jl
@@ -332,6 +332,11 @@ end
     if plotattributes[:markershape] ≢ :none
         primary := false
         @series begin
+            markershape := if plotattributes[:markershape] === :arrow
+                [isless(yi, 0.0) ? :downarrow : :uparrow for yi in y]
+            else
+                plotattributes[:markershape]
+            end
             seriestype := :scatter
             x := x
             y := y

--- a/PlotsBase/src/utils.jl
+++ b/PlotsBase/src/utils.jl
@@ -103,19 +103,14 @@ function _update_series_attributes!(plotattributes::AKW, plt::Plot, sp::Subplot)
     end
 
     # update markerstrokecolor
-    if plotattributes[:markerstrokecolor] ≡ :match
-        stroke_color = plotattributes[:seriescolor]
+    plotattributes[:markerstrokecolor] = if plotattributes[:markerstrokecolor] ≡ :match
+        get_series_color(plotattributes[:seriescolor], sp, plotIndex, stype)
     elseif plotattributes[:markerstrokecolor] ≡ :auto
-        stroke_color = plotattributes[:markercolor]
+        get_series_color(plotattributes[:markercolor], sp, plotIndex, stype)
     else
-        stroke_color = something(plotattributes[:markerstrokecolor], plotattributes[:seriescolor])
+        get_series_color(something(plotattributes[:markerstrokecolor], plotattributes[:seriescolor]), sp, plotIndex, stype)
     end
-    
-    marker_color = something(plotattributes[:markercolor], plotattributes[:seriescolor])
-    
-    plotattributes[:markerstrokecolor] = get_series_color(stroke_color, sp, plotIndex, stype)
-    plotattributes[:markercolor] = get_series_color(marker_color, sp, plotIndex, stype)
-    
+     
     # if marker_z, fill_z or line_z are set, ensure we have a gradient
     if plotattributes[:marker_z] ≢ nothing
         Commons.ensure_gradient!(plotattributes, :markercolor, :markeralpha)

--- a/PlotsBase/src/utils.jl
+++ b/PlotsBase/src/utils.jl
@@ -103,14 +103,19 @@ function _update_series_attributes!(plotattributes::AKW, plt::Plot, sp::Subplot)
     end
 
     # update markerstrokecolor
-    plotattributes[:markerstrokecolor] = if plotattributes[:markerstrokecolor] ≡ :match
-        plot_color(sp[:foreground_color_subplot])
+    if plotattributes[:markerstrokecolor] ≡ :match
+        stroke_color = plotattributes[:seriescolor]
     elseif plotattributes[:markerstrokecolor] ≡ :auto
-        get_series_color(plotattributes[:markercolor], sp, plotIndex, stype)
+        stroke_color = plotattributes[:markercolor]
     else
-        get_series_color(plotattributes[:markerstrokecolor], sp, plotIndex, stype)
+        stroke_color = something(plotattributes[:markerstrokecolor], plotattributes[:seriescolor])
     end
-
+    
+    marker_color = something(plotattributes[:markercolor], plotattributes[:seriescolor])
+    
+    plotattributes[:markerstrokecolor] = get_series_color(stroke_color, sp, plotIndex, stype)
+    plotattributes[:markercolor] = get_series_color(marker_color, sp, plotIndex, stype)
+    
     # if marker_z, fill_z or line_z are set, ensure we have a gradient
     if plotattributes[:marker_z] ≢ nothing
         Commons.ensure_gradient!(plotattributes, :markercolor, :markeralpha)

--- a/PlotsBase/src/utils.jl
+++ b/PlotsBase/src/utils.jl
@@ -104,7 +104,7 @@ function _update_series_attributes!(plotattributes::AKW, plt::Plot, sp::Subplot)
 
     # update markerstrokecolor
     plotattributes[:markerstrokecolor] = if plotattributes[:markerstrokecolor] ≡ :match
-        get_series_color(plotattributes[:seriescolor], sp, plotIndex, stype)
+        plot_color(sp[:foreground_color_subplot])
     elseif plotattributes[:markerstrokecolor] ≡ :auto
         get_series_color(plotattributes[:markercolor], sp, plotIndex, stype)
     else

--- a/PlotsBase/test/test_animations.jl
+++ b/PlotsBase/test/test_animations.jl
@@ -54,7 +54,7 @@ end
         circleplot(x, y, i, line_z = 1:n, cbar = false, framestyle = :zerolines)
     end when i % 5 == 0 fps = 10
 
-    @test_throws LoadError macroexpand(
+    @test_throws ErrorException macroexpand(
         @__MODULE__,
         quote
             @gif for i ∈ 1:n

--- a/PlotsBase/test/test_pgfplotsx.jl
+++ b/PlotsBase/test/test_pgfplotsx.jl
@@ -436,7 +436,7 @@ with(:pgfplotsx) do
         @test PlotsBase.pgfx_sanitize_string("A string, with 2 punctuation chars.") ==
               "A string, with 2 punctuation chars."
         @test PlotsBase.pgfx_sanitize_string("Interpolação polinomial") ==
-              raw"Interpola$\textnormal{\c{c}}$$\textnormal{\~{a}}$o polinomial"
+              raw"Interpola$\textnormal{\c{c}}$$\tilde{a}$o polinomial"
         @test PlotsBase.pgfx_sanitize_string("∫∞ ∂x") == raw"$\int$$\infty$ $\partial$x"
 
         # special LaTeX characters

--- a/PlotsBase/test/test_reference.jl
+++ b/PlotsBase/test/test_reference.jl
@@ -18,7 +18,7 @@ reference_dir(args...) =
     else
         joinpath(homedir(), ".julia", "dev", "PlotReferenceImages.jl", args...)
     end
-reference_path(backend, version) = reference_dir("Plots", string(backend), string(version))
+reference_path(backend, version) = reference_dir("PlotsBase", string(backend), string(version))
 
 function checkout_reference_dir(dn::AbstractString)
     mkpath(dn)
@@ -54,7 +54,7 @@ end
 
 function reference_file(backend, version, i)
     # NOTE: keep ref[...].png naming consistent with `PlotDocs`
-    refdir = reference_dir("Plots", string(backend))
+    refdir = mkpath(reference_dir("PlotsBase", string(backend)))
     fn = ref_name(i) * ".png"
     reffn = joinpath(refdir, string(version), fn)
     for ver ∈ sort(VersionNumber.(readdir(refdir)), rev = true)

--- a/Project.toml
+++ b/Project.toml
@@ -9,30 +9,11 @@ PlotsBase = "c52230a3-c5da-43a3-9e85-260fcdfdc737"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
-[weakdeps]
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-
-[extensions]
-FileIOExt = "FileIO"
-GeometryBasicsExt = "GeometryBasics"
-IJuliaExt = "IJulia"
-ImageInTerminalExt = "ImageInTerminal"
-UnitfulExt = "Unitful"
-
 [compat]
-FileIO = "1"
 GR = "0.73, 1"
-ImageInTerminal = "0.5"
-GeometryBasics = "0.4"
-IJulia = "1"
 PlotsBase = "0.1"
 PrecompileTools = "1"
 Reexport = "1"
-Unitful = "1"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Description
Adds `:uparrow` as a predefined markershape and causes `markercolor=nothing` to create an unfilled open shape as requested in #4962. 
The changes also make it possible to create unfilled markers of every predefined markershape and also add an `:downarrow` shape. 
Unfortunately I couldn´t quite figure out how to make sticks flip the marker shape vertically if the data value is less or equal to `0.0.`
## Attribution
- [X] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
