### PR TITLE
Add specialised type handling for vector of vectors

### DIFF
--- a/RecipesPipeline/test/Project.toml
+++ b/RecipesPipeline/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RecipesPipeline = "01d81517-befc-4cb6-b9ec-a95719d0359c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"


### PR DESCRIPTION
## Description

Just getting myself familiar with the Plots.jl library and so thought I would try and fix some of the outstanding bugs to help me with that.

This looks to fix #4777 by introducing a specialisation for vector of vectors, applying recipes in a similar fashion to the AbstractArray handling. We also add a specific handling for type recipes built for `AVec{<:AVec{<:T}}` to maintain backwards compatibly with the current behaviour.

Added unit testing to verify behaviour within the bug works as well as supporting of custom type recipes. Have also tested manually that consistent behaviour applies for array type recipes (https://docs.juliaplots.org/stable/gallery/gr/generated/gr-ref045/) and vector of vector type recipes (https://github.com/JuliaPlots/Plots.jl/blob/v2/PlotsBase/ext/UnitfulExt.jl#L84)