### PR TITLE
render more `html` and `svg` in docs

### DIFF
--- a/PlotsBase/ext/UnicodePlotsExt.jl
+++ b/PlotsBase/ext/UnicodePlotsExt.jl
@@ -427,7 +427,10 @@ Base.show(io::IO, plt::Plot{UnicodePlotsBackend}) =
     PlotsBase._show(io, MIME("text/plain"), plt)
 
 # NOTE: _show(...) must be kept for Base.showable (src/output.jl)
-function PlotsBase._show(io::IO, ::MIME"text/plain", plt::Plot{UnicodePlotsBackend})
+function PlotsBase._show(
+        io::IO, ::MIME"text/plain", plt::Plot{UnicodePlotsBackend};
+        color::Union{Nothing, Bool} = nothing
+    )
     PlotsBase.prepare_output(plt)
     nr, nc = size(plt.layout)
     if nr == 1 && nc == 1  # fast path
@@ -437,7 +440,7 @@ function PlotsBase._show(io::IO, ::MIME"text/plain", plt::Plot{UnicodePlotsBacke
             i < n && println(io)
         end
     else
-        have_color = Base.get_have_color()
+        have_color = color ≡ nothing ? Base.get_have_color() : color
         lines_colored = Array{Union{Nothing, Vector{String}}}(nothing, nr, nc)
         lines_uncolored = have_color ? similar(lines_colored) : lines_colored
         l_max = zeros(Int, nr)

--- a/PlotsBase/src/output.jl
+++ b/PlotsBase/src/output.jl
@@ -176,8 +176,15 @@ end
 
 # ---------------------------------------------------------
 
-const _best_html_output_type =
-    KW(:pythonplot => :png, :unicodeplots => :txt, :plotlyjs => :html, :plotly => :html)
+const _best_html_output_type = KW(
+    :unicodeplots => :png,  # better rendered as :png in web pages
+    :pythonplot => :svg,
+    :pgfplotsx => :svg,
+    :plotlyjs => :html,
+    :plotly => :html,
+    :gaston => :svg,
+    :gr => :svg,
+)
 
 # a backup for html... passes to svg or png depending on the html_output_format arg
 function _show(io::IO, ::MIME"text/html", plt::Plot)
@@ -212,16 +219,16 @@ _display(plt::Plot) = @maxlog_warn "_display is not defined for this backend."
 Base.show(io::IO, m::MIME"text/plain", plt::Plot) = show(io, plt)
 # for writing to io streams... first prepare, then callback
 for mime in (
-        "text/html",
+        "application/vnd.plotly.v1+json",
+        "application/postscript",
+        "application/x-tex",
+        "application/pdf",
+        "application/eps",
+        "image/svg+xml",
         "text/latex",
         "image/png",
         "image/eps",
-        "image/svg+xml",
-        "application/eps",
-        "application/pdf",
-        "application/postscript",
-        "application/x-tex",
-        "application/vnd.plotly.v1+json",
+        "text/html",
     )
     @eval function Base.show(io::IO, m::MIME{Symbol($mime)}, plt::Plot)
         if haskey(io, :juno_plotsize)

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ author = ["Tom Breloff (@tbreloff)"]
 version = "2.0.0"
 
 [deps]
+Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"
 GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 PlotsBase = "c52230a3-c5da-43a3-9e85-260fcdfdc737"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -14,6 +15,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 PlotsBase = {path = "PlotsBase"}
 
 [compat]
+Contour = "0.6.3"
 GR = "0.73"
 PlotsBase = "0.1"
 Reexport = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -125,7 +125,7 @@ function generate_cards(
         jl = PipeBuffer()
         # DemoCards YAML frontmatter
         # https://johnnychen94.github.io/DemoCards.jl/stable/quickstart/usage_example/julia_demos/1.julia_demo/#juliademocard_example
-        svg_ready_backends = (:gr, :pythonplot, :plotlyjs, :gaston)
+        svg_ready_backends = (:gr, :pythonplot, :pgfplotsx, :plotlyjs, :gaston)
         asset_name = "$(backend)_$(PlotsBase.ref_name(i))"
         asset_path = asset_name * if i ∈ PlotsBase._animation_examples
             ".gif"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -125,10 +125,11 @@ function generate_cards(
         jl = PipeBuffer()
         # DemoCards YAML frontmatter
         # https://johnnychen94.github.io/DemoCards.jl/stable/quickstart/usage_example/julia_demos/1.julia_demo/#juliademocard_example
+        svg_ready_backends = (:gr, :pythonplot, :plotlyjs, :gaston)
         asset_name = "$(backend)_$(PlotsBase.ref_name(i))"
         asset_path = asset_name * if i ∈ PlotsBase._animation_examples
             ".gif"
-        elseif backend ∈ (:gr, :pythonplot, :gaston)
+        elseif backend ∈ svg_ready_backends
             ".svg"
         else
             ".png"
@@ -177,17 +178,11 @@ function generate_cards(
         # #src and #hide are quite similar. The only difference is that #src lines are filtered out before execution (if execute=true) and #hide lines are filtered out after execution.
         # """
         asset_cmd = if i ∈ PlotsBase._animation_examples
-            "PlotsBase.gif(anim, \"$asset_path\")\n"  # NOTE: must not be hidden, for appearance in the rendered `html`
-        elseif backend ∈ (:gr, :pythonplot, :gaston)
-            "PlotsBase.svg(\"$asset_path\")  #src\n"
-        elseif backend ≡ :plotlyjs
-            """
-            PlotsBase.png(\"$asset_path\")  #src
-            nothing  #hide
-            # ![plot]($asset_path)
-            """
+            "PlotsBase.gif(anim, \"$asset_path\")"  # NOTE: must not be hidden, for appearance in the rendered `html`
+        elseif backend ∈ svg_ready_backends
+            "PlotsBase.svg(\"$asset_path\")  #src"
         else
-            "PlotsBase.png(\"$asset_path\")  #src\n"
+            "PlotsBase.png(\"$asset_path\")  #src"
         end
         write(jl, """mkpath("assets")  #src\n$asset_cmd\n""")
 

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -53,18 +53,18 @@ This document is meant to be a guide and introduction to make that choice.
 # At a glance
 My favorites: `GR` for speed, `Plotly(JS)` for interactivity, `UnicodePlots` for REPL/SSH and `PythonPlot` otherwise.
 
-| If you require...         | then use...                                 |
-| :------------------------ | :------------------------------------------ |
-| features                  | GR, PythonPlot, Plotly(JS), Gaston          |
-| speed                     | GR, UnicodePlots, InspectDR, Gaston         |
-| interactivity             | PythonPlot, Plotly(JS), InspectDR           |
-| beauty                    | GR, Plotly(JS), PGFPlots/ PGFPlotsX         |
-| REPL plotting             | UnicodePlots                                |
-| 3D plots                  | GR, PythonPlot, Plotly(JS), Gaston          |
-| a GUI window              | GR, PythonPlot, PlotlyJS, Gaston, InspectDR |
-| a small footprint         | UnicodePlots, Plotly                        |
-| backend stability         | PythonPlot, Gaston                          |
-| plot+data -> `.hdf5` file | HDF5                                        |
+| If you require...         | then use...                         |
+| :------------------------ | :-----------------------------------|
+| features                  | GR, PythonPlot, Plotly(JS), Gaston  |
+| speed                     | GR, UnicodePlots, Gaston            |
+| interactivity             | PythonPlot, Plotly(JS)              |
+| beauty                    | GR, Plotly(JS), PGFPlots/ PGFPlotsX |
+| REPL plotting             | UnicodePlots                        |
+| 3D plots                  | GR, PythonPlot, Plotly(JS), Gaston  |
+| a GUI window              | GR, PythonPlot, PlotlyJS, Gaston    |
+| a small footprint         | UnicodePlots, Plotly                |
+| backend stability         | PythonPlot, Gaston                  |
+| plot+data -> `.hdf5` file | HDF5                                |
 
 Of course this list is rather subjective and nothing in life is that simple. Likely there are subtle tradeoffs between backends, long hidden bugs, and more excitement. Don't be shy to try out something new !
 

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -27,8 +27,8 @@ Plots support 2 different versions per save-command.
 Command `savefig` chooses file type automatically based on the file extension.
 
 ```julia
-savefig(filename_string) # save the most recent fig as filename_string (such as "output.png")
-savefig(plot_ref, filename_string) # save the fig referenced by plot_ref as filename_string (such as "output.png")
+savefig(filename_string)  # save the most recent fig as filename_string (such as "output.png")
+savefig(plot_ref, filename_string)  # save the fig referenced by plot_ref as filename_string (such as "output.png")
 ```
 
 In addition, `Plots` exports the convenience function `png(filename::AbstractString)`.
@@ -37,31 +37,31 @@ conflict with exports from other packages.
 In this case the string fn containing the filename does not need a file extension.
 
 ```julia
-png(filename_string) # save the current fig as png with filename filename_string (such as "output.png")
-png(plot_ref, filename_string) # save the fig referenced by plot_ref as png with filename filename_string (such as "output.png")
+png(filename_string)  # save the current fig as png with filename filename_string (such as "output.png")
+png(plot_ref, filename_string)  # save the fig referenced by plot_ref as png with filename filename_string (such as "output.png")
 ```
 
 #### File formats supported by most graphical backends
  - png (default output format for `savefig`, if no file extension is given)
  - svg
- - PDF
+ - pdf
 
 When not using `savefig`, the default output format depends on the environment (e.g., when using IJulia/Jupyter).
 
 #### Supported output file formats
-Note:   not all backends support every output file format !
+Note: not all backends support every output file format !
 A simple table showing which format is supported by which backend
 
-| format | backends                                                             |
-| :----- | :------------------------------------------------------------------- |
-| eps    | inspectdr, plotlyjs, pythonplot                                      |
-| html   | plotly,  plotlyjs                                                    |
-| json   | plotly, plotlyjs                                                     |
-| pdf    | gr, plotlyjs, pythonplot, pgfplotsx, inspectdr, gaston               |
-| png    | gr, plotlyjs, pythonplot, pgfplotsx, inspectdr, gaston, unicodeplots |
-| ps     | gr, pythonplot                                                       |
-| svg    | gr, inspectdr, pgfplotsx, plotlyjs, pythonplot, gaston               |
-| tex    | pgfplotsx, pythonplot                                                |
-| text   | hdf5, unicodeplots                                                   |
+| format | backends                                                  |
+| :----- | :-------------------------------------------------------- |
+| eps    | plotlyjs, pythonplot                                      |
+| html   | plotly, plotlyjs                                          |
+| json   | plotly, plotlyjs                                          |
+| pdf    | gr, pythonplot, plotlyjs, pgfplotsx, gaston               |
+| png    | gr, pythonplot, unicodeplots, plotlyjs, pgfplotsx, gaston |
+| ps     | gr, pythonplot                                            |
+| svg    | gr, pythonplot, pgfplotsx, plotlyjs, gaston               |
+| tex    | pythonplot, pgfplotsx                                     |
+| text   | unicodeplots, hdf5                                        |
 
 Supported file formats can be written to an IO stream via, for example, `png(myplot, pipebuffer::IO)`, so the image file can be passed via a PipeBuffer to other functions, eg. `Cairo.read_from_png(pipebuffer::IO)`.


### PR DESCRIPTION
Storing `png`s is heavy, so prefer using `svg` and `html`.