### PR TITLE
fixed issue #4880

### DIFF
--- a/PlotsBase/src/recipes.jl
+++ b/PlotsBase/src/recipes.jl
@@ -410,6 +410,14 @@ end
 
 # create a bar plot as a filled step function
 @recipe function f(::Type{Val{:bar}}, x, y, z)  # COV_EXCL_LINE
+    if typeof(y) <: NamedTuple
+        names = collect(keys(y))
+        values_y = [values(y)...]
+        plotnames = string.(names)
+
+        x = plotnames
+        y = values_y
+    end
     ywiden --> false
     procx, procy, xscale, yscale, _ = _preprocess_barlike(plotattributes, x, y)
     nx, ny = length(procx), length(procy)

--- a/PlotsBase/src/shorthands.jl
+++ b/PlotsBase/src/shorthands.jl
@@ -25,6 +25,7 @@ julia> scatter([(1,4),(2,5),(3,6)])
     bar!(x,y)
 
 Make a bar plot of `y` vs `x`.
+If `y` is a named tuple the keys are used as ticklabels. 
 
 # Keyword arguments
 - $(_document_argument(:bar_position))
@@ -37,6 +38,7 @@ Make a bar plot of `y` vs `x`.
 ```julia-repl
 julia> bar([1,2,3],[4,5,6],fillcolor=[:red,:green,:blue],fillalpha=[0.2,0.4,0.6])
 julia> bar([(1,4),(2,5),(3,6)])
+julia> bar((A=5, B=8, C=3, D=5, E=8, F=10, G=3))
 ```
 """
 @shorthands bar

--- a/RecipesPipeline/src/series.jl
+++ b/RecipesPipeline/src/series.jl
@@ -10,6 +10,7 @@ _prepare_series_data(::Nothing) = nothing
 _prepare_series_data(t::Tuple{T,T}) where {T<:Number} = t
 _prepare_series_data(f::Function) = f
 _prepare_series_data(ar::AbstractRange{<:Number}) = ar
+_prepare_series_data(nt::NamedTuple) = nt
 function _prepare_series_data(a::AbstractArray{T}) where {T<:MaybeNumber}
     # Get a non-missing AbstractFloat type for the array
     # There may be a better way to do this?
@@ -67,6 +68,7 @@ _compute_x(x::Nothing, y::Nothing, z) = axes(z, 1)
 _compute_x(x::Nothing, y, z) = axes(y, 1)
 _compute_x(x::Function, y, z) = map(x, y)
 _compute_x(x, y, z) = x
+_compute_x(x::Nothing, y::NamedTuple, z) = length(y) 
 
 _compute_y(x::Nothing, y::Nothing, z) = axes(z, 2)
 _compute_y(x, y::Function, z) = map(y, x)

--- a/RecipesPipeline/src/user_recipe.jl
+++ b/RecipesPipeline/src/user_recipe.jl
@@ -301,6 +301,7 @@ end
 @recipe f(v::AVec{<:Tuple}) = unzip(v)
 @recipe f(tup::Tuple) = [tup]
 
+
 # list of NamedTuples
 @recipe function f(ntv::AVec{<:NamedTuple{K,Tuple{S,T}}}) where {K,S,T}  # COV_EXCL_LINE
     xguide --> string(K[1])


### PR DESCRIPTION
## Description
new feature: now you can use named tuples to create bar plots. 

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
