### PR TITLE
Fix GR colorbar ticks

### DIFF
--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -105,6 +105,7 @@ const _gr_attrs = PlotsBase.merge_with_base_supported(
         :colorbar_titlefontcolor,
         :colorbar_entry,
         :colorbar_scale,
+        :colorbar_ticks,
         :clims,
         :fill,
         :fill_z,
@@ -740,6 +741,51 @@ end
 
 const gr_colorbar_tick_size = Ref(0.005)
 
+function gr_draw_colorbar_ticks(sp::Subplot, x_max, z_min, z_max)
+    ticks = get_colorbar_ticks(sp)
+    ticks === nothing && return
+    tick_values, tick_labels = ticks
+    isempty(tick_values) && return
+
+    gr_set_line(1, :solid, plot_color(:black), sp)
+    gr_set_font(
+        font(;
+            family = sp[:colorbar_tickfontfamily],
+            pointsize = sp[:colorbar_tickfontsize],
+            halign = sp[:colorbar_tickfonthalign],
+            valign = sp[:colorbar_tickfontvalign],
+            rotation = sp[:colorbar_tickfontrotation],
+            color = sp[:colorbar_tickfontcolor],
+        ),
+        sp,
+        halign = :left,
+        valign = :vcenter,
+    )
+
+    GR.savestate()
+    (yscale = sp[:colorbar_scale]) ∈ _log_scales && GR.setscale(gr_y_log_scales[yscale])
+    ndc_ticks = map(tick_values, tick_labels) do value, label
+        z_min ≤ value ≤ z_max || return nothing
+        x, y = GR.wctondc(x_max, value)
+        return x, y, label
+    end
+    filter!(x -> !isnothing(x), ndc_ticks)
+    isempty(ndc_ticks) && return GR.restorestate()
+    axis_x, axis_ymin = GR.wctondc(x_max, z_min)
+    _, axis_ymax = GR.wctondc(x_max, z_max)
+
+    GR.selntran(0)
+    GR.setclip(0)
+    GR.polyline([axis_x, axis_x], [axis_ymin, axis_ymax])
+    for (x, y, label) in ndc_ticks
+        GR.polyline([x, x + gr_colorbar_tick_size[]], [y, y])
+        gr_text(x + 2gr_colorbar_tick_size[], y, label)
+    end
+    GR.setclip(1)
+    GR.restorestate()
+    return
+end
+
 function gr_colorbar_title(sp::Subplot)
     title = if (ttl = sp[:colorbar_title]) isa PlotText
         ttl
@@ -811,11 +857,7 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, vp::GRViewport)
     end
 
     if _has_ticks(sp[:colorbar_ticks])
-        z_tick = 0.5GR.tick(z_min, z_max)
-        gr_set_line(1, :solid, plot_color(:black), sp)
-        (yscale = sp[:colorbar_scale]) ∈ _log_scales && GR.setscale(gr_y_log_scales[yscale])
-        # signature: gr.axes(x_tick, y_tick, x_org, y_org, major_x, major_y, tick_size)
-        GR.axes(0, z_tick, x_max, z_min, 0, 1, gr_colorbar_tick_size[])
+        gr_draw_colorbar_ticks(sp, x_max, z_min, z_max)
     end
 
     title = gr_colorbar_title(sp)

--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -741,6 +741,8 @@ end
 
 const gr_colorbar_tick_size = Ref(0.005)
 
+gr_has_custom_colorbar_ticks(ticks) = _has_ticks(ticks) && !(ticks isa Symbol) && ticks !== true
+
 function gr_draw_colorbar_ticks(sp::Subplot, x_max, z_min, z_max)
     ticks = get_colorbar_ticks(sp)
     ticks === nothing && return
@@ -857,7 +859,15 @@ function gr_draw_colorbar(cbar::GRColorbar, sp::Subplot, vp::GRViewport)
     end
 
     if _has_ticks(sp[:colorbar_ticks])
-        gr_draw_colorbar_ticks(sp, x_max, z_min, z_max)
+        if gr_has_custom_colorbar_ticks(sp[:colorbar_ticks])
+            gr_draw_colorbar_ticks(sp, x_max, z_min, z_max)
+        else
+            z_tick = 0.5GR.tick(z_min, z_max)
+            gr_set_line(1, :solid, plot_color(:black), sp)
+            (yscale = sp[:colorbar_scale]) ∈ _log_scales && GR.setscale(gr_y_log_scales[yscale])
+            # signature: gr.axes(x_tick, y_tick, x_org, y_org, major_x, major_y, tick_size)
+            GR.axes(0, z_tick, x_max, z_min, 0, 1, gr_colorbar_tick_size[])
+        end
     end
 
     title = gr_colorbar_title(sp)

--- a/PlotsBase/test/test_args.jl
+++ b/PlotsBase/test/test_args.jl
@@ -61,6 +61,16 @@ end
     end
 end
 
+@testset "GR colorbar ticks" begin
+    with(:gr) do
+        ticks = ([2, 4], ["two", "four"])
+        @test PlotsBase.is_attr_supported(backend(), :colorbar_ticks)
+        pl = @test_nowarn heatmap([1 2; 3 4], colorbar_ticks = ticks)
+        @test pl[1][:colorbar_ticks] == ticks
+        @test PlotsBase.Colorbars.get_colorbar_ticks(pl[1]) == ticks
+    end
+end
+
 @testset "Plotting Plots" begin
     pl = @test_nowarn plot(rand(3, 3))
     @test plot(pl, plot_title = "Test")[:plot_title] == "Test"

--- a/PlotsBase/test/test_args.jl
+++ b/PlotsBase/test/test_args.jl
@@ -68,6 +68,8 @@ end
         pl = @test_nowarn heatmap([1 2; 3 4], colorbar_ticks = ticks)
         @test pl[1][:colorbar_ticks] == ticks
         @test PlotsBase.Colorbars.get_colorbar_ticks(pl[1]) == ticks
+        @test_nowarn display(pl)
+        @test_nowarn display(heatmap([1 2; 3 4], colorbar_ticks = :auto))
     end
 end
 


### PR DESCRIPTION
  Fixes #3560.

  ## Summary
  - add `:colorbar_ticks` to the GR backend supported attributes
  - render GR colorbar ticks from `get_colorbar_ticks`, so explicit tick values and `(values, labels)` are honored
  - add a regression test that GR keeps and resolves explicit colorbar ticks

  ## Tests
  - `git diff --check`
  - `julia --startup-file=no -e 'for path in ARGS; Meta.parseall(read(path, String)); end; println("Julia syntax parse check passed")' PlotsBase/ext/GRExt.jl PlotsBase/test/test_args.jl`

  I also attempted a focused runtime check with `julia --project=PlotsBase`, but the local environment could not finish `Pkg.instantiate()` because several Julia artifacts timed out while downloading. CI should provide the full backend validation.
