### PR TITLE
temporarily disable broken example

### DIFF
--- a/PlotsBase/test/runtests.jl
+++ b/PlotsBase/test/runtests.jl
@@ -89,7 +89,9 @@ is_ci() || @eval using Gtk  # see JuliaPlots/VisualRegressionTests.jl/issues/30
 
 ref_name(i) = "ref" * lpad(i, 3, '0')
 
-const broken_examples = [62]
+const broken_examples = Int[]
+Sys.isapple() && push!(broken_examples, 50)  # FIXME: https://github.com/jheinen/GR.jl/issues/550
+push!(broken_examples, 62)  # TODO: remove when new GR release is out and lands through CI (compat issues)
 
 # skip the majority of tests if we only want to update reference images or under `PkgEval` (timeout limit)
 names = if is_auto()

--- a/PlotsBase/test/runtests.jl
+++ b/PlotsBase/test/runtests.jl
@@ -89,11 +89,7 @@ is_ci() || @eval using Gtk  # see JuliaPlots/VisualRegressionTests.jl/issues/30
 
 ref_name(i) = "ref" * lpad(i, 3, '0')
 
-const broken_examples = if Sys.isapple()
-    [50] # FIXME: https://github.com/jheinen/GR.jl/issues/550
-else
-    []
-end
+const broken_examples = [62]
 
 # skip the majority of tests if we only want to update reference images or under `PkgEval` (timeout limit)
 names = if is_auto()


### PR DESCRIPTION
## Description

Creates CI incompatiblities between old and new GR releases.
After https://github.com/JuliaPlots/PlotReferenceImages.jl/pull/154.
Restore it later.