### PR TITLE
Correct connector line in `lens!` for non-linear scales

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -92,7 +92,7 @@ function attr!(axis::Axis, args...; kw...)
         if k === :discrete_values
             foreach(x -> discrete_value!(axis, x), v)  # add these discrete values to the axis
         elseif k === :lims && isa(v, NTuple{2,TimeType})
-            plotattributes[k] = (v[1].instant.periods.value, v[2].instant.periods.value)
+            plotattributes[k] = (Dates.value(v[1]), Dates.value(v[2]))
         else
             plotattributes[k] = v
         end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1034,8 +1034,6 @@ export lens!
         @series begin
             primary := false
             subplot := sp_index
-            # x := RecipesPipeline.inverse_scale_func(xscale).([xi_mag, xi_lens])
-            # y := RecipesPipeline.inverse_scale_func(yscale).([yi_mag, yi_lens])
             x := [xi_mag, xi_lens]
             y := [yi_mag, yi_lens]
             ()

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -993,16 +993,21 @@ export lens!
     xscale = sp[:xaxis][:scale]
     yscale = sp[:yaxis][:scale]
     xl1, xl2 = xlims(sp)
-    bbx1 = xl1 + left(inset_bbox).value * (xl2 - xl1)
-    bbx2 = bbx1 + width(inset_bbox).value * (xl2 - xl1)
+    xls1, xls2 = RecipesPipeline.scale_func(xscale).((xl1, xl2))
+    bbx1 = xls1 + left(inset_bbox).value * (xls2 - xls1)
+    bbx2 = bbx1 + width(inset_bbox).value * (xls2 - xls1)
     yl1, yl2 = ylims(sp)
-    bby1 = yl1 + (1 - bottom(inset_bbox).value) * (yl2 - yl1)
-    bby2 = bby1 + height(inset_bbox).value * (yl2 - yl1)
-    bbx = bbx1 + width(inset_bbox).value * (xl2 - xl1) / 2 * (sp[:xaxis][:flip] ? -1 : 1)
-    bby = bby1 + height(inset_bbox).value * (yl2 - yl1) / 2 * (sp[:yaxis][:flip] ? -1 : 1)
+    yls1, yls2 = RecipesPipeline.scale_func(yscale).((yl1, yl2))
+    bby1 = yls1 + (1 - bottom(inset_bbox).value) * (yls2 - yls1)
+    bby2 = bby1 + height(inset_bbox).value * (yls2 - yls1)
+    bbx = bbx1 + width(inset_bbox).value * (xls2 - xls1) / 2 * (sp[:xaxis][:flip] ? -1 : 1)
+    bby = bby1 + height(inset_bbox).value * (yls2 - yls1) / 2 * (sp[:yaxis][:flip] ? -1 : 1)
     lens_index = last(plt.subplots)[:subplot_index] + 1
-    x1, x2 = RecipesPipeline.inverse_scale_func(xscale).(plotattributes[:x])
-    y1, y2 = RecipesPipeline.inverse_scale_func(yscale).(plotattributes[:y])
+    x1, x2 = plotattributes[:x]
+    y1, y2 = plotattributes[:y]
+    xs1, xs2 = RecipesPipeline.scale_func(xscale).((x1, x2))
+    ys1, ys2 = RecipesPipeline.scale_func(yscale).((y1, y2))
+
     backup = copy(plotattributes)
     empty!(plotattributes)
 
@@ -1016,19 +1021,23 @@ export lens!
     if haskey(backup, :linewidth)
         linewidth := backup[:linewidth]
     end
-    bbx_mag = (x1 + x2) / 2
-    bby_mag = (y1 + y2) / 2
+    bbx_mag = (xs1 + xs2) / 2
+    bby_mag = (ys1 + ys2) / 2
     xi_lens, yi_lens =
         intersection_point(bbx_mag, bby_mag, bbx, bby, abs(bby2 - bby1), abs(bbx2 - bbx1))
     xi_mag, yi_mag =
         intersection_point(bbx, bby, bbx_mag, bby_mag, abs(y2 - y1), abs(x2 - x1))
+    xi_mag, xi_lens = RecipesPipeline.inverse_scale_func(xscale).((xi_mag, xi_lens))
+    yi_mag, yi_lens = RecipesPipeline.inverse_scale_func(yscale).((yi_mag, yi_lens))
     # add lines
     if xl1 < xi_lens < xl2 && yl1 < yi_lens < yl2
         @series begin
             primary := false
             subplot := sp_index
-            x := RecipesPipeline.scale_func(xscale).([xi_mag, xi_lens])
-            y := RecipesPipeline.scale_func(yscale).([yi_mag, yi_lens])
+            # x := RecipesPipeline.inverse_scale_func(xscale).([xi_mag, xi_lens])
+            # y := RecipesPipeline.inverse_scale_func(yscale).([yi_mag, yi_lens])
+            x := [xi_mag, xi_lens]
+            y := [yi_mag, yi_lens]
             ()
         end
     end
@@ -1036,8 +1045,8 @@ export lens!
     @series begin
         primary := false
         subplot := sp_index
-        x := RecipesPipeline.scale_func(xscale).([x1, x1, x2, x2, x1])
-        y := RecipesPipeline.scale_func(yscale).([y1, y2, y2, y1, y1])
+        x := [x1, x1, x2, x2, x1]
+        y := [y1, y2, y2, y1, y1]
         ()
     end
     # add subplot
@@ -1046,8 +1055,8 @@ export lens!
             plotattributes = merge(backup, copy(series.plotattributes))
             subplot := lens_index
             primary := false
-            xlims := RecipesPipeline.scale_func(xscale).((x1, x2))
-            ylims := RecipesPipeline.scale_func(yscale).((y1, y2))
+            xlims := (x1, x2)
+            ylims := (y1, y2)
             ()
         end
     end


### PR DESCRIPTION
## Description

Fix #4975 

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
