### PR TITLE
Add `stem` plots for sampled data systems

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -814,6 +814,11 @@
             "affiliation": "@JuliaComputing",
             "name": "Παναγιώτης Γεωργακόπουλος",
             "type": "Other"
+        },
+        {
+            "affiliation": "@ZiplineTeam",
+            "name": "Jonnie Diegelman",
+            "type": "Other"
         }
     ],
     "upload_type": "software"

--- a/PlotsBase/src/recipes.jl
+++ b/PlotsBase/src/recipes.jl
@@ -1620,4 +1620,30 @@ end
     end
 end
 
+# -------------------------------------------------
+# Stem plots are useful for visualizing discretely sampled time series data
+@userplot Stem
+
+# If the second arg is a function, eagerly apply it so we can create the stem lines
+process_stem_args(x, f::Function) = (x, f.(x))
+process_stem_args(x, y) = (x, y)
+
+@recipe function f(s::Stem)
+    if length(s.args) != 2
+        throw(MethodError(stem, s.args))
+    end
+    x, y = process_stem_args(s.args...)
+    @series begin
+        primary := true
+        seriestype := :scatter
+        markerstrokewidth --> 0
+        x, y
+    end
+    @series begin
+        primary := false
+        seriestype := :line
+        [x x]', [zero(y) y]'
+    end
+end
+
 @specialize

--- a/PlotsBase/test/test_recipes.jl
+++ b/PlotsBase/test/test_recipes.jl
@@ -143,6 +143,20 @@ with(:gr) do
         @test_nowarn show(devnull, scatter3d(1:2, 1:2, 1:2))
     end
 
+    @testset "stem" begin
+        n = 0:0.5:10
+
+        # Make sure array and function arguments work
+        @test stem(n, sin.(n)) isa PlotsBase.Plot
+        @test stem(n, sin) isa PlotsBase.Plot
+
+        # Should only accept two positional arguments, otherwise throw an error
+        @test_throws MethodError stem()
+        @test_throws MethodError stem(n)
+        @test_throws MethodError stem(n, n, n)
+        @test_throws MethodError stem(n, n, n, n)
+    end
+
     @testset "sticks" begin
         @test_nowarn show(devnull, sticks(1:2, marker = :circle))
     end


### PR DESCRIPTION
## Description
Discretely sampled timeseries data is usually best visualized as a `stem` plot. It is helpful especially in cases where single-point impulse functions are viewed, since it can be hard to see them on scatter plots (see below)
<img width="615" height="842" alt="image" src="https://github.com/user-attachments/assets/b77b6b0e-9ed4-442d-a713-3b3d9c33253f" />


## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [x] Does it work on log scales?
- [x] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [x] PR includes or updates tests?
- [ ] PR includes or updates documentation?
