### PR TITLE
Make @df support string column names

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -789,6 +789,10 @@
         {
             "name": "Patrick Jaap",
             "type": "Other"
+        },
+        {
+            "name": "Wolf, Ron",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/StatsPlots/src/df.jl
+++ b/StatsPlots/src/df.jl
@@ -191,6 +191,8 @@ get_col(syms, col_nt, names) = hcat((get_col(s, col_nt, names) for s ∈ syms)..
 
 # get the appropriate name when passed an Integer
 add_sym!(cols, i::Integer, names) = push!(cols, names[i])
+# get the appropriate name when passed an AbstractString
+add_sym!(cols, str::AbstractString, names) = add_sym!(cols, Symbol(str), names)
 # check for errors in Symbols
 add_sym!(cols, s::Symbol, names) = s in names ? push!(cols, s) : cols
 # recursively extract column names


### PR DESCRIPTION
## Description

Add a special case to `add_sym!` to convert an `AbstractString` column name to a `Symbol` before adding it.

The old behavior would iterate over the string and try to add each character as a column name. This produced a stack overflow, since `add_sym!` had no special case for `Char`, resulting in indefinite recursion. More details in JuliaPlots/StatsPlots.jl#562.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/ron-wolf/Plots.jl/blob/56514c75f6fef7f288518feee8d3a83feba55434/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [x] Does it work on log scales? -- Change only affects column names
- [x] Does it work in layouts? -- ''
- [x] Does it work in recipes? -- ''
- [x] Does it work with multiple series in one call? -- No new functions introduced
- [x] PR includes or updates tests? -- No changes to tests
- [x] PR includes or updates documentation? -- No changes to docs