### PR TITLE
CI fixes v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,7 @@ jobs:
           - false
         os: [ubuntu-latest, windows-latest, macos-latest]
         arch: [x64]
-        exclude:
-          # No native binaries for Julia 1.6 on ARM macOS
-          - os: macos-latest
-            version: '1.6'
         include:
-          # In its place, test Julia 1.6 on x86 macOS
-          - os: macos-13
-            experimental: false
-            version: '1.6'
           - os: ubuntu-latest
             experimental: true
             version: 'pre'  # upcoming julia version (`alpha`, `beta` or `rc`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,15 @@ jobs:
           - false
         os: [ubuntu-latest, windows-latest, macos-latest]
         arch: [x64]
+        exclude:
+          # No native binaries for Julia 1.6 on ARM macOS
+          - os: macos-latest
+            version: '1.6'
         include:
+          # In its place, test Julia 1.6 on x86 macOS
+          - os: macos-13
+            experimental: false
+            version: '1.6'
           - os: ubuntu-latest
             experimental: true
             version: 'pre'  # upcoming julia version (`alpha`, `beta` or `rc`)

--- a/PlotsBase/src/examples.jl
+++ b/PlotsBase/src/examples.jl
@@ -1258,12 +1258,10 @@ _animation_examples = [02, 31]
 _backend_skips = Dict(
     :none => Int[],
     :pythonplot => Int[],
-    :gr => [25, 30],  # TODO: add back when StatsPlots is available
+    :gr => Int[],
     :plotlyjs => [
         21,
         24,
-        25,
-        30,
         49,
         50,
         51,
@@ -1314,6 +1312,10 @@ _backend_skips = Dict(
     ],
 )
 _backend_skips[:plotly] = _backend_skips[:plotlyjs]
+# 25 and 30 require StatsPlots, which doesn't support Plots v2 yet
+for backend in keys(_backend_skips)
+    append!(_backend_skips[backend], [25, 30])
+end
 
 # ---------------------------------------------------------------------------------
 # replace `f(args...)` with `f(rng, args...)` for `f ∈ (rand, randn)`

--- a/PlotsBase/test/runtests.jl
+++ b/PlotsBase/test/runtests.jl
@@ -54,17 +54,10 @@ is_ci() || @eval using Gtk  # see JuliaPlots/VisualRegressionTests.jl/issues/30
 
 ref_name(i) = "ref" * lpad(i, 3, '0')
 
-const blacklist = if VERSION.major == 1 && VERSION.minor ≥ 9
-    [
-        25,
-        30, # FIXME: remove, when StatsPlots supports Plots v2
-        41,
-    ]  # FIXME: github.com/JuliaLang/julia/issues/47261
+const broken_examples = if Sys.isapple()
+    [50] # FIXME: https://github.com/jheinen/GR.jl/issues/550
 else
     []
-end
-if Sys.isapple()
-    push!(blacklist, 50)  # FIXME: https://github.com/jheinen/GR.jl/issues/550
 end
 
 for name ∈ (

--- a/PlotsBase/test/runtests.jl
+++ b/PlotsBase/test/runtests.jl
@@ -63,6 +63,9 @@ const blacklist = if VERSION.major == 1 && VERSION.minor ≥ 9
 else
     []
 end
+if Sys.isapple()
+    push!(blacklist, 50)  # FIXME: https://github.com/jheinen/GR.jl/issues/550
+end
 
 for name ∈ (
     "misc",

--- a/PlotsBase/test/test_backends.jl
+++ b/PlotsBase/test/test_backends.jl
@@ -66,7 +66,7 @@ is_pkgeval() || @testset "Backends" begin
         @test filesize(fn) > 1_000
     end
     Sys.islinux() && for be ∈ TEST_BACKENDS
-        skip = vcat(PlotsBase._backend_skips[be], blacklist)
+        skip = vcat(PlotsBase._backend_skips[be], broken_examples)
         PlotsBase.test_examples(be; skip, callback, disp = is_ci(), strict = true)  # `ci` display for coverage
         closeall()
     end

--- a/PlotsBase/test/test_pgfplotsx.jl
+++ b/PlotsBase/test/test_pgfplotsx.jl
@@ -436,7 +436,7 @@ with(:pgfplotsx) do
         @test PlotsBase.pgfx_sanitize_string("A string, with 2 punctuation chars.") ==
               "A string, with 2 punctuation chars."
         @test PlotsBase.pgfx_sanitize_string("Interpolação polinomial") ==
-              raw"Interpola$\textnormal{\c{c}}$$\textnormal{\~{a}}$o polinomial"
+              raw"Interpola$\textnormal{\c{c}}$$\tilde{a}$o polinomial"
         @test PlotsBase.pgfx_sanitize_string("∫∞ ∂x") == raw"$\int$$\infty$ $\partial$x"
 
         # special LaTeX characters

--- a/PlotsBase/test/test_reference.jl
+++ b/PlotsBase/test/test_reference.jl
@@ -105,6 +105,7 @@ end
 function image_comparison_facts(
     pkg::Symbol;
     skip = [],          # skip these examples (int index)
+    broken = [],        # known broken examples (int index)
     only = nothing,     # limit to these examples (int index)
     debug = false,      # print debug information ?
     sigma = [1, 1],     # number of pixels to "blur"
@@ -112,7 +113,11 @@ function image_comparison_facts(
 )
     for i ∈ setdiff(1:length(PlotsBase._examples), skip)
         if only ≡ nothing || i in only
-            @test success(image_comparison_tests(pkg, i; debug, sigma, tol))
+            if i ∈ broken
+                @test_broken success(image_comparison_tests(pkg, i; debug, sigma, tol))
+            else
+                @test success(image_comparison_tests(pkg, i; debug, sigma, tol))
+            end
         end
     end
 end
@@ -141,7 +146,8 @@ end
         image_comparison_facts(
             :gr,
             tol = PLOTS_IMG_TOL,
-            skip = vcat(PlotsBase._backend_skips[:gr], blacklist),
+            skip = vcat(PlotsBase._backend_skips[:gr]),
+            broken = broken_examples,
         )
     end
 end

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,22 @@ PlotsBase = "c52230a3-c5da-43a3-9e85-260fcdfdc737"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
+[weakdeps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
+ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[extensions]
+FileIOExt = "FileIO"
+GeometryBasicsExt = "GeometryBasics"
+IJuliaExt = "IJulia"
+ImageInTerminalExt = "ImageInTerminal"
+UnitfulExt = "Unitful"
+
 [compat]
-GR = "0, 1"
+GR = "0.73, 1"
 PlotsBase = "0.1"
 PrecompileTools = "1"
 Reexport = "1"


### PR DESCRIPTION
## Description

Port of #4974 for v2. Sorry this took so long for not very much code! 

Some tests are failing, though, because GR 0.73.7 on macOS causes some regressions on plotting — specifically reference image #50. I filed an upstream issue here: https://github.com/jheinen/GR.jl/issues/550

In the meantime, I've added #50 to the list of reference tests to not run on macOS.

(I would probably also prefer if that was renamed from `blacklist`. It seems that we are using that to denote tests that we don't expect to work — could we use `@test_broken` in its place instead? Then we'd also get to know when the test starts working.)

### Expected

![artifact 2](https://github.com/user-attachments/assets/e909b8bc-75e9-4154-8904-864b05be7e01)

### Actual

![artifact](https://github.com/user-attachments/assets/6d150fb0-d927-4e88-8768-1055f35fc772)


## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
