### PR TITLE
fixed issue #4881, arrowsize

### DIFF
--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -360,11 +360,12 @@ gr_set_projectiontype(sp) = GR.setprojectiontype(gr_projections[sp[:projection_t
 
 # draw line segments, splitting x/y into contiguous/finite segments
 # note: this can be used for shapes by passing func `GR.fillarea`
-function gr_polyline(x, y, func = GR.polyline; arrowside = :none, arrowstyle = :simple)
+function gr_polyline(x, y, func = GR.polyline; arrowside = :none, arrowstyle = :simple, arrowsize = 1)
     draw_head = arrowside in (:head, :both)
     draw_tail = arrowside in (:tail, :both)
     n = length(x)
     iend = 0
+    GR.setarrowsize(arrowsize)
     while iend < n - 1
         istart = -1  # set istart to the first index that is finite
         for j ∈ (iend + 1):n
@@ -2021,12 +2022,11 @@ function gr_draw_segments(series, x, y, z, fillrange, clims)
         if is3d
             GR.polyline3d(x[rng], y[rng], z[rng])
         elseif is2d
-            arrowside, arrowstyle = if (arrow = series[:arrow]) isa Arrow
-                arrow.side, arrow.style
-            else
-                :none, :simple
-            end
-            gr_polyline(x[rng], y[rng]; arrowside = arrowside, arrowstyle = arrowstyle)
+            arrow = series[:arrow] isa Arrow ? series[:arrow] : Arrow(:none, :simple, 1.0, 1.0)
+        
+            arrowside, arrowstyle, arrowsize = arrow.side, arrow.style, (arrow.headlength+arrow.headwidth)/2
+                 
+            gr_polyline(x[rng], y[rng]; arrowside = arrowside, arrowstyle = arrowstyle, arrowsize = arrowsize)
         end
     end
 end

--- a/PlotsBase/src/Arrows.jl
+++ b/PlotsBase/src/Arrows.jl
@@ -20,7 +20,7 @@ Define arrowheads to apply to lines - args are `style` (`:open` or `:closed`),
 """
 function arrow(args...)
     style, side = :simple, :head
-    headlength = headwidth = 0.3
+    headlength = headwidth = 1
     setlength = false
     for arg ∈ args
         T = typeof(arg)


### PR DESCRIPTION
## Description
fixed arrowsize, created mean of arrow.headlength and arrow.headwidth to plot more suitable arrow size
set default of headlength and headwidth to 1 instead of 0.3
## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
