### PR TITLE
make Plots relocatable again

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -68,7 +68,6 @@ const _backend_paths = Dict{Symbol, RelocatableFolders.Path}(
     :plotlyjs => @path(joinpath(@__DIR__, "backends", "plotlyjs.jl")),
     :pythonplot => @path(joinpath(@__DIR__, "backends", "pythonplot.jl")),
     :unicodeplots => @path(joinpath(@__DIR__, "backends", "unicodeplots.jl")),
-    :web => @path(joinpath(@__DIR__, "backends", "web.jl")),
     # Deprecated backends
     :pgfplots => @path(joinpath(@__DIR__, "backends", "deprecated", "pgfplots.jl")),
     :pyplot => @path(joinpath(@__DIR__, "backends", "deprecated", "pyplot.jl")),


### PR DESCRIPTION
The `@path` command needs to *execute* during precompilation for RelocatableFolders to work. This was changed in https://github.com/JuliaPlots/Plots.jl/commit/a1ad4c9aeab18e47eff0859689aacdc3beaae9da#diff-4bd462497f5ac8631d218b72f21cf9d5f383e7a1500f0fee0b8cb776b9a4dac4.