### PR TITLE
backport plotly fix

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1108,23 +1108,23 @@ function plotly_html_body(plt, style = nothing)
         requirejs_suffix = "});"
     end
 
-    uuid = UUIDs.uuid4()
+    unique_tag = replace(string(UUIDs.uuid4()), '-' => '_')
     html = """
-        <div id=\"$(uuid)\" style=\"$(style)\"></div>
-        <script src="https://requirejs.org/docs/release/$(_requirejs_version)/minified/require.js" onload="plots_jl_plotly_init()"></script>
+        <div id=\"$unique_tag\" style=\"$style\"></div>
         <script>
-        function plots_jl_plotly_init() {
+        function plots_jl_plotly_$unique_tag() {
             $(requirejs_prefix)
-            $(js_body(plt, uuid))
+            $(js_body(plt, unique_tag))
             $(requirejs_suffix)
         }
         </script>
+        <script src="https://requirejs.org/docs/release/$_requirejs_version/minified/require.js" onload="plots_jl_plotly_$unique_tag()"></script>
     """
     return html
 end
 
-js_body(plt::Plot, uuid) =
-    "Plotly.newPlot('$(uuid)', $(plotly_series_json(plt)), $(plotly_layout_json(plt)));"
+js_body(plt::Plot, unique_tag) =
+    "Plotly.newPlot('$unique_tag', $(plotly_series_json(plt)), $(plotly_layout_json(plt)));"
 
 plotly_show_js(io::IO, plot::Plot) =
     JSON.print(io, Dict(:data => plotly_series(plot), :layout => plotly_layout(plot)))


### PR DESCRIPTION
Backport https://github.com/JuliaPlots/Plots.jl/pull/5135 to `master` for v1.