### PR TITLE
restrict to LTS 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         version:
           - '1'  # latest stable
-          - '1.9'  # minimal declared julia compat in `Project.toml`
+          - '1.10'  # minimal declared julia compat in `Project.toml`
         experimental:
           - false
         os: [ubuntu-latest, windows-latest]

--- a/PlotsBase/Project.toml
+++ b/PlotsBase/Project.toml
@@ -109,7 +109,7 @@ UnicodePlots = "3"
 UnitfulLatexify = "1"
 Unzip = "0.1 - 0.2"
 UUIDs = "1"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ PlotsBase = "0.1"
 PrecompileTools = "1"
 Reexport = "1"
 Unitful = "1"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"

--- a/RecipesBase/Project.toml
+++ b/RecipesBase/Project.toml
@@ -8,7 +8,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 PrecompileTools = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"

--- a/RecipesPipeline/Project.toml
+++ b/RecipesPipeline/Project.toml
@@ -15,7 +15,7 @@ NaNMath = "0.3, 1"
 PlotUtils = "0.6.5, 1"
 RecipesBase = "1.3.1"
 PrecompileTools = "1"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
## Description

Per PSA : https://discourse.julialang.org/t/julia-v1-11-0-has-been-released-and-v1-10-is-now-lts/121064

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
