### PR TITLE
Fix precompilation in Julia 1.12

### DIFF
--- a/PlotsBase/src/init.jl
+++ b/PlotsBase/src/init.jl
@@ -1,4 +1,4 @@
-using Scratch
+using Scratch: @get_scratch!
 using REPL
 
 const _plotly_local_file_path = Ref{Union{Nothing,String}}(nothing)
@@ -147,7 +147,7 @@ macro precompile_backend(backend_package)
                             @debug $i
                             $(PlotsBase._examples[i].exprs)
                             $i == 1 || return  # trigger display only for one example
-                            fn = tempname(scratch_dir)
+                            fn = tempname($scratch_dir)
                             pl = current()
                             show(devnull, pl)
                             if backend_name() ≡ :plotlyjs


### PR DESCRIPTION
See: https://github.com/JuliaPlots/Plots.jl/pull/5072

## Description

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
