### PR TITLE
GR backend: use textext for :log2 and :ln axis scaling

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -775,6 +775,10 @@
             "affiliation": "The Alan Turing Institute",
             "name": "Penelope Yong",
             "type": "Other"
+        },
+        {
+            "name": "Patrick Jaap",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -250,7 +250,7 @@ end
 
 gr_inqtext(x, y, s) = gr_inqtext(x, y, string(s))
 gr_inqtext(x, y, s::AbstractString) =
-    if (occursin('\\', s) || occursin("10^{", s)) &&
+    if (occursin('\\', s) || occursin(r"10\^{|2\^{|e\^{", s)) &&
        match(r".*\$[^\$]+?\$.*", String(s)) === nothing
         GR.inqtextext(x, y, s)
     else
@@ -259,7 +259,7 @@ gr_inqtext(x, y, s::AbstractString) =
 
 gr_text(x, y, s) = gr_text(x, y, string(s))
 gr_text(x, y, s::AbstractString) =
-    if (occursin('\\', s) || occursin("10^{", s)) &&
+    if (occursin('\\', s) || occursin(r"10\^{|2\^{|e\^{", s)) &&
        match(r".*\$[^\$]+?\$.*", String(s)) === nothing
         GR.textext(x, y, s)
     else


### PR DESCRIPTION
This fixes #4871

Only the case of `:log10` has been treated before.

## Description

## Attribution
- [ x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
