### PR TITLE
Add `unit` axis attribute, for Plots v1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -779,6 +779,12 @@
         {
             "name": "Patrick Jaap",
             "type": "Other"
+        },
+        {
+            "affiliation": "Purdue University",
+            "name": "Isaac Wheeler",
+            "orcid": "0000-0002-9717-073X",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/args.jl
+++ b/src/args.jl
@@ -519,6 +519,7 @@ const _axis_defaults = KW(
     :showaxis                    => true,
     :widen                       => :auto,
     :draw_arrow                  => false,
+    :unit                        => nothing,
     :unitformat                  => :round,
 )
 

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -114,7 +114,7 @@ _series_updated(plt::Plot, series::Series) = nothing
 _before_layout_calcs(plt::Plot) = nothing
 
 title_padding(sp::Subplot) = sp[:title] == "" ? 0mm : sp[:titlefontsize] * pt
-guide_padding(axis::Axis) = axis[:guide] == "" ? 0mm : axis[:guidefontsize] * pt
+guide_padding(axis::Axis) = Plots.get_guide(axis) == "" ? 0mm : axis[:guidefontsize] * pt
 
 closeall(::AbstractBackend) = nothing
 

--- a/src/backends/deprecated/pgfplots.jl
+++ b/src/backends/deprecated/pgfplots.jl
@@ -339,7 +339,7 @@ function pgf_axis(sp::Subplot, letter)
     framestyle = pgf_framestyle(sp[:framestyle])
 
     # axis guide
-    kw[get_attr_symbol(letter, :label)] = axis[:guide]
+    kw[get_attr_symbol(letter, :label)] = Plots.get_guide(axis)
 
     # axis label position
     labelpos = ""

--- a/src/backends/deprecated/pyplot.jl
+++ b/src/backends/deprecated/pyplot.jl
@@ -1211,7 +1211,7 @@ function _before_layout_calcs(plt::Plot{PyPlotBackend})
                          5py_thickness_scale(plt, intensity),
             )
 
-            getproperty(ax, Symbol("set_", letter, "label"))(axis[:guide])
+            getproperty(ax, Symbol("set_", letter, "label"))(Plots.get_guide(axis))
             if get(axis.plotattributes, :flip, false)
                 getproperty(ax, Symbol("invert_", letter, "axis"))()
             end

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -765,7 +765,7 @@ function gr_axis_height(sp, axis)
         ticks in (nothing, false, :none) ? 0 :
         last(gr_get_ticks_size(ticks, axis[:rotation]))
     )
-    if (guide = axis[:guide]) != ""
+    if (guide = Plots.get_guide(axis)) != ""
         gr_set_font(guidefont(axis), sp)
         h += last(gr_text_size(guide))
     end
@@ -781,7 +781,7 @@ function gr_axis_width(sp, axis)
         ticks in (nothing, false, :none) ? 0 :
         first(gr_get_ticks_size(ticks, axis[:rotation]))
     )
-    if (guide = axis[:guide]) != ""
+    if (guide = Plots.get_guide(axis)) != ""
         gr_set_font(guidefont(axis), sp)
         w += last(gr_text_size(guide))
     end
@@ -846,7 +846,7 @@ function _update_min_padding!(sp::Subplot{GRBackend})
         # Add margin for x or y label
         m = 0mm
         for ax in (xaxis, yaxis)
-            (guide = ax[:guide] == "") && continue
+            (guide = Plots.get_guide(ax) == "") && continue
             gr_set_font(guidefont(ax), sp)
             l = last(gr_text_size(guide))
             m = max(m, 1mm + height * l * px)
@@ -856,7 +856,7 @@ function _update_min_padding!(sp::Subplot{GRBackend})
             padding[mirrored(xaxis, :top) ? :top : :bottom][] += m
         end
         # Add margin for z label
-        if (guide = zaxis[:guide]) != ""
+        if (guide = Plots.get_guide(zaxis)) != ""
             gr_set_font(guidefont(zaxis), sp)
             l = last(gr_text_size(guide))
             padding[mirrored(zaxis, :right) ? :right : :left][] += 1mm + height * l * px  # NOTE:  why `height` here ?
@@ -872,7 +872,7 @@ function _update_min_padding!(sp::Subplot{GRBackend})
                 l = 0.01 + (isy ? first(ts) : last(ts))
                 padding[ax[:mirror] ? a : b][] += 1mm + sp_size[isy ? 1 : 2] * l * px
             end
-            if (guide = ax[:guide]) != ""
+            if (guide = Plots.get_guide(ax)) != ""
                 gr_set_font(guidefont(ax), sp)
                 l = last(gr_text_size(guide))
                 padding[mirrored(ax, a) ? a : b][] += 1mm + height * l * px  # NOTE: using `height` is arbitrary
@@ -1645,8 +1645,9 @@ function gr_label_ticks_3d(sp, letter, ticks)
     end
 end
 
-gr_label_axis(sp, letter, vp) =
-    if (ax = sp[get_attr_symbol(letter, :axis)])[:guide] != ""
+function gr_label_axis(sp, letter, vp)
+    ax = sp[get_attr_symbol(letter, :axis)]
+    if Plots.get_guide(ax) != ""
         mirror = ax[:mirror]
         GR.savestate()
         guide_position = ax[:guide_position]
@@ -1673,12 +1674,14 @@ gr_label_axis(sp, letter, vp) =
                 end
         end
         gr_set_font(guidefont(ax), sp; rotation, halign, valign)
-        gr_text(xpos, ypos, ax[:guide])
+        gr_text(xpos, ypos, Plots.get_guide(ax))
         GR.restorestate()
     end
+end
 
-gr_label_axis_3d(sp, letter) =
-    if (ax = sp[get_attr_symbol(letter, :axis)])[:guide] != ""
+function gr_label_axis_3d(sp, letter)
+    ax = sp[get_attr_symbol(letter, :axis)]
+    if Plots.get_guide(ax) != ""
         letters = axes_letters(sp, letter)
         (amin, amax), (namin, namax), (famin, famax) = map(l -> axis_limits(sp, l), letters)
         n0, n1 = letter === :y ? (namax, namin) : (namin, namax)
@@ -1706,9 +1709,10 @@ gr_label_axis_3d(sp, letter) =
         end
         letter === :z && GR.setcharup(-1, 0)
         sgn = ax[:mirror] ? -1 : 1
-        gr_text(x + sgn * x_offset, y + sgn * y_offset, ax[:guide])
+        gr_text(x + sgn * x_offset, y + sgn * y_offset, Plots.get_guide(ax))
         GR.restorestate()
     end
+end
 
 gr_add_title(sp, vp_plt, vp_sp) =
     if (title = sp[:title]) != ""

--- a/src/backends/inspectdr.jl
+++ b/src/backends/inspectdr.jl
@@ -375,8 +375,8 @@ function _inspectdr_setupsubplot(sp::Subplot{InspectDRBackend})
 
     a = plot.annotation
     a.title = texmath2unicode(sp[:title])
-    a.xlabel = texmath2unicode(xaxis[:guide])
-    a.ylabels = [texmath2unicode(yaxis[:guide])]
+    a.xlabel = Plots.get_guide(texmath2unicode(xaxis))
+    a.ylabels = [texmath2unicode(Plots.getguide(yaxis))]
 
     #Modify base layout of new object:
     l = plot.layout.defaults = deepcopy(InspectDR.defaults.plotlayout)

--- a/src/backends/pgfplotsx.jl
+++ b/src/backends/pgfplotsx.jl
@@ -1158,7 +1158,7 @@ function pgfx_axis!(opt::Options, sp::Subplot, letter)
     push!(
         opt,
         "scaled $(letter) ticks" => "false",
-        "$(letter)label" => axis[:guide],
+        "$(letter)label" => Plots.get_guide(axis),
         "$(letter) tick style" =>
             Options("color" => color(tick_color), "opacity" => alpha(tick_color)),
         "$(letter) tick label style" => Options(

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -122,7 +122,7 @@ function plotly_axis(axis, sp, anchor = nothing, domain = nothing)
     framestyle = sp[:framestyle]
     ax = KW(
         :visible => framestyle !== :none,
-        :title => axis[:guide],
+        :title => Plots.get_guide(axis),
         :showgrid => axis[:grid],
         :gridcolor =>
             rgba_string(plot_color(axis[:foreground_color_grid], axis[:gridalpha])),

--- a/src/backends/pythonplot.jl
+++ b/src/backends/pythonplot.jl
@@ -1118,7 +1118,7 @@ function _before_layout_calcs(plt::Plot{PythonPlotBackend})
                 pyaxis.set_major_locator(mpl.ticker.NullLocator())
             end
 
-            getproperty(ax, set_axis(letter, :label))(axis[:guide])
+            getproperty(ax, set_axis(letter, :label))(Plots.get_guide(axis))
             pyaxis.label.set_fontsize(_py_thickness_scale(plt, axis[:guidefontsize]))
             pyaxis.label.set_family(axis[:guidefontfamily])
             pyaxis.label.set_math_fontfamily(

--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -97,8 +97,8 @@ function _before_layout_calcs(plt::Plot{UnicodePlotsBackend})
         kw = (
             compact = true,
             title = texmath2unicode(sp[:title]),
-            xlabel = texmath2unicode(xaxis[:guide]),
-            ylabel = texmath2unicode(yaxis[:guide]),
+            xlabel = texmath2unicode(Plots.get_guide(xaxis)),
+            ylabel = texmath2unicode(Plots.get_guide(yaxis)),
             labels = !plot_3d,  # guide labels and limits do not make sense in 3d
             xscale = xaxis[:scale],
             yscale = yaxis[:scale],

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -569,6 +569,8 @@ function link_axes!(axes::Axis...)
     a1 = axes[1]
     for i in 2:length(axes)
         a2 = axes[i]
+        a1[:unit] ≡ a2[:unit] || 
+            error( "Cannot link axes with different units: $(a1[:unit]) and $(a2[:unit])",)
         expand_extrema!(a1, ignorenan_extrema(a2))
         for k in (:extrema, :discrete_values, :continuous_values, :discrete_map)
             a2[k] = a1[k]
@@ -662,6 +664,8 @@ function twin(sp, letter)
     tax[:grid] = false
     tax[:showaxis] = false
     tax[:ticks] = :none
+    tax[:unitformat] = :none
+    tax[:unit] = orig_sp[get_attr_symbol(letter, :axis)][:unit]
     oax[:grid] = false
     oax[:mirror] = true
     twin_sp[:background_color_inside] = RGBA{Float64}(0, 0, 0, 0)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1250,8 +1250,23 @@ macro ext_imp_use(imp_use::QuoteNode, mod::Symbol, args...)
     Expr(imp_use.value, ex) |> esc
 end
 
-# for UnitfulExt - cannot reside in `UnitfulExt` (macro)
-function protectedstring end  # COV_EXCL_LINE
+# for UnitfulExt 
+abstract type AbstractProtectedString <: AbstractString end
+struct ProtectedString{S} <: AbstractProtectedString
+    content::S
+end
+const APS = AbstractProtectedString
+# Minimum required AbstractString interface to work with PlotsBase
+Base.iterate(n::APS) = iterate(n.content)
+Base.iterate(n::APS, i::Integer) = iterate(n.content, i)
+Base.codeunit(n::APS) = codeunit(n.content)
+Base.ncodeunits(n::APS) = ncodeunits(n.content)
+Base.isvalid(n::APS, i::Integer) = isvalid(n.content, i)
+Base.pointer(n::APS) = pointer(n.content)
+Base.pointer(n::APS, i::Integer) = pointer(n.content, i)
+protectedstring(s) = ProtectedString(s)
+
+
 
 """
     P_str(s)

--- a/test/test_axes.jl
+++ b/test/test_axes.jl
@@ -153,7 +153,7 @@ end
     @test haskey(Plots._keyAliases, :x_guide_position)
     @test !haskey(Plots._keyAliases, :xguide_position)
     pl = plot(1:2, xl = "x label")
-    @test pl[1][:xaxis][:guide] === "x label"
+    @test Plots.get_guide(pl[1][:xaxis]) === "x label"
     pl = plot(1:2, xrange = (0, 3))
     @test xlims(pl) === (0, 3)
     pl = plot(1:2, xtick = [1.25, 1.5, 1.75])

--- a/test/test_shorthands.jl
+++ b/test/test_shorthands.jl
@@ -33,11 +33,11 @@ end
     sp = pl[1]
     @test sp[:title] == "Foo"
     xlabel!(pl, "xlabel")
-    @test sp[:xaxis][:guide] == "xlabel"
+    @test Plots.get_guide(sp[:xaxis]) == "xlabel"
     ylabel!(pl, "ylabel")
-    @test sp[:yaxis][:guide] == "ylabel"
+    @test Plots.get_guide(sp[:yaxis]) == "ylabel"
     zlabel!(pl, "zlabel")
-    @test sp[:zaxis][:guide] == "zlabel"
+    @test Plots.get_guide(sp[:zaxis]) == "zlabel"
 end
 
 @testset "Misc" begin

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -2,9 +2,9 @@ using Plots, Test
 using Unitful
 using Unitful: m, cm, s, DimensionError
 # Some helper functions to access the subplot labels and the series inside each test plot
-xguide(pl, idx = length(pl.subplots)) = pl.subplots[idx].attr[:xaxis].plotattributes[:guide]
-yguide(pl, idx = length(pl.subplots)) = pl.subplots[idx].attr[:yaxis].plotattributes[:guide]
-zguide(pl, idx = length(pl.subplots)) = pl.subplots[idx].attr[:zaxis].plotattributes[:guide]
+xguide(pl, idx = length(pl.subplots)) = Plots.get_guide(pl.subplots[idx].attr[:xaxis])
+yguide(pl, idx = length(pl.subplots)) = Plots.get_guide(pl.subplots[idx].attr[:yaxis])
+zguide(pl, idx = length(pl.subplots)) = Plots.get_guide(pl.subplots[idx].attr[:zaxis])
 xseries(pl, idx = length(pl.series_list)) = pl.series_list[idx].plotattributes[:x]
 yseries(pl, idx = length(pl.series_list)) = pl.series_list[idx].plotattributes[:y]
 zseries(pl, idx = length(pl.series_list)) = pl.series_list[idx].plotattributes[:z]


### PR DESCRIPTION
## Description

Essentially identical to #5095 , but made against the `master` branch so that I'm not waiting for Plots v2--folder structures are different enough that it made sense to open as a separate PR.

@gustaphe and I discussed some in #5095; it would be helpful to get feedback from @t-bltg or @BeastyBlacksmith or someone else who is not as focused on Unitful usage.

A lot of the noise in the diff is a result of switching to `Plots.get_guide(axis)` instead of `axis[:guide]`, because that new function allows us to more elegantly handle differing unit formats in the guide strings; in any case where the axis has no units, the result of `get_guide(axis)` is `axis[:guide]` so not a big change in behavior.

Other changes involve moving some of the machinery out of the UnitfulExt so that it is accessible within Plots for axis handling.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
