### PR TITLE
Fix GR text-state corruption causing persistent layout assertion failures

### DIFF
--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -444,20 +444,30 @@ end
 
 gr_inqtext(x, y, s) = gr_inqtext(x, y, string(s))
 gr_inqtext(x, y, s::AbstractString) =
-if (occursin('\\', s) || occursin(r"10\^{|2\^{|e\^{", s)) &&
-        match(r".*\$[^\$]+?\$.*", String(s)) ≡ nothing
-    GR.inqtextext(x, y, s)
-else
-    GR.inqtext(x, y, s)
+begin
+    coords =
+        if (occursin('\\', s) || occursin(r"10\^{|2\^{|e\^{", s)) &&
+                match(r".*\$[^\$]+?\$.*", String(s)) ≡ nothing
+            GR.inqtextext(x, y, s)
+        else
+            GR.inqtext(x, y, s)
+        end
+    xs, ys = coords
+    if any(v -> !(v isa Real && isfinite(v)), xs) || any(v -> !(v isa Real && isfinite(v)), ys)
+        return map(_ -> 0.0, xs), map(_ -> 0.0, ys)
+    end
+    return coords
 end
 
 gr_text(x, y, s) = gr_text(x, y, string(s))
 gr_text(x, y, s::AbstractString) =
-if (occursin('\\', s) || occursin(r"10\^{|2\^{|e\^{", s)) &&
-        match(r".*\$[^\$]+?\$.*", String(s)) ≡ nothing
-    GR.textext(x, y, s)
-else
-    GR.text(x, y, s)
+if x isa Real && y isa Real && isfinite(x) && isfinite(y)
+    if (occursin('\\', s) || occursin(r"10\^{|2\^{|e\^{", s)) &&
+            match(r".*\$[^\$]+?\$.*", String(s)) ≡ nothing
+        GR.textext(x, y, s)
+    else
+        GR.text(x, y, s)
+    end
 end
 
 function gr_polaraxes(rmin::Real, rmax::Real, sp::Subplot)

--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -444,14 +444,14 @@ end
 
 gr_inqtext(x, y, s) = gr_inqtext(x, y, string(s))
 gr_inqtext(x, y, s::AbstractString) =
-begin
+    begin
     coords =
-        if (occursin('\\', s) || occursin(r"10\^{|2\^{|e\^{", s)) &&
-                match(r".*\$[^\$]+?\$.*", String(s)) ≡ nothing
-            GR.inqtextext(x, y, s)
-        else
-            GR.inqtext(x, y, s)
-        end
+    if (occursin('\\', s) || occursin(r"10\^{|2\^{|e\^{", s)) &&
+            match(r".*\$[^\$]+?\$.*", String(s)) ≡ nothing
+        GR.inqtextext(x, y, s)
+    else
+        GR.inqtext(x, y, s)
+    end
     xs, ys = coords
     if any(v -> !(v isa Real && isfinite(v)), xs) || any(v -> !(v isa Real && isfinite(v)), ys)
         return map(_ -> 0.0, xs), map(_ -> 0.0, ys)

--- a/PlotsBase/test/test_misc.jl
+++ b/PlotsBase/test/test_misc.jl
@@ -249,6 +249,29 @@ with(:gr) do
         @test occursin("Plot:", str)
     end
 
+    @testset "non-finite text does not poison subsequent plots" begin
+        function badplot()
+            plt1 = heatmap(rand(4, 4); title = "title")
+            plt2 = plot(fill(NaN, 4), fill(NaN, 4))
+            annotate!(plt2, [NaN, NaN], [NaN, NaN], PlotsBase.text.(["a", "b"], 12))
+            plot(plt1, plt2)
+        end
+
+        @test_nowarn show(IOBuffer(), MIME("image/png"), badplot())
+        @test_nowarn show(IOBuffer(), MIME("image/png"), badplot())
+
+        @test_nowarn show(
+            IOBuffer(),
+            MIME("image/png"),
+            plot(1:3, -(1:3), yscale = :log10, xlabel = "test"),
+        )
+        @test_nowarn show(
+            IOBuffer(),
+            MIME("image/png"),
+            plot(1:3, 1:3, yscale = :log10, xlabel = "test", ylabel = "test"),
+        )
+    end
+
     @testset "recipes" begin
         @test PlotsBase.seriestype_supported(:path) ≡ :native
 

--- a/PlotsBase/test/test_misc.jl
+++ b/PlotsBase/test/test_misc.jl
@@ -260,10 +260,10 @@ with(:gr) do
         @test_nowarn show(IOBuffer(), MIME("image/png"), badplot())
         @test_nowarn show(IOBuffer(), MIME("image/png"), badplot())
 
-        @test_logs (:warn, r"Invalid negative or zero value") match_mode = :any show(
+        @test_nowarn show(
             IOBuffer(),
             MIME("image/png"),
-            plot(1:3, -(1:3), yscale = :log10, xlabel = "test"),
+            plot(1:3, 10 .^ (0:2), yscale = :log10, xlabel = "test"),
         )
         @test_nowarn show(
             IOBuffer(),

--- a/PlotsBase/test/test_misc.jl
+++ b/PlotsBase/test/test_misc.jl
@@ -260,7 +260,7 @@ with(:gr) do
         @test_nowarn show(IOBuffer(), MIME("image/png"), badplot())
         @test_nowarn show(IOBuffer(), MIME("image/png"), badplot())
 
-        @test_nowarn show(
+        @test_logs (:warn, r"Invalid negative or zero value") match_mode = :any show(
             IOBuffer(),
             MIME("image/png"),
             plot(1:3, -(1:3), yscale = :log10, xlabel = "test"),
@@ -268,7 +268,7 @@ with(:gr) do
         @test_nowarn show(
             IOBuffer(),
             MIME("image/png"),
-            plot(1:3, 1:3, yscale = :log10, xlabel = "test", ylabel = "test"),
+            plot(1:3, 10 .^ (0:2), yscale = :log10, xlabel = "test", ylabel = "test"),
         )
     end
 


### PR DESCRIPTION
Fixes a GR backend state-corruption bug behind issue #4816 where plotting with non-finite text coordinates/extents could poison subsequent plots in the same session and trigger layout assertions (`total_plotarea_vertical > 0mm` / `total_plotarea_horizontal > 0mm`).

### Root cause
When GR was asked to draw or measure text at invalid coordinates (for example, `annotate!` with `NaN` positions, or labels/ticks after invalid log-scale inputs), GR could return non-finite text extents (`inqtext` / `inqtextext`). Those values propagated into subplot padding and layout calculations, causing assertion failures. Because GR state persisted, later unrelated plots also failed until restart.

### Fix
In `GRExt.jl`:
- `gr_text(...)`: skip text draw when `(x, y)` is non-finite.
- `gr_inqtext(...)`: sanitize non-finite returned text bounds and fall back to finite zero extents.

This prevents non-finite values from entering layout padding math while preserving normal behavior for valid inputs.

### Testing
Added regression test in `test_misc.jl` covering:
- Non-finite annotation reproducer (including repeated call and history dependence)
- Invalid negative log-scale case followed by a valid labeled log-scale plot

Strengthened test path to renderer-level checks (`show(..., MIME("image/png"), ...)`) so GR drawing and measuring is exercised directly.

Additional GR stress verification in a clean environment (repeated bad → good render cycles, including `twinx`) completed without reintroducing assertion failures or session poisoning.

### Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json` for PRs against v2 or PRs against master (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

### Things to consider
- [x] Does it work on log scales?
- [x] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [x] PR includes or updates tests?
- [ ] PR includes or updates documentation?