### PR TITLE
Remove reference to `RecipesBase.debug`

### DIFF
--- a/docs/src/recipes.md
+++ b/docs/src/recipes.md
@@ -435,14 +435,6 @@ This can be put anywhere in the code and will appear on the call `?my_plotfunc`.
 
 ### Troubleshooting
 
-It can sometimes be helpful when debugging recipes to see the order of dispatch inside the `apply_recipe` calls.  Turn on debugging info with:
-
-```julia
-RecipesBase.debug()
-```
-
-You can also pass a `Bool` to the `debug` method to turn it on/off.
-
 Here are some common errors, and what to look out for:
 
 #### convertToAnyVector


### PR DESCRIPTION
## Description

`RecipesBase.debug()` was removed in https://github.com/JuliaPlots/Plots.jl/pull/4459 but the docs still refers to it.

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
