### PR TITLE
Generalise mesh3d within GR backend to support Integer types

### DIFF
--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -2147,14 +2147,14 @@ function gr_draw_surface(series, x, y, z, clims)
         GR.setfillcolorind(0)
         GR.surface(x, y, z, get(e_kwargs, :display_option, GR.OPTION_FILLED_MESH))
     elseif st ≡ :mesh3d
-        if series[:connections] isa AbstractVector{<:AbstractVector{Int}}
+        if series[:connections] isa AbstractVector{<:AbstractVector{<:Integer}}
             # Combination of any polygon types
             cns = map(cns -> [length(cns), cns...], series[:connections])
-        elseif series[:connections] isa AbstractVector{NTuple{N,Int}} where {N}
+        elseif series[:connections] isa AbstractVector{NTuple{N,<:Integer}} where {N}
             # Only N-gons - connections have to be 1-based (indexing)
             N = length(series[:connections][1])
             cns = map(cns -> [N, cns...], series[:connections])
-        elseif series[:connections] isa NTuple{3,<:AbstractVector{Int}}
+        elseif series[:connections] isa NTuple{3,<:AbstractVector{<:Integer}}
             # Only triangles - connections have to be 0-based (indexing)
             ci, cj, ck = series[:connections]
             if !(length(ci) == length(cj) == length(ck))

--- a/PlotsBase/test/test_misc.jl
+++ b/PlotsBase/test/test_misc.jl
@@ -306,6 +306,22 @@ with(:gr) do
             fillcolor = :blue,
             fillalpha = 0.2,
         )
+        # Validate still works when we iuse different int types
+        mesh3d(
+            x,
+            y,
+            z;
+            connections = [
+                Int32[1, 2, 4, 3], # Quadrangle
+                Int32[1, 2, 5], # Triangle
+                Int32[2, 4, 5], # Triangle
+                Int32[4, 3, 5], # Triangle
+                Int32[3, 1, 5],  # Triangle
+            ],
+            linecolor = :black,
+            fillcolor = :blue,
+            fillalpha = 0.2,
+        )
         @test true
     end
 


### PR DESCRIPTION
## Description

Small fix - noticed while looking at https://github.com/JuliaPlots/Plots.jl/issues/5051 that the GR backend only supports the system signed integer type `Int` for the `connections` within a `mesh3d`.

Seems an unnecessary constraint, so broadening to support any Integer type. The underlying `polygonmesh3d` converts it into a `Vector{Int32}` for the ccall so no need to do any conversion higher up.

Tested locally that cases with various signed and unsigned integers work as expected
