### PR TITLE
interpolate scratch_dir to avoid precompilation failure in 1.12

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -125,7 +125,7 @@ include(_path(backend_name()))
                 $func() = begin  # evaluate each example in a local scope
                     $(_examples[i].exprs)
                     $i == 1 || return  # only for one example
-                    fn = tempname(scratch_dir)
+                    fn = tempname($scratch_dir)
                     pl = current()
                     show(devnull, pl)
                     showable(MIME"image/png"(), pl) && savefig(pl, "$fn.png")

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,4 +1,4 @@
-using Scratch
+using Scratch: @get_scratch!
 using REPL
 import Base64
 
@@ -114,7 +114,7 @@ include(_path(backend_name()))
     n = length(_examples)
     imports = sizehint!(Expr[], n)
     examples = sizehint!(Expr[], 10n)
-    _scratch_dir = mktempdir()
+    scratch_dir = mktempdir()
     for i in setdiff(1:n, _backend_skips[backend_name()], _animation_examples)
         _examples[i].external && continue
         (imp = _examples[i].imports) === nothing || push!(imports, imp)
@@ -125,7 +125,7 @@ include(_path(backend_name()))
                 $func() = begin  # evaluate each example in a local scope
                     $(_examples[i].exprs)
                     $i == 1 || return  # only for one example
-                    fn = tempname($_scratch_dir)
+                    fn = tempname($scratch_dir)
                     pl = current()
                     show(devnull, pl)
                     showable(MIME"image/png"(), pl) && savefig(pl, "$fn.png")

--- a/src/init.jl
+++ b/src/init.jl
@@ -114,7 +114,7 @@ include(_path(backend_name()))
     n = length(_examples)
     imports = sizehint!(Expr[], n)
     examples = sizehint!(Expr[], 10n)
-    scratch_dir = mktempdir()
+    _scratch_dir = mktempdir()
     for i in setdiff(1:n, _backend_skips[backend_name()], _animation_examples)
         _examples[i].external && continue
         (imp = _examples[i].imports) === nothing || push!(imports, imp)
@@ -125,7 +125,7 @@ include(_path(backend_name()))
                 $func() = begin  # evaluate each example in a local scope
                     $(_examples[i].exprs)
                     $i == 1 || return  # only for one example
-                    fn = tempname($scratch_dir)
+                    fn = tempname($_scratch_dir)
                     pl = current()
                     show(devnull, pl)
                     showable(MIME"image/png"(), pl) && savefig(pl, "$fn.png")


### PR DESCRIPTION
## Description

Interpolating the `scratch_dir` variable in the precompilation directive solves the precompilation failure observed in v1.12-beta1. 

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
