### PR TITLE
Add specialised type handling for vector of vectors

### DIFF
--- a/RecipesPipeline/src/type_recipe.jl
+++ b/RecipesPipeline/src/type_recipe.jl
@@ -54,6 +54,45 @@ function _apply_type_recipe(plotattributes, v::AbstractArray, letter)
     w
 end
 
+# Specialisation to apply type recipes on a vector of vectors. The type recipe can either 
+# apply to the vector of elements or the elements themselves
+function _apply_type_recipe(plotattributes, v::AVec{<:AVec}, letter)
+    plt = plotattributes[:plot_object]
+    preprocess_axis_args!(plt, plotattributes, letter)
+    # First we attempt the array type recipe and if any of the vector elements applies,
+    # we will stop there. Note we use the same type equivalency test as for a general array 
+    # to check if changes applied
+    did_replace = false
+    w = map(v) do u
+        newu = RecipesBase.apply_recipe(plotattributes, typeof(u), u)[1].args[1]
+        warn_on_recipe_aliases!(plt, plotattributes, :type, u)
+        did_replace |= typeof(u) !== typeof(newu)
+        newu
+    end
+
+    # if nothing changed, then we attempt it at a piecewise level
+    if !did_replace
+        if (smv = skipmissing(Base.Iterators.flatten(v))) |> isempty
+            postprocess_axis_args!(plt, plotattributes, letter)
+            # We'll just leave it untampered with if there are no elements
+            return v
+        end
+        x = first(smv)
+        args = RecipesBase.apply_recipe(plotattributes, typeof(x), x)[1].args
+        warn_on_recipe_aliases!(plt, plotattributes, :type, x)
+        postprocess_axis_args!(plt, plotattributes, letter)
+        return if length(args) == 2 && all(arg -> arg isa Function, args)
+            numfunc, formatter = args
+            Formatted(map(u -> map(numfunc, u), v), formatter)
+        else
+            v
+        end
+    end
+
+    postprocess_axis_args!(plt, plotattributes, letter)
+    w
+end
+
 # special handling for Surface... need to properly unwrap and re-wrap
 _apply_type_recipe(
     plotattributes,

--- a/RecipesPipeline/src/type_recipe.jl
+++ b/RecipesPipeline/src/type_recipe.jl
@@ -59,7 +59,15 @@ end
 function _apply_type_recipe(plotattributes, v::AVec{<:AVec}, letter)
     plt = plotattributes[:plot_object]
     preprocess_axis_args!(plt, plotattributes, letter)
-    # First we attempt the array type recipe and if any of the vector elements applies,
+    # First we try a vector of vectors recipe and see if that exists. if so, just stop there.
+    w = RecipesBase.apply_recipe(plotattributes, typeof(v), v)[1].args[1]
+    if typeof(v) != typeof(w)
+        warn_on_recipe_aliases!(plt, plotattributes, :type, v)
+        postprocess_axis_args!(plt, plotattributes, letter)
+        return w
+    end
+
+    # Second we attempt the array type recipe and if any of the vector elements applies,
     # we will stop there. Note we use the same type equivalency test as for a general array 
     # to check if changes applied
     did_replace = false

--- a/RecipesPipeline/test/runtests.jl
+++ b/RecipesPipeline/test/runtests.jl
@@ -3,7 +3,9 @@ using BenchmarkTools
 using StableRNGs
 using Test
 
-import RecipesPipeline: _prepare_series_data
+import Dates
+import RecipesPipeline: _prepare_series_data, _apply_type_recipe
+
 import RecipesBase
 
 @testset "DefaultsDict" begin
@@ -80,6 +82,22 @@ end
     @test RecipesPipeline.epochdays2epochms(1) == 86_400_000
 
     @test RecipesBase.is_key_supported("key")
+end
+
+@testset "_apply_type_recipe" begin
+    plt = nothing
+    plotattributes = Dict{Symbol,Any}(:plot_object => plt)
+    @test _apply_type_recipe(plotattributes, [1, 2, 3], :x) == [1, 2, 3]
+    @test _apply_type_recipe(plotattributes, [[1, 2], [3, 4]], :x) == [[1, 2], [3, 4]]
+    res = _apply_type_recipe(plotattributes, [Dates.Date(2001)], :x)
+    @test typeof(res) <: Formatted
+    @test res.data == [Dates.value(Dates.Date(2001))]
+    @test res.formatter(Dates.value(Dates.Date(2001))) == "2001-01-01"
+
+    res = _apply_type_recipe(plotattributes, [[Dates.Date(2001)]], :x)
+    @test typeof(res) <: Formatted
+    @test res.data == [[Dates.value(Dates.Date(2001))]]
+    @test res.formatter(Dates.value(Dates.Date(2001))) == "2001-01-01"
 end
 
 @testset "_prepare_series_data" begin


### PR DESCRIPTION
## Description

Just getting myself familiar with the `Plots.jl` library and so thought I would try and fix some of the outstanding bugs to help me with that. 

This looks to fix https://github.com/JuliaPlots/Plots.jl/issues/4777 by introducing a specialisation for vector of vectors, applying recipes in a similar fashion to the `AbstractArray` handling.

Added unit testing to verify behaviour within the bug works. Have also tested manually that consistent behaviour applies for array type recipes (https://docs.juliaplots.org/stable/gallery/gr/generated/gr-ref045/).