### PR TITLE
Fix GR dashed legend line rendering

### DIFF
--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -369,6 +369,8 @@ function gr_polyline(
         arrowside = :none,
         arrowstyle = :simple,
         arrowsize = 1,
+        linestyle = :solid,
+        linewidth = 1.0,
     )
     draw_head = arrowside in (:head, :both)
     draw_tail = arrowside in (:tail, :both)
@@ -395,7 +397,11 @@ function gr_polyline(
         end
         # if we found a start and end, draw the line segment, otherwise we're done
         if istart > 0 && iend > 0
-            func(x[istart:iend], y[istart:iend])
+            if func === GR.polyline
+                gr_styled_polyline(x[istart:iend], y[istart:iend], linestyle, linewidth)
+            else
+                func(x[istart:iend], y[istart:iend])
+            end
             if draw_head
                 gr_set_arrowstyle(arrowstyle)
                 GR.drawarrow(x[iend - 1], y[iend - 1], x[iend], y[iend])
@@ -406,6 +412,59 @@ function gr_polyline(
             end
         else
             break
+        end
+    end
+    return
+end
+
+function gr_styled_polyline(x, y, style, linewidth)
+    style in (:dash, :dot, :dashdot, :dashdotdot) || return GR.polyline(x, y)
+    GR.setlinetype(gr_linetypes.solid)
+    lscale = max(1, linewidth) / 2
+    dash = 0.012lscale
+    gap = 0.008lscale
+    dot = 0.0025lscale
+    return if style === :dash
+        gr_dashed_polyline(x, y, (dash, gap))
+    elseif style === :dot
+        gr_dashed_polyline(x, y, (dot, gap))
+    elseif style === :dashdot
+        gr_dashed_polyline(x, y, (dash, gap, dot, gap))
+    else
+        gr_dashed_polyline(x, y, (dash, gap, dot, gap, dot, gap))
+    end
+end
+
+function gr_dashed_polyline(x, y, pattern)
+    ipattern = 1
+    pattern_offset = 0.0
+    xs = Vector{Float64}(undef, 2)
+    ys = Vector{Float64}(undef, 2)
+    for i in 1:(length(x) - 1)
+        x1, y1 = GR.wctondc(x[i], y[i])
+        x2, y2 = GR.wctondc(x[i + 1], y[i + 1])
+        dx, dy = x2 - x1, y2 - y1
+        segment_length = hypot(dx, dy)
+        segment_length > 0 || continue
+        segment_offset = 0.0
+        while segment_offset < segment_length
+            pattern_remaining = pattern[ipattern] - pattern_offset
+            step = min(pattern_remaining, segment_length - segment_offset)
+            if isodd(ipattern)
+                t1 = segment_offset / segment_length
+                t2 = (segment_offset + step) / segment_length
+                xa, ya = GR.ndctowc(x1 + t1 * dx, y1 + t1 * dy)
+                xb, yb = GR.ndctowc(x1 + t2 * dx, y1 + t2 * dy)
+                xs[1], xs[2] = xa, xb
+                ys[1], ys[2] = ya, yb
+                GR.polyline(xs, ys)
+            end
+            segment_offset += step
+            pattern_offset += step
+            if pattern_offset >= pattern[ipattern]
+                pattern_offset = 0.0
+                ipattern = ipattern == length(pattern) ? 1 : ipattern + 1
+            end
         end
     end
     return
@@ -600,10 +659,11 @@ end
 # ---------------------------------------------------------
 
 function gr_set_line(lw, style, c, s)  # s can be Subplot or Series
+    linewidth = get_thickness_scaling(s) * max(0, lw / gr_nominal_size(s))
     GR.setlinetype(gr_linetypes[style])
-    GR.setlinewidth(get_thickness_scaling(s) * max(0, lw / gr_nominal_size(s)))
+    GR.setlinewidth(linewidth)
     gr_set_linecolor(c)
-    return nothing
+    return linewidth
 end
 
 gr_set_fill(c) = (gr_set_fillcolor(c); GR.setfillintstyle(GR.INTSTYLE_SOLID); nothing)
@@ -1190,7 +1250,7 @@ gr_legend_bbox(xpos, ypos, leg) = GR.drawrect(
     ypos + 0.5leg.dy,
 )
 
-const gr_lw_clamp_factor = Ref(5)
+const gr_lw_clamp_factor = Ref(3)
 
 function gr_add_legend(sp, leg, viewport_area)
     sp[:legend_position] ∈ (:none, :inline) && return
@@ -1244,7 +1304,7 @@ function gr_add_legend(sp, leg, viewport_area)
             ls = get_linestyle(series)
             la = get_linealpha(series)
             clamped_lw = (lfps / 8) * clamp(lw, min_lw, max_lw)
-            gr_set_line(clamped_lw, ls, lc, sp)  # see github.com/JuliaPlots/Plots.jl/issues/3003
+            linewidth = gr_set_line(clamped_lw, ls, lc, sp)  # see github.com/JuliaPlots/Plots.jl/issues/3003
             _debug[] && gr_legend_bbox(xpos, ypos, leg)
 
             if ((st ≡ :shape || series[:fillrange] ≢ nothing) && series[:ribbon] ≡ nothing)
@@ -1262,8 +1322,8 @@ function gr_add_legend(sp, leg, viewport_area)
                 gr_set_transparency(fc, get_fillalpha(series))
                 gr_polyline(x, y, GR.fillarea)
                 gr_set_transparency(lc, la)
-                gr_set_line(clamped_lw, ls, lc, sp)
-                st ≡ :shape && gr_polyline(x, y)
+                linewidth = gr_set_line(clamped_lw, ls, lc, sp)
+                st ≡ :shape && gr_styled_polyline(x, y, ls, linewidth)
             end
 
             max_markersize = Inf
@@ -1271,7 +1331,12 @@ function gr_add_legend(sp, leg, viewport_area)
                 max_markersize = leg.base_markersize
                 gr_set_transparency(lc, la)
                 filled = series[:fillrange] ≢ nothing && series[:ribbon] ≡ nothing
-                GR.polyline(xpos .+ [lft, rgt], ypos .+ (filled ? [top, top] : [0, 0]))
+                gr_styled_polyline(
+                    xpos .+ [lft, rgt],
+                    ypos .+ (filled ? [top, top] : [0, 0]),
+                    ls,
+                    linewidth,
+                )
             end
 
             if (msh = series[:markershape]) ≢ :none
@@ -2033,7 +2098,8 @@ function gr_draw_segments(series, x, y, z, fillrange, clims)
             GR.fillarea(fx, fy)
         end
         (lc = get_linecolor(series, clims, i)) |> gr_set_fillcolor
-        gr_set_line(get_linewidth(series, i), get_linestyle(series, i), lc, series)
+        ls = get_linestyle(series, i)
+        linewidth = gr_set_line(get_linewidth(series, i), ls, lc, series)
         gr_set_transparency(lc, get_linealpha(series, i))
         if is3d
             GR.polyline3d(x[rng], y[rng], z[rng])
@@ -2044,7 +2110,15 @@ function gr_draw_segments(series, x, y, z, fillrange, clims)
             arrowside, arrowstyle, arrowsize =
                 arrow.side, arrow.style, (arrow.headlength + arrow.headwidth) / 2
 
-            gr_polyline(x[rng], y[rng]; arrowside, arrowstyle, arrowsize)
+            gr_polyline(
+                x[rng],
+                y[rng];
+                arrowside,
+                arrowstyle,
+                arrowsize,
+                linestyle = ls,
+                linewidth,
+            )
         end
     end
     return
@@ -2110,9 +2184,10 @@ function gr_draw_shapes(series, clims)
 
             # draw the shapes
             lc = get_linecolor(series, clims, i)
-            gr_set_line(get_linewidth(series, i), get_linestyle(series, i), lc, series)
+            ls = get_linestyle(series, i)
+            linewidth = gr_set_line(get_linewidth(series, i), ls, lc, series)
             gr_set_transparency(lc, get_linealpha(series, i))
-            GR.polyline(xseg, yseg)
+            gr_styled_polyline(xseg, yseg, ls, linewidth)
         end
     end
     return

--- a/PlotsBase/test/test_backends.jl
+++ b/PlotsBase/test/test_backends.jl
@@ -44,6 +44,25 @@
     end
 end
 
+@testset "GR - linestyle visual defaults" begin
+    with(:gr) do
+        fn = tempname() * ".svg"
+        plt = plot(
+            1:4,
+            [1:4 4:-1:1];
+            marker = :circle,
+            linestyle = [:dash :dot],
+            linewidth = 2,
+            label = ["dash" "dot"],
+        )
+        savefig(plt, fn)
+        svg_text = read(fn, String)
+        @test !occursin("stroke-dasharray", svg_text)
+        @test count(r"stroke:#009af9", svg_text) > 10
+        @test count(r"stroke:#e26f46", svg_text) > 10
+    end
+end
+
 is_pkgeval() || @testset "PlotlyJS" begin
     with(:plotlyjs) do
         PlotlyJSExt = Base.get_extension(PlotsBase, :PlotlyJSExt)


### PR DESCRIPTION
## Summary

Fixes GR rendering of dashed and dotted 2D lines in legends and line segments by drawing those styles as explicit short solid GR polylines. Dash and gap lengths scale with the effective GR linewidth, using `linewidth = 2` as the visual reference.

The legend linewidth clamp is reduced so thick series lines do not dominate the legend sample. Marker sizing is intentionally unchanged: legend markers remain normalized to the legend font/cap rather than scaling with plotted marker size or linewidth.

This targets the v2 layout, where the GR backend implementation lives in `PlotsBase/ext/GRExt.jl`.

Fixes #4892.

## Root Cause

GR legend samples are short line segments. With GR's native dashed/dotted linetypes, short samples can collapse visually into solid lines or otherwise fail to show the requested style clearly.

## Visual Checks

The linewidth sweep below checks `linewidth = 1:5` across the default GR dashed/dotted styles. The important points are that `linewidth = 2` is the reference appearance, larger linewidths keep scaled gaps instead of bleeding into solid lines, and thin lines remain readable.

Reference figure: [linewidth sweep](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/gr_linestyle_linewidth_sweep.png)

![GR linestyle linewidth sweep](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/gr_linestyle_linewidth_sweep.png)

The marker sweep below checks that marker sizing behavior is unchanged. Marker sizes vary in the plot body, while legend markers remain normalized. This keeps the PR scoped to line style rendering.

Reference figure: [marker size sweep](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/gr_marker_size_sweep.png)

![GR marker size sweep](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/gr_marker_size_sweep.png)

## Reference Image Comparisons

These panels compare the affected GR reference examples before and after this change. In each panel, the left image is before and the right image is after.

For `ref012` (`Line styles`), the existing reference image is not correct for this issue: it does not render `dash`, `dashdot`, and `dashdotdot` correctly. The final comparison shows that this fix renders `dash`, `dashdot`, and `dashdotdot` correctly. For `ref005` (`Global`) and `ref007` (`Arguments`), the differences are not significant; they are incidental visual-reference changes from the same line rendering path.

Reference figure: [ref005 before/after](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/ref005_before_after.png)

![ref005 before/after](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/ref005_before_after.png)

Reference figure: [ref007 before/after](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/ref007_before_after.png)

![ref007 before/after](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/ref007_before_after.png)

Reference figure: [ref012 before/after](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/ref012_before_after.png)

![ref012 before/after](https://raw.githubusercontent.com/AshtonSBradley/Plots.jl/gr-legend-linestyle-figures/tmp/pr_figures/ref012_before_after.png)

## Tests

Added a GR SVG regression test that checks dashed and dotted lines are emitted as multiple solid segments rather than relying on `stroke-dasharray`.

Locally run on the v2 port:

```sh
julia --project=/private/tmp/plotsbase_v2_gr_test -e 'using PlotsBase, Test; import GR; gr(); with(:gr) do; fn = tempname() * ".svg"; plt = plot(1:4, [1:4 4:-1:1]; marker = :circle, linestyle = [:dash :dot], linewidth = 2, label = ["dash" "dot"]); savefig(plt, fn); svg_text = read(fn, String); @test !occursin("stroke-dasharray", svg_text); @test count(r"stroke:#009af9", svg_text) > 10; @test count(r"stroke:#e26f46", svg_text) > 10; end'
```

Also run:

```sh
julia --project=@runic -m Runic --check PlotsBase/ext/GRExt.jl PlotsBase/test/test_backends.jl
git diff --check
```

Before this change, the focused SVG regression fails because the GR SVG output still uses `stroke-dasharray`. After this v2 port, the focused regression passes.

## Type Stability and Allocations

Solid lines keep the existing GR path. Dashed and dotted 2D lines now make multiple short `GR.polyline` calls proportional to the rendered dash count. Pattern tuples remain concretely typed per branch, and the two-point draw buffers are reused inside each dashed polyline to avoid per-dash vector allocation.
