### PR TITLE
revert docs svg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ examples/meetup/.ipynb_checkpoints/*
 deps/plotly-*
 deps/build.log
 deps/deps.jl
+
+Manifest-v*.toml
 Manifest.toml
 
 dev/

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -120,7 +120,11 @@ function generate_cards(
 
         # DemoCards YAML frontmatter
         # https://johnnychen94.github.io/DemoCards.jl/stable/quickstart/usage_example/julia_demos/1.julia_demo/#juliademocard_example
-        svg_ready_backends = (:gr, :pythonplot, :pgfplotsx, :plotlyjs, :gaston)
+        svg_ready_backends = if false
+            (:gr, :pythonplot, :pgfplotsx, :plotlyjs, :gaston)  # NOTE: could increase docs repo size ...
+        else
+            ()
+        end
         cover_name = "$(backend)_$(Plots.ref_name(i))"
         cover_path = let cover_file = cover_name * if i ∈ Plots._animation_examples
                 ".gif"

--- a/src/output.jl
+++ b/src/output.jl
@@ -177,14 +177,14 @@ end
 # ---------------------------------------------------------
 
 const _best_html_output_type = KW(
-    :unicodeplots => :png,  # better rendered as :png in web pages
-    :pgfplotsx => :svg,
-    :inspectdr => :svg,
+    :unicodeplots => :png,
+    :pgfplotsx => :png,
+    :inspectdr => :png,
     :plotlyjs => :html,
     :plotly => :html,
-    :pyplot => :svg,
-    :gaston => :svg,
-    :gr => :svg,
+    :pyplot => :png,
+    :gaston => :png,
+    :gr => :png,
 )
 
 # a backup for html... passes to svg or png depending on the html_output_format arg


### PR DESCRIPTION
## Description

Fix https://github.com/JuliaPlots/Plots.jl/issues/5165 on `v1`, as it would be breaking to change the preferred `html` output type.
