### PR TITLE
add macros that turn unit from cm/mm/in to px

### DIFF
--- a/PlotsBase/src/Commons/Commons.jl
+++ b/PlotsBase/src/Commons/Commons.jl
@@ -44,6 +44,7 @@ export width, height, leftpad, toppad, bottompad, rightpad
 export origin, left, right, bottom, top, bbox, bbox!
 export DEFAULT_BBOX, DEFAULT_MINPAD, DEFAULT_LINEWIDTH
 export MM_PER_PX, MM_PER_INCH, DPI, PX_PER_INCH
+export @cm, @mm, @in
 
 export GridLayout, EmptyLayout, RootLayout
 export BBox, BoundingBox, mm, cm, inch, pt, w, h

--- a/PlotsBase/src/Commons/measures.jl
+++ b/PlotsBase/src/Commons/measures.jl
@@ -67,6 +67,63 @@ Base.:*(m1::Length{:pct}, m2::AbsoluteLength) = AbsoluteLength(m2.value * m1.val
 Base.:/(m1::AbsoluteLength, m2::Length{:pct}) = AbsoluteLength(m1.value / m2.value)
 Base.:/(m1::Length{:pct}, m2::AbsoluteLength) = AbsoluteLength(m2.value / m1.value)
 
+"""
+Define size in cm.
+
+Example:
+
+```
+plot(X, Y; size = @cm(10, 7))
+```
+"""
+macro cm(x, y)
+    return quote
+        if ($x isa Real) && ($y isa Real)
+            ($x, $y) ./ (MM_PER_PX / 10)
+        else
+            error("macro @cm is not defined for this datatype")
+        end
+    end
+end
+
+"""
+Define size in mm.
+
+Example:
+
+```
+plot(X, Y; size = @mm(100, 70))
+```
+"""
+macro mm(x, y)
+    return quote
+        if ($x isa Real) && ($y isa Real)
+            ($x, $y) ./ MM_PER_PX
+        else
+            error("macro @mm is not defined for this datatype")
+        end
+    end
+end
+
+"""
+Define size in inch.
+
+Example:
+
+```
+plot(X, Y; size = @in(10, 7))
+```
+"""
+macro in(x, y)
+    return quote
+        if ($x isa Real) && ($y isa Real)
+            ($x, $y) .* PX_PER_INCH
+        else
+            error("macro @in is not defined for this datatype")
+        end
+    end
+end
+
 inch2px(inches::Real) = float(inches * PX_PER_INCH)
 px2inch(px::Real)     = float(px / PX_PER_INCH)
 inch2mm(inches::Real) = float(inches * MM_PER_INCH)

--- a/PlotsBase/src/PlotsBase.jl
+++ b/PlotsBase/src/PlotsBase.jl
@@ -74,6 +74,10 @@ export
     plotarea,
     KW,
 
+    @cm,
+    @mm,
+    @in,
+
     theme,
     protect,
     plot,

--- a/PlotsBase/test/test_utils.jl
+++ b/PlotsBase/test/test_utils.jl
@@ -49,6 +49,10 @@
     @test PlotsBase.nansplit([1, 2, NaN, 3, 4]) == [[1.0, 2.0], [3.0, 4.0]]
     @test PlotsBase.nanvcat([1, NaN]) |> length == 4
 
+    @test PlotsBase.Commons.@in(1,1) isa AbstractFloat
+    @test PlotsBase.Commons.@cm(1,1) isa AbstractFloat
+    @test PlotsBase.Commons.@mm(1,1) isa AbstractFloat
+
     @test PlotsBase.Commons.inch2px(1) isa AbstractFloat
     @test PlotsBase.Commons.px2inch(1) isa AbstractFloat
     @test PlotsBase.Commons.inch2mm(1) isa AbstractFloat


### PR DESCRIPTION
## Description
It can be useful to be able to define the size of plots in other units.
Therefor these macros convert the tuple of size in px before the size tuple is evaluated by the function.

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
It shouldn't affect anything since the macros are executed before the tuple is transferred to the plot function.
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?

## Considerations
I have seen that other values like left_margin are implemented by the Measure package.
To apply this method to the plot size the changes would have more impact, because the pixels unit needs to be recalculated for the selected DPI value after receipt.
