### PR TITLE
Add GR colorbar border width

### DIFF
--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -105,6 +105,7 @@ const _gr_attrs = PlotsBase.merge_with_base_supported(
         :colorbar_titlefontcolor,
         :colorbar_entry,
         :colorbar_scale,
+        :colorbar_borderwidth,
         :clims,
         :fill,
         :fill_z,
@@ -811,7 +812,7 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, vp::GRViewport)
     end
 
     if _has_ticks(sp[:colorbar_ticks])
-        gr_set_line(1, :solid, plot_color(:black), sp)
+        gr_set_line(sp[:colorbar_borderwidth], :solid, plot_color(:black), sp)
         (yscale = sp[:colorbar_scale]) ∈ _log_scales && GR.setscale(gr_y_log_scales[yscale])
 
         if sp[:colorbar_ticks] isa Union{Symbol, Bool}

--- a/PlotsBase/src/Commons/aliases.jl
+++ b/PlotsBase/src/Commons/aliases.jl
@@ -347,6 +347,12 @@ add_aliases(
 )
 add_aliases(:colorbar, :cb, :cbar, :colorkey)
 add_aliases(
+    :colorbar_borderwidth,
+    :colorbar_border_width,
+    :cborderwidth,
+    :cborder_width,
+)
+add_aliases(
     :colorbar_title,
     :colorbartitle,
     :cb_title,

--- a/PlotsBase/src/Commons/attrs.jl
+++ b/PlotsBase/src/Commons/attrs.jl
@@ -444,6 +444,7 @@ const _subplot_defaults = KW(
     :colorbar_tickfontrotation => 0.0,
     :colorbar_tickfontcolor => :match,
     :colorbar_scale => :identity,
+    :colorbar_borderwidth => 1,
     :colorbar_formatter => :auto,
     :colorbar_discrete_values => [],
     :colorbar_continuous_values => zeros(0),

--- a/PlotsBase/src/arg_desc.jl
+++ b/PlotsBase/src/arg_desc.jl
@@ -132,6 +132,7 @@ const _arg_desc = KW(
     :colorbar_tickfontsize => (Integer, "Font pointsize of colorbar tick entries."),
     :colorbar_tickfontcolor => (ColorType, "Font color of colorbar tick entries."),
     :colorbar_scale => (Symbol, "Scale of the colorbar axis. Choose from $(Commons._all_scales)."),
+    :colorbar_borderwidth => (Real, "Line width of the colorbar border."),
     :colorbar_formatter => (Union{Function, Symbol}, "Choose from (:scientific, :plain, :none, :auto), or a method which converts a number to a string for tick labeling."),
     :legend_font => (Font, "Font of legend items."),
     :legend_titlefont => (Font, "Font of the legend title."),

--- a/PlotsBase/test/test_args.jl
+++ b/PlotsBase/test/test_args.jl
@@ -109,6 +109,7 @@ end
 
 @testset "aliases" begin
     @test :legend in PlotsBase.Commons.aliases(:legend_position)
+    @test :cborderwidth in PlotsBase.Commons.aliases(:colorbar_borderwidth)
     PlotsBase.Commons.add_non_underscore_aliases!(PlotsBase.Commons._typeAliases)
     PlotsBase.Commons.add_axes_aliases(:ticks, :tick)
 end

--- a/PlotsBase/test/test_output.jl
+++ b/PlotsBase/test/test_output.jl
@@ -37,6 +37,15 @@ with(:gr) do
     @test_save :pdf
     @test_save :svg
     @test_save :ps
+
+    @testset "colorbar border width" begin
+        fn = tempname() * ".svg"
+        pl = heatmap(reshape(1:9, 3, 3); colorbar_borderwidth = 4)
+
+        @test pl[1][:colorbar_borderwidth] == 4
+        @test_nowarn savefig(pl, fn)
+        @test isfile(fn)
+    end
 end
 
 with(:unicodeplots) do


### PR DESCRIPTION
## Summary

- add a `colorbar_borderwidth` subplot attribute for GR colorbars
- wire the attribute into GR colorbar axis drawing instead of always using width `1`
- add aliases/docs plus coverage for keyword acceptance and GR SVG rendering

Refs #3174. This is limited to the remaining GR colorbar border-thickness slice.

## Tests

- `git diff --check`
- not run locally: Julia is not installed in this Codex environment, so execution coverage should come from CI
