### PR TITLE
skip annotations for plot title subplot

### DIFF
--- a/PlotsBase/src/Plots.jl
+++ b/PlotsBase/src/Plots.jl
@@ -247,6 +247,8 @@ function _update_subplot_attrs(
 
     # grab those args which apply to this subplot
     for k ∈ keys(_subplot_defaults)
+        # We don't apply annotations to the plot-title sub-plot
+        k != :annotations || get(plt.attr, :plot_titleindex, 0) != subplot_index || continue
         PlotsBase.slice_arg!(plotattributes_in, sp.attr, k, subplot_index, remove_pair)
     end
 

--- a/PlotsBase/test/test_components.jl
+++ b/PlotsBase/test/test_components.jl
@@ -187,6 +187,46 @@ end
             annotate!(pl, loc, string(loc))
         end
     end
+
+    let p = scatter([4], [4], plot_title = "x", xlims = (0, 10), ylims = (0, 10))
+        for sp ∈ p.subplots
+            @test sp[:annotations] == []
+        end
+        annotate!(4, 4, "4")
+
+        for (i, sp) ∈ enumerate(p.subplots)
+            if i == p.attr[:plot_titleindex]
+                @test sp[:annotations] == []
+            else
+                @test length(sp[:annotations]) == 1
+                @test sp[:annotations][1][1] == 4
+                @test sp[:annotations][1][2] == 4
+                @test sp[:annotations][1][3].str == "4"
+            end
+        end
+    end
+
+    let p = plot(
+            scatter([4], [4], xlims = (0, 10), ylims = (0, 10)),
+            scatter([4], [4], xlims = (0, 10), ylims = (0, 10)),
+            plot_title = "x",
+        )
+        for sp ∈ p.subplots
+            @test sp[:annotations] == []
+        end
+        annotate!(4, 4, "4")
+
+        for (i, sp) ∈ enumerate(p.subplots)
+            if i == p.attr[:plot_titleindex]
+                @test sp[:annotations] == []
+            else
+                @test length(sp[:annotations]) == 1
+                @test sp[:annotations][1][1] == 4
+                @test sp[:annotations][1][2] == 4
+                @test sp[:annotations][1][3].str == "4"
+            end
+        end
+    end
 end
 
 @testset "Fonts" begin


### PR DESCRIPTION
## Description

When applying annotations to a plot which has used `plot_title` the behaviour is inconsistent. Applying it as part of the initial plot will not apply the annotation to the title sub-plot but doing it separately will.

```
scatter([4], [4], plot_title = "x", xlims = (0, 10), ylims = (0, 10), annotation=(4,4,"4"))
```

versus

```
scatter([4], [4], plot_title = "x", xlims = (0, 10), ylims = (0, 10))
annotate!(4, 4, "4")
```

It seems sensible to never have annotations applied to the plot title sub-plot, so updating to ignore these property updates and get consistent behaviour. This fixes https://github.com/JuliaPlots/Plots.jl/issues/5096
