### PR TITLE
Load RequireJS explictly for Plotly when running in IJulia

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -803,6 +803,12 @@
             "name": "Isaac Wheeler",
             "orcid": "0000-0002-9717-073X",
             "type": "Other"
+        },
+        {
+            "affiliation": "European XFEL",
+            "name": "James Wrigley",
+            "orcid": "0009-0003-6525-7413",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/PlotsBase/src/init.jl
+++ b/PlotsBase/src/init.jl
@@ -6,6 +6,8 @@ const _plotly_local_file_path = Ref{Union{Nothing,String}}(nothing)
 # see github.com/JuliaPlots/Plots.jl/pull/2779
 const _plotly_min_js_filename = "plotly-2.3.0.min.js"  # must match https://github.com/JuliaPlots/PlotlyJS.jl/blob/master/deps/plotly_cdn_version.jl
 
+const _requirejs_version = v"2.3.7"
+
 const _use_local_dependencies = Ref(false)
 const _use_local_plotlyjs = Ref(false)
 

--- a/PlotsBase/src/plotly.jl
+++ b/PlotsBase/src/plotly.jl
@@ -1281,10 +1281,13 @@ function plotly_html_body(plt, style = nothing)
     uuid = UUIDs.uuid4()
     html = """
         <div id=\"$(uuid)\" style=\"$(style)\"></div>
+        <script src="https://requirejs.org/docs/release/$(PlotsBase._requirejs_version)/minified/require.js" onload="plots_jl_plotly_init()"></script>
         <script>
-        $(requirejs_prefix)
-        $(js_body(plt, uuid))
-        $(requirejs_suffix)
+        function plots_jl_plotly_init() {
+            $(requirejs_prefix)
+            $(js_body(plt, uuid))
+            $(requirejs_suffix)
+        }
         </script>
     """
     html


### PR DESCRIPTION
## Description
Plotly support in IJulia previously relied on Jupyter itself loading RequireJS first, but that seems to no longer be the case in recent versions (the console shows an error saying that `requirejs` is not found) so now it's loaded explicitly. It did require refactoring the code a bit to ensure that the body is only executed after RequireJS has been loaded with `onload`, just using `script` tags didn't work on its own (disclaimer: I'm not a web developer :sweat_smile:).

Tested with IJulia 1.29.0, Plots v2, and Plots 1.40.13. Fixes https://github.com/JuliaLang/IJulia.jl/issues/1094, fixes https://github.com/JuliaPlots/Plots.jl/issues/4827. It would be great if this could be backported to v1 as well.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
