### PR TITLE
fix: prevent namespace pollution bug (master)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -791,6 +791,11 @@
             "name": "James Wrigley",
             "orcid": "0009-0003-6525-7413",
             "type": "Other"
+        },
+        {
+            "affiliation": "@JuliaComputing",
+            "name": "Παναγιώτης Γεωργακόπουλος",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1108,7 +1108,8 @@ function plotly_html_body(plt, style = nothing)
         requirejs_suffix = "});"
     end
 
-    unique_tag = replace(string(UUIDs.uuid4()), '-' => '_')
+    unique_tag = "id_$(replace(string(UUIDs.uuid4()), '-' => '_'))"
+
     html = """
         <div id=\"$unique_tag\" style=\"$style\"></div>
         <script>

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1117,8 +1117,12 @@ function plotly_html_body(plt, style = nothing)
             $(js_body(plt, unique_tag))
             $(requirejs_suffix)
         }
+        let plotlyloader = window.document.createElement("script")
+        let src="https://requirejs.org/docs/release/$(PlotsBase._requirejs_version)/minified/require.js"
+        plotlyloader.addEventListener("load", plots_jl_plotly_$unique_tag);
+        plotlyloader.src = src
+        document.querySelector("#$unique_tag").appendChild(plotlyloader)
         </script>
-        <script src="https://requirejs.org/docs/release/$_requirejs_version/minified/require.js" onload="plots_jl_plotly_$unique_tag()"></script>
     """
     return html
 end

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1120,7 +1120,7 @@ function plotly_html_body(plt, style = nothing)
             $(requirejs_suffix)
         }
         let plotlyloader = window.document.createElement("script")
-        let src="https://requirejs.org/docs/release/$(PlotsBase._requirejs_version)/minified/require.js"
+        let src="https://requirejs.org/docs/release/$(Plots._requirejs_version)/minified/require.js"
         plotlyloader.addEventListener("load", plots_jl_plotly_$unique_tag);
         plotlyloader.src = src
         document.querySelector("#$unique_tag").appendChild(plotlyloader)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -1112,6 +1112,7 @@ function plotly_html_body(plt, style = nothing)
     html = """
         <div id=\"$unique_tag\" style=\"$style\"></div>
         <script>
+        ;(()=> {
         function plots_jl_plotly_$unique_tag() {
             $(requirejs_prefix)
             $(js_body(plt, unique_tag))
@@ -1122,6 +1123,7 @@ function plotly_html_body(plt, style = nothing)
         plotlyloader.addEventListener("load", plots_jl_plotly_$unique_tag);
         plotlyloader.src = src
         document.querySelector("#$unique_tag").appendChild(plotlyloader)
+        })()
         </script>
     """
     return html


### PR DESCRIPTION
## Description

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
