### PR TITLE
GR: Fix zscale support in surface plots

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -1370,7 +1370,7 @@ gr_set_window(sp, vp) =
             if (yscale = sp[:yaxis][:scale]) ∈ _logScales
                 scaleop |= gr_y_log_scales[yscale]
             end
-            if needs_3d && (zscale = sp[:zaxis][:scale] ∈ _logScales)
+            if needs_3d && ((zscale = sp[:zaxis][:scale]) ∈ _logScales)
                 scaleop |= gr_z_log_scales[zscale]
             end
             sp[:xaxis][:flip] && (scaleop |= GR.OPTION_FLIP_X)


### PR DESCRIPTION
## Description

Previously, `zscale` was being set to a Bool value (the result of the set membership check). This caused a crash when querying the `gr_z_log_scales` tuple on the next line, because that array is indexed by symbols like :log10.

Given that the lines above assign the actual symbols to `xscale` and `yscale`, it seems likely that `zscale` should behave the same.

Fixes: https://github.com/JuliaPlots/Plots.jl/issues/5062

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
