### PR TITLE
minor: backport diagonal annotation placement

### DIFF
--- a/Plots/src/backends/pgfplotsx.jl
+++ b/Plots/src/backends/pgfplotsx.jl
@@ -1029,10 +1029,13 @@ function pgfx_add_annotation!(
     cstr = val.font.color
     ann_opt = merge(
         Options(
-            get((hcenter = "", left = "right", right = "left"), val.font.halign, "") =>
-                nothing,
-            get((vcenter = "", top = "below", bottom = "above"), val.font.valign, "") =>
-                nothing,
+            join(
+                (
+                    get((vcenter = "", top = "below", bottom = "above"), val.font.valign, ""),
+                    get((hcenter = "", left = "right", right = "left"), val.font.halign, ""),
+                ),
+                ' '
+            ) => nothing,
             "color" => cstr,
             "draw opacity" => float(alpha(cstr)),  # float(...): convert N0f8
             "rotate" => val.font.rotation,


### PR DESCRIPTION
## Description

see https://github.com/JuliaPlots/Plots.jl/pull/5729

## Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json` for [PRs against v2](https://github.com/JuliaPlots/Plots.jl/blob/v2/.zenodo.json) or [PRs against master](https://github.com/JuliaPlots/Plots.jl/blob/master/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
