### PR TITLE
fix date time access

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -92,7 +92,7 @@ function attr!(axis::Axis, args...; kw...)
         if k === :discrete_values
             foreach(x -> discrete_value!(axis, x), v)  # add these discrete values to the axis
         elseif k === :lims && isa(v, NTuple{2,TimeType})
-            plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
+            plotattributes[k] = (Dates.value(v[1]), Dates.value(v[2]))
         else
             plotattributes[k] = v
         end


### PR DESCRIPTION
## Description

Used `Dates.value` instead of the current solution.

Fixes #5034 for Plots v1

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
