### PR TITLE
Fix plot append!

### DIFF
--- a/PlotsBase/src/Plots.jl
+++ b/PlotsBase/src/Plots.jl
@@ -86,6 +86,8 @@ Base.iterate(plt::Plot) = iterate(plt.subplots)
 
 Base.push!(plt::Plot, args::Real...) = push!(plt, 1, args...)
 Base.push!(plt::Plot, i::Integer, args::Real...) = push!(plt.series_list[i], args...)
+Base.append!(plt::Plot, args::Real...) = append!(plt, 1, args...)
+Base.append!(plt::Plot, i::Integer, args::Real...) = append!(plt.series_list[i], args...)
 Base.append!(plt::Plot, args::AbstractVector...) = append!(plt, 1, args...)
 Base.append!(plt::Plot, i::Integer, args::AbstractVector...) = append!(plt.series_list[i], args...)
 


### PR DESCRIPTION
Fixes #4825

## Description
Allow appending vectors of data to plot, using a syntax consistent with `push!`.