### PR TITLE
Fixes orientation warning in marginalkde.jl

### DIFF
--- a/StatsPlots/src/marginalkde.jl
+++ b/StatsPlots/src/marginalkde.jl
@@ -66,7 +66,7 @@
     @series begin
         seriestype := :density
         subplot := 3
-        orientation := :h
+        permute := (:x, :y)
         xlims := (0, 1.1 * maximum(ky.density))
         ylims := (ymin, ymax)
 


### PR DESCRIPTION
## Description
Fixes a warning about deprecated argument orientation: 
`Warning: Keyword argument orientation is deprecated.`
Raised this in issue #5220



