### PR TITLE
fix: prevent namespace pollution bug

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -809,6 +809,11 @@
             "name": "James Wrigley",
             "orcid": "0009-0003-6525-7413",
             "type": "Other"
+        },
+        {
+            "affiliation": "@JuliaComputing",
+            "name": "Παναγιώτης Γεωργακόπουλος",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/PlotsBase/src/plotly.jl
+++ b/PlotsBase/src/plotly.jl
@@ -1285,6 +1285,7 @@ function plotly_html_body(plt, style = nothing)
     return """
         <div id=\"$unique_tag\" style=\"$style\"></div>
         <script>
+        ;(()=> {
         function plots_jl_plotly_$unique_tag() {
             $requirejs_prefix
             $(js_body(plt, unique_tag))
@@ -1295,6 +1296,7 @@ function plotly_html_body(plt, style = nothing)
         plotlyloader.addEventListener("load", plots_jl_plotly_$unique_tag);
         plotlyloader.src = src
         document.querySelector("#$unique_tag").appendChild(plotlyloader)
+        })()
         </script>
     """
 end

--- a/PlotsBase/src/plotly.jl
+++ b/PlotsBase/src/plotly.jl
@@ -1280,7 +1280,7 @@ function plotly_html_body(plt, style = nothing)
         requirejs_suffix = "});"
     end
 
-    unique_tag = replace(string(UUIDs.uuid4()), '-' => '_')
+    unique_tag = "id_$(replace(string(UUIDs.uuid4()), '-' => '_'))"
 
     return """
         <div id=\"$unique_tag\" style=\"$style\"></div>

--- a/PlotsBase/src/plotly.jl
+++ b/PlotsBase/src/plotly.jl
@@ -1290,8 +1290,12 @@ function plotly_html_body(plt, style = nothing)
             $(js_body(plt, unique_tag))
             $requirejs_suffix
         }
+        let plotlyloader = window.document.createElement("script")
+        let src="https://requirejs.org/docs/release/$(PlotsBase._requirejs_version)/minified/require.js"
+        plotlyloader.addEventListener("load", plots_jl_plotly_$unique_tag);
+        plotlyloader.src = src
+        document.querySelector("#$unique_tag").appendChild(plotlyloader)
         </script>
-        <script src="https://requirejs.org/docs/release/$(PlotsBase._requirejs_version)/minified/require.js" onload="plots_jl_plotly_$unique_tag()"></script>
     """
 end
 


### PR DESCRIPTION
## Description
https://github.com/fonsp/Pluto.jl/issues/3306 and https://github.com/JuliaPlots/Plots.jl/issues/5156

There is a small issue with the id generation; it should start with a letter.

Apart from that, the main issue here is referencing functions that get executed inside a different "module" (in julia terms). Pluto (and maybe also VSCode?) do not hoist the functions to the top level as you would expect, so referencing the created function from onload isn't working. The solution is simple; programmatically register the handler, and then `appendChild` the script to the DOM.


## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
