### PR TITLE
Load RequireJS explictly for Plotly when running in IJulia

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -779,6 +779,12 @@
         {
             "name": "Patrick Jaap",
             "type": "Other"
+        },
+        {
+            "affiliation": "European XFEL",
+            "name": "James Wrigley",
+            "orcid": "0009-0003-6525-7413",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Plots"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 author = ["Tom Breloff (@tbreloff)"]
-version = "1.40.14"
+version = "1.40.13"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Plots"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 author = ["Tom Breloff (@tbreloff)"]
-version = "1.40.13"
+version = "1.40.14"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1109,10 +1109,13 @@ function plotly_html_body(plt, style = nothing)
     uuid = UUIDs.uuid4()
     html = """
         <div id=\"$(uuid)\" style=\"$(style)\"></div>
+        <script src="https://requirejs.org/docs/release/$(_requirejs_version)/minified/require.js" onload="plots_jl_plotly_init()"></script>
         <script>
-        $(requirejs_prefix)
-        $(js_body(plt, uuid))
-        $(requirejs_suffix)
+        function plots_jl_plotly_init() {
+            $(requirejs_prefix)
+            $(js_body(plt, uuid))
+            $(requirejs_suffix)
+        }
         </script>
     """
     html

--- a/src/init.jl
+++ b/src/init.jl
@@ -24,6 +24,8 @@ use fixed version of Plotly instead of the latest one for stable dependency
 """
 const _plotly_min_js_filename = "plotly-2.6.3.min.js"
 
+const _requirejs_version = v"2.3.7"
+
 """
 Whether to use local embedded or local dependencies instead of CDN.
 """


### PR DESCRIPTION
## Description
Backport of #5109. I took the liberty of bumping the version number as well, hope that's ok.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
