### PR TITLE
Incorrect Behavior of Bars under (:permute) -> remove the expand_extrema call

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -779,6 +779,11 @@
         {
             "name": "Patrick Jaap",
             "type": "Other"
+        },
+        {   
+            "affiliation": "Ludwig-Maximilians-Universiaet Muenchen",
+            "name": "Jonas Zimmermann",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -363,7 +363,7 @@ function RecipesPipeline.add_series!(plt::Plot, plotattributes)
         elseif ms === :vline && (perm == (:x, :y) || perm == (:y, :x))
             plotattributes[:markershape] = :hline
         end
-        if plotattributes[:seriestype] === :bar # bar calls expand_extrema! in its recipe...
+        if plotattributes[:seriestype] === :bar
             sp = plotattributes[:subplot]
             sp[get_attr_symbol(letter1, :axis)][:lims],
             sp[get_attr_symbol(letter2, :axis)][:lims] =

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -461,9 +461,6 @@ end
         push!(yseg, yi, fi, fi, yi, yi)
     end
 
-    # widen limits out a bit
-    expand_extrema!(axis, scale_lims(ignorenan_extrema(xseg.pts)..., default_widen_factor))
-
     # switch back
     if !isvertical(plotattributes)
         xseg, yseg = yseg, xseg


### PR DESCRIPTION
## Description
Removed the `expand_extrema!` call in the `bar` recipe, as this leads to an issue with the permute option; 
see https://github.com/JuliaPlots/Plots.jl/issues/5009

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503) (Part of this PR)
