### PR TITLE
temporarily disable broken example

### DIFF
--- a/PlotsBase/test/runtests.jl
+++ b/PlotsBase/test/runtests.jl
@@ -48,6 +48,12 @@ using FileIO
 using Dates
 using Test
 
+const broken_examples = Int[]  # NOTE: unexpected pass is a failure
+Sys.isapple() && push!(broken_examples, 50)  # FIXME: https://github.com/jheinen/GR.jl/issues/550
+
+const skipped_examples = Int[]  # NOTE: won't error, regardless of the test output
+push!(skipped_examples, 62)  # TODO: remove when new GR release is out and lands through CI (compat issues)
+
 function available_channels()
     juliaup = "https://julialang-s3.julialang.org/juliaup"
     for i ∈ 1:6
@@ -88,10 +94,6 @@ is_ci() = Base.get_bool_env("CI", false)
 is_ci() || @eval using Gtk  # see JuliaPlots/VisualRegressionTests.jl/issues/30
 
 ref_name(i) = "ref" * lpad(i, 3, '0')
-
-const broken_examples = Int[]
-Sys.isapple() && push!(broken_examples, 50)  # FIXME: https://github.com/jheinen/GR.jl/issues/550
-push!(broken_examples, 62)  # TODO: remove when new GR release is out and lands through CI (compat issues)
 
 # skip the majority of tests if we only want to update reference images or under `PkgEval` (timeout limit)
 names = if is_auto()

--- a/PlotsBase/test/runtests.jl
+++ b/PlotsBase/test/runtests.jl
@@ -89,7 +89,9 @@ is_ci() || @eval using Gtk  # see JuliaPlots/VisualRegressionTests.jl/issues/30
 
 ref_name(i) = "ref" * lpad(i, 3, '0')
 
-const broken_examples = [62]
+const broken_examples = Int[]
+Sys.isapple() && push!(broken_examples, 50)  # FIXME: https://github.com/jheinen/GR.jl/issues/550
+push!(broken_examples, 62)  # TODO: remove when new GR release is out and lands through CI (compat issues)
 
 # skip the majority of tests if we only want to update reference images or under `PkgEval` (timeout limit)
 names = if is_auto()

--- a/PlotsBase/test/runtests.jl
+++ b/PlotsBase/test/runtests.jl
@@ -89,11 +89,7 @@ is_ci() || @eval using Gtk  # see JuliaPlots/VisualRegressionTests.jl/issues/30
 
 ref_name(i) = "ref" * lpad(i, 3, '0')
 
-const broken_examples = if Sys.isapple()
-    [50] # FIXME: https://github.com/jheinen/GR.jl/issues/550
-else
-    []
-end
+const broken_examples = [62]
 
 # skip the majority of tests if we only want to update reference images or under `PkgEval` (timeout limit)
 names = if is_auto()

--- a/PlotsBase/test/test_backends.jl
+++ b/PlotsBase/test/test_backends.jl
@@ -66,7 +66,7 @@ is_pkgeval() || @testset "Backends" begin
         @test filesize(fn) > 1_000
     end
     (Sys.islinux() && is_latest("release")) && for be ∈ TEST_BACKENDS
-        skip = vcat(PlotsBase._backend_skips[be], broken_examples)
+        skip = vcat(PlotsBase._backend_skips[be], skipped_examples, broken_examples)
         PlotsBase.test_examples(be; skip, callback, disp = is_ci(), strict = true)  # `ci` display for coverage
         closeall()
     end

--- a/PlotsBase/test/test_reference.jl
+++ b/PlotsBase/test/test_reference.jl
@@ -151,7 +151,7 @@ end
         image_comparison_facts(
             :gr,
             tol = PLOTSBASE_IMG_TOL,
-            skip = vcat(PlotsBase._backend_skips[:gr]),
+            skip = vcat(PlotsBase._backend_skips[:gr], skipped_examples),
             broken = broken_examples,
         )
     end


### PR DESCRIPTION
Creates CI incompatiblities between old and new GR releases.
After https://github.com/JuliaPlots/PlotReferenceImages.jl/pull/154.
Restore it later.