### PR TITLE
UnitfulExt: Check if PGFPlotsX is available, then check if it's the current backend

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -797,6 +797,12 @@
         {
             "name": "Finn Eisenach",
             "type": "Other"
+        },
+        {
+            "affiliation": "Purdue University",
+            "name": "Isaac Wheeler",
+            "orcid": "0000-0002-9717-073X",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/PlotsBase/ext/UnitfulExt.jl
+++ b/PlotsBase/ext/UnitfulExt.jl
@@ -228,13 +228,12 @@ Append unit to labels when appropriate
 =====================================#
 
 append_unit_if_needed!(attr, key, u) =
-    append_unit_if_needed!(attr, key, get(attr, key, nothing), u)
+            append_unit_if_needed!(attr, key, get(attr, key, nothing), u)
 # dispatch on the type of `label`
 append_unit_if_needed!(attr, key, label::ProtectedString, u) = nothing
 append_unit_if_needed!(attr, key, label::UnitfulString, u) = nothing
 function append_unit_if_needed!(attr, key, label::Nothing, u)
-    attr[key] = if (haskey(PlotsBase._backendType, :pgfplotsx) && 
-        attr[:plot_object].backend == PlotsBase.backend_instance(:pgfplotsx))
+    attr[key] = if PlotsBase.backend_name() ≡ :pgfplotsx
         UnitfulString(LaTeXString(Latexify.latexify(u)), u)
     else
         UnitfulString(string(u), u)
@@ -242,8 +241,7 @@ function append_unit_if_needed!(attr, key, label::Nothing, u)
 end
 function append_unit_if_needed!(attr, key, label::S, u) where {S<:AbstractString}
     isempty(label) && return attr[key] = UnitfulString(label, u)
-    attr[key] = if (haskey(PlotsBase._backendType, :pgfplotsx) && 
-        attr[:plot_object].backend == PlotsBase.backend_instance(:pgfplotsx))
+    attr[key] = if PlotsBase.backend_name() ≡ :pgfplotsx
         UnitfulString(
             LaTeXString(
                 format_unit_label(

--- a/PlotsBase/ext/UnitfulExt.jl
+++ b/PlotsBase/ext/UnitfulExt.jl
@@ -233,7 +233,8 @@ append_unit_if_needed!(attr, key, u) =
 append_unit_if_needed!(attr, key, label::ProtectedString, u) = nothing
 append_unit_if_needed!(attr, key, label::UnitfulString, u) = nothing
 function append_unit_if_needed!(attr, key, label::Nothing, u)
-    attr[key] = if attr[:plot_object].backend == PlotsBase.backend_instance(:pgfplotsx)
+    attr[key] = if (haskey(PlotsBase._backendType, :pgfplotsx) && 
+        attr[:plot_object].backend == PlotsBase.backend_instance(:pgfplotsx))
         UnitfulString(LaTeXString(Latexify.latexify(u)), u)
     else
         UnitfulString(string(u), u)
@@ -241,7 +242,8 @@ function append_unit_if_needed!(attr, key, label::Nothing, u)
 end
 function append_unit_if_needed!(attr, key, label::S, u) where {S<:AbstractString}
     isempty(label) && return attr[key] = UnitfulString(label, u)
-    attr[key] = if attr[:plot_object].backend == PlotsBase.backend_instance(:pgfplotsx)
+    attr[key] = if (haskey(PlotsBase._backendType, :pgfplotsx) && 
+        attr[:plot_object].backend == PlotsBase.backend_instance(:pgfplotsx))
         UnitfulString(
             LaTeXString(
                 format_unit_label(

--- a/PlotsBase/ext/UnitfulExt.jl
+++ b/PlotsBase/ext/UnitfulExt.jl
@@ -228,7 +228,7 @@ Append unit to labels when appropriate
 =====================================#
 
 append_unit_if_needed!(attr, key, u) =
-            append_unit_if_needed!(attr, key, get(attr, key, nothing), u)
+    append_unit_if_needed!(attr, key, get(attr, key, nothing), u)
 # dispatch on the type of `label`
 append_unit_if_needed!(attr, key, label::ProtectedString, u) = nothing
 append_unit_if_needed!(attr, key, label::UnitfulString, u) = nothing


### PR DESCRIPTION
## Description

Fix part of #5093.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)
(as of now)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
