### PR TITLE
minor: allow diagonal annotation placement

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,3 +19,13 @@ jobs:
       - uses: julia-actions/setup-julia@latest
       - uses: julia-actions/cache@v2
       - uses: fredrikekre/runic-action@v1
+      - name: Create PR with formatting changes
+        if: failure()
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Apply Runic formatting"
+          title: "Apply Runic formatting"
+          body: "Automated formatting changes from Runic."
+          branch: runic/format-${{ github.head_ref || github.ref_name }}
+          base: ${{ github.head_ref || github.ref_name }}
+          delete-branch: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,10 +2,11 @@ name: format
 
 on:
   push:
-    branches: ['release-', 'master', 'v2']
+    branches: [ 'release-', 'master', 'v2' ]
     tags:
-      - '*'
+    - '*'
   pull_request:
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -15,17 +16,7 @@ jobs:
   runic:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/cache@v2
-      - uses: fredrikekre/runic-action@v1
-      - name: Create PR with formatting changes
-        if: failure()
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: "Apply Runic formatting"
-          title: "Apply Runic formatting"
-          body: "Automated formatting changes from Runic."
-          branch: runic/format-${{ github.head_ref || github.ref_name }}
-          base: ${{ github.head_ref || github.ref_name }}
-          delete-branch: true
+    - uses: actions/checkout@v6
+    - uses: julia-actions/setup-julia@latest
+    - uses: julia-actions/cache@v2
+    - uses: fredrikekre/runic-action@v1

--- a/PlotsBase/ext/PGFPlotsXExt.jl
+++ b/PlotsBase/ext/PGFPlotsXExt.jl
@@ -1232,8 +1232,8 @@ function pgfx_add_annotation!(
         Options(
             join(
                 (
-                    get((vcenter = "", top = "below", bottom = "above"), val.font.valign, ""), 
-                    get((hcenter = "", left = "right", right = "left"), val.font.halign, ""), 
+                    get((vcenter = "", top = "below", bottom = "above"), val.font.valign, ""),
+                    get((hcenter = "", left = "right", right = "left"), val.font.halign, ""),
                 ),
                 ' '
             ) => nothing,

--- a/PlotsBase/ext/PGFPlotsXExt.jl
+++ b/PlotsBase/ext/PGFPlotsXExt.jl
@@ -1230,10 +1230,13 @@ function pgfx_add_annotation!(
     cstr = val.font.color
     ann_opt = merge(
         Options(
-            get((hcenter = "", left = "right", right = "left"), val.font.halign, "") =>
-                nothing,
-            get((vcenter = "", top = "below", bottom = "above"), val.font.valign, "") =>
-                nothing,
+            join(
+                (
+                    get((vcenter = "", top = "below", bottom = "above"), val.font.valign, ""), 
+                    get((hcenter = "", left = "right", right = "left"), val.font.halign, ""), 
+                ),
+                ' '
+            ) => nothing,
             "color" => cstr,
             "draw opacity" => float(alpha(cstr)),  # float(...): convert N0f8
             "rotate" => val.font.rotation,


### PR DESCRIPTION
fix previous bug https://github.com/JuliaPlots/Plots.jl/issues/5727

## Description

## Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json` for [PRs against v2](https://github.com/JuliaPlots/Plots.jl/blob/v2/.zenodo.json) or [PRs against master](https://github.com/JuliaPlots/Plots.jl/blob/master/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
