### PR TITLE
Up minimum compat for v1 to 1.10 (current LTS), test "min" and "lts" on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6' # LTS (minimal declared julia compat in `Project.toml`)
-          - 'lts'
+          - 'min' # minimum declared julia compat in `Project.toml`
+          - 'lts' # LTS 
           - '1' # latest stable
         experimental:
           - false

--- a/Project.toml
+++ b/Project.toml
@@ -94,7 +94,7 @@ UnicodeFun = "0.4"
 UnicodePlots = "3.4"
 UnitfulLatexify = "1"
 Unzip = "0.1 - 0.2"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/init.jl
+++ b/src/init.jl
@@ -84,24 +84,6 @@ function __init__()
         )
     end |> atreplinit
 
-    @static if !isdefined(Base, :get_extension)  # COV_EXCL_LINE
-        @require FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" include(
-            normpath(@__DIR__, "..", "ext", "FileIOExt.jl"),
-        )
-        @require GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326" include(
-            normpath(@__DIR__, "..", "ext", "GeometryBasicsExt.jl"),
-        )
-        @require IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a" include(
-            normpath(@__DIR__, "..", "ext", "IJuliaExt.jl"),
-        )
-        @require ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254" include(
-            normpath(@__DIR__, "..", "ext", "ImageInTerminalExt.jl"),
-        )
-        @require Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d" include(
-            normpath(@__DIR__, "..", "ext", "UnitfulExt.jl"),
-        )
-    end
-
     _runtime_init(backend())
     return nothing
 end


### PR DESCRIPTION
## Description

On the current master, Plots has a Julia compat of 1.6. 
However, hxtensions have been used in Plots for a while; it seems like the burden of loading them on old Julia hasn't been too high. But for  #5174, the lack of extensions for dependencies of extensions starts to make maintenance of new code pretty difficult. A possible compat bound for getting the extensions working would be 1.9, but since 1.10 has been the LTS [for almost a year now](https://julialang.org/blog/2024/10/julia-1.11-highlights/), I propose that gets used as a lower bound for testing and compat on new versions of Plots.

This PR updates that in Project.toml, the CI pipeline (where "min", referring to minimum Julia compat, and "lts" are both set as versions). I also drop the block in `Plots.__init()__` where extensions were loaded for old versions of Julia.

## Attribution
- [x] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

