### PR TITLE
Update axis ticks and expand limits for integer values

### DIFF
--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -111,24 +111,17 @@ function get_axis(sp::Subplot, letter::Symbol)
 end
 
 """
-Expand `(amin, amax)` to the span that `ticks = n::Int` needs, so that all `n` requested
-ticks are within the axis limits instead of being clipped by the backend.
-
-`get_ticks` lays out the ticks over the limits returned here, so the expansion is iterated
-until it is a fixed point of `optimize_int_ticks` - the span it returns for its own output.
-Widening is monotonic, hence no data can be hidden and the iteration terminates.
+Expand `(amin, amax)` so that all `n` ticks requested by `ticks = n::Int` fit inside the axis
+limits. Ticks are laid out over the *unexpanded* limits (`get_ticks` passes
+`expand_int_ticks = false`), hence they always fall inside the span returned here.
 """
-function expand_limits_to_ticks(amin, amax, n::Int, scale::Symbol, max_passes = 5)
+function expand_limits_to_ticks(amin, amax, n::Int, scale::Symbol)
     sf, invsf, _ = scale_inverse_scale_func(scale)
     smin, smax = sf(amin), sf(amax)
     (isfinite(smin) && isfinite(smax)) || return amin, amax
-    for _ in 1:max_passes
-        _, viewmin, viewmax = optimize_int_ticks(smin, smax, n; scale)
-        (isfinite(viewmin) && isfinite(viewmax)) || break
-        viewmin ≥ smin && viewmax ≤ smax && break  # fixed point
-        smin, smax = min(smin, viewmin), max(smax, viewmax)
-    end
-    lmin, lmax = invsf(smin), invsf(smax)
+    _, viewmin, viewmax = optimize_int_ticks(smin, smax, n; scale)
+    lmin, lmax = invsf(viewmin), invsf(viewmax)
+    # only ever widen, so that no data can be hidden by the expansion
     return (
         isfinite(lmin) ? min(amin, lmin) : amin, isfinite(lmax) ? max(amax, lmax) : amax,
     )
@@ -138,7 +131,8 @@ function Commons.axis_limits(
         sp,
         letter,
         lims_factor = widen_factor(get_axis(sp, letter)),
-        consider_aspect = true,
+        consider_aspect = true;
+        expand_int_ticks = true,
     )
     axis = get_axis(sp, letter)
     ex = axis[:extrema]
@@ -182,7 +176,8 @@ function Commons.axis_limits(
         amin, amax = round_limits(amin, amax, axis[:scale])
     end
 
-    if !has_user_lims &&
+    if expand_int_ticks &&
+            !has_user_lims &&
             !ispolar(axis.sps[1]) &&
             (n = axis[:ticks]) isa Int &&
             n > 0 &&
@@ -510,7 +505,9 @@ function Commons.get_ticks(
             collect(0:(π / 4):(7π / 4)), string.(0:45:315)
         else
             cvals = axis[:continuous_values]
-            alims = axis_limits(sp, axis[:letter])
+            # NOTE: lay out the ticks over the unexpanded limits, since `axis_limits` expands
+            # them to the tick span for `ticks::Int` - see `expand_limits_to_ticks`
+            alims = axis_limits(sp, axis[:letter]; expand_int_ticks = false)
             Commons.get_ticks(ticks, cvals, dvals, alims, axis[:scale], formatter)
         end
     end

--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -111,9 +111,8 @@ function get_axis(sp::Subplot, letter::Symbol)
 end
 
 """
-Expand `(amin, amax)` so that all `n` ticks requested by `ticks = n::Int` fit inside the axis
-limits. Ticks are laid out over the *unexpanded* limits (`get_ticks` passes
-`expand_int_ticks = false`), hence they always fall inside the span returned here.
+Expand `(amin, amax)` so that the `n` ticks requested by `ticks = n::Int` fit: `get_ticks`
+lays them out over the unexpanded limits, hence they are always within the span returned here.
 """
 function expand_limits_to_ticks(amin, amax, n::Int, scale::Symbol)
     sf, invsf, _ = scale_inverse_scale_func(scale)
@@ -505,8 +504,7 @@ function Commons.get_ticks(
             collect(0:(π / 4):(7π / 4)), string.(0:45:315)
         else
             cvals = axis[:continuous_values]
-            # NOTE: lay out the ticks over the unexpanded limits, since `axis_limits` expands
-            # them to the tick span for `ticks::Int` - see `expand_limits_to_ticks`
+            # NOTE: unexpanded, see `expand_limits_to_ticks`
             alims = axis_limits(sp, axis[:letter]; expand_int_ticks = false)
             Commons.get_ticks(ticks, cvals, dvals, alims, axis[:scale], formatter)
         end

--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -5,7 +5,6 @@ export sort_3d_axes, axes_letters, process_axis_arg!, has_ticks, get_axis, get_g
 
 import ..PlotsBase: PlotsBase, Subplot, DefaultsDict
 using Latexify: latexify
-using PlotUtils: optimize_ticks
 
 using ..RecipesPipeline
 using ..Commons
@@ -112,26 +111,24 @@ function get_axis(sp::Subplot, letter::Symbol)
 end
 
 """
-Expand `(amin, amax)` to the tick span `optimize_ticks` needs to lay out `n` ticks.
+Expand `(amin, amax)` to the span that `ticks = n::Int` needs, so that all `n` requested
+ticks are within the axis limits instead of being clipped by the backend.
 
-`ticks = n::Int` asks for `n` ticks, which `optimize_ticks` can usually only honor with a
-span wider than the data (it prefers round tick values); without expanding the limits the
-extra ticks fall outside the drawing window and are clipped by the backend.
+`get_ticks` lays out the ticks over the limits returned here, so the expansion is iterated
+until it is a fixed point of `optimize_int_ticks` - the span it returns for its own output.
+Widening is monotonic, hence no data can be hidden and the iteration terminates.
 """
-function expand_limits_to_ticks(amin, amax, n::Int, scale::Symbol)
+function expand_limits_to_ticks(amin, amax, n::Int, scale::Symbol, max_passes = 5)
     sf, invsf, _ = scale_inverse_scale_func(scale)
     smin, smax = sf(amin), sf(amax)
     (isfinite(smin) && isfinite(smax)) || return amin, amax
-    _, viewmin, viewmax = optimize_ticks(
-        smin,
-        smax;
-        k_min = n,
-        k_max = n,
-        k_ideal = n,
-        strict_span = false,
-    )
-    lmin, lmax = invsf(viewmin), invsf(viewmax)
-    # only ever widen, so that no data can be hidden by the expansion
+    for _ in 1:max_passes
+        _, viewmin, viewmax = optimize_int_ticks(smin, smax, n; scale)
+        (isfinite(viewmin) && isfinite(viewmax)) || break
+        viewmin ≥ smin && viewmax ≤ smax && break  # fixed point
+        smin, smax = min(smin, viewmin), max(smax, viewmax)
+    end
+    lmin, lmax = invsf(smin), invsf(smax)
     return (
         isfinite(lmin) ? min(amin, lmin) : amin, isfinite(lmax) ? max(amax, lmax) : amax,
     )

--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -5,6 +5,7 @@ export sort_3d_axes, axes_letters, process_axis_arg!, has_ticks, get_axis, get_g
 
 import ..PlotsBase: PlotsBase, Subplot, DefaultsDict
 using Latexify: latexify
+using PlotUtils: optimize_ticks
 
 using ..RecipesPipeline
 using ..Commons
@@ -110,6 +111,32 @@ function get_axis(sp::Subplot, letter::Symbol)
     end::Axis
 end
 
+"""
+Expand `(amin, amax)` to the tick span `optimize_ticks` needs to lay out `n` ticks.
+
+`ticks = n::Int` asks for `n` ticks, which `optimize_ticks` can usually only honor with a
+span wider than the data (it prefers round tick values); without expanding the limits the
+extra ticks fall outside the drawing window and are clipped by the backend.
+"""
+function expand_limits_to_ticks(amin, amax, n::Int, scale::Symbol)
+    sf, invsf, _ = scale_inverse_scale_func(scale)
+    smin, smax = sf(amin), sf(amax)
+    (isfinite(smin) && isfinite(smax)) || return amin, amax
+    _, viewmin, viewmax = optimize_ticks(
+        smin,
+        smax;
+        k_min = n,
+        k_max = n,
+        k_ideal = n,
+        strict_span = false,
+    )
+    lmin, lmax = invsf(viewmin), invsf(viewmax)
+    # only ever widen, so that no data can be hidden by the expansion
+    return (
+        isfinite(lmin) ? min(amin, lmin) : amin, isfinite(lmax) ? max(amax, lmax) : amax,
+    )
+end
+
 function Commons.axis_limits(
         sp,
         letter,
@@ -156,6 +183,14 @@ function Commons.axis_limits(
         amin, amax = scale_lims(amin, amax, lims_factor, axis[:scale])
     elseif lims ≡ :round
         amin, amax = round_limits(amin, amax, axis[:scale])
+    end
+
+    if !has_user_lims &&
+            !ispolar(axis.sps[1]) &&
+            (n = axis[:ticks]) isa Int &&
+            n > 0 &&
+            isempty(axis[:discrete_values])
+        amin, amax = expand_limits_to_ticks(amin, amax, n, axis[:scale])
     end
 
     aspect_ratio = get_aspect_ratio(sp)

--- a/PlotsBase/src/Ticks.jl
+++ b/PlotsBase/src/Ticks.jl
@@ -9,11 +9,8 @@ using ..Dates
 
 const DEFAULT_MINOR_INTERVALS = Ref(5)  # 5 intervals -> 4 ticks
 
-"""
-`n` ticks for the scaled limits `smin, smax`, as `(ticks, viewmin, viewmax)`: honoring `n`
-needs the wider span `viewmin, viewmax`, which `axis_limits` expands the limits to, else the
-outermost ticks are clipped (github.com/JuliaPlots/Plots.jl/issues/5738).
-"""
+# `(ticks, viewmin, viewmax)`: `n` ticks only fit the wider span `viewmin, viewmax`, which
+# `axis_limits` expands the limits to, else the outermost ticks are clipped
 optimize_int_ticks(smin, smax, n::Int; scale = :identity) =
     optimize_ticks(smin, smax; k_min = n, k_max = n, k_ideal = n, strict_span = false, scale)
 

--- a/PlotsBase/src/Ticks.jl
+++ b/PlotsBase/src/Ticks.jl
@@ -1,12 +1,21 @@
 module Ticks
 
-export _has_ticks, _transform_ticks, get_minor_ticks
+export _has_ticks, _transform_ticks, get_minor_ticks, optimize_int_ticks
 export no_minor_intervals, num_minor_intervals, ticks_type
 
+using PlotUtils: optimize_ticks
 using ..Commons
 using ..Dates
 
 const DEFAULT_MINOR_INTERVALS = Ref(5)  # 5 intervals -> 4 ticks
+
+"""
+`n` ticks for the scaled limits `smin, smax`, as `(ticks, viewmin, viewmax)`: honoring `n`
+needs the wider span `viewmin, viewmax`, which `axis_limits` expands the limits to, else the
+outermost ticks are clipped (github.com/JuliaPlots/Plots.jl/issues/5738).
+"""
+optimize_int_ticks(smin, smax, n::Int; scale = :identity) =
+    optimize_ticks(smin, smax; k_min = n, k_max = n, k_ideal = n, strict_span = false, scale)
 
 ticks_type(ticks::AVec{<:Real}) = :ticks
 ticks_type(ticks::AVec{<:AbstractString}) = :labels

--- a/PlotsBase/src/axes_utils.jl
+++ b/PlotsBase/src/axes_utils.jl
@@ -93,7 +93,7 @@ end
 
 Commons.get_ticks(ticks::AVec, cvals, dvals, args...) =
     optimal_ticks_and_labels(ticks, args...)
-Commons.get_ticks(ticks::Int, dvals, cvals, args...) =
+Commons.get_ticks(ticks::Int, cvals, dvals, args...) =
 if isempty(dvals)
     optimal_ticks_and_labels(ticks, args...)
 else

--- a/PlotsBase/src/axes_utils.jl
+++ b/PlotsBase/src/axes_utils.jl
@@ -50,8 +50,7 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
             scale,
         ) |> first
     elseif typeof(ticks) <: Int
-        # NOTE: `axis_limits` expands the limits to the span returned here, so that all
-        # `ticks` ticks are visible - both must go through `optimize_int_ticks`
+        # NOTE: `axis_limits` expands the limits to the span returned here
         optimize_int_ticks(sf(amin), sf(amax), ticks; scale) |> first
     else
         map(sf, filter(t -> amin ≤ t ≤ amax, ticks))

--- a/PlotsBase/src/axes_utils.jl
+++ b/PlotsBase/src/axes_utils.jl
@@ -50,17 +50,9 @@ function optimal_ticks_and_labels(ticks, alims, scale, formatter)
             scale,
         ) |> first
     elseif typeof(ticks) <: Int
-        optimize_ticks(
-            sf(amin),
-            sf(amax);
-            k_min = ticks, # minimum number of ticks
-            k_max = ticks, # maximum number of ticks
-            k_ideal = ticks,
-            # `strict_span = false` rewards cases where the span of the
-            # chosen  ticks is not too much bigger than amin - amax:
-            strict_span = false,
-            scale,
-        ) |> first
+        # NOTE: `axis_limits` expands the limits to the span returned here, so that all
+        # `ticks` ticks are visible - both must go through `optimize_int_ticks`
+        optimize_int_ticks(sf(amin), sf(amax), ticks; scale) |> first
     else
         map(sf, filter(t -> amin ≤ t ≤ amax, ticks))
     end

--- a/PlotsBase/test/test_axes.jl
+++ b/PlotsBase/test/test_axes.jl
@@ -89,8 +89,8 @@ end
         end
     end
 
-    # `get_ticks` lays out the ticks over the expanded limits, so the expansion has to be a
-    # fixed point of the tick optimization - it is not reached in one pass on log scales
+    # ticks must be laid out over the unexpanded limits, else they disagree with the
+    # expansion computed from them - which was only visible on log scales
     for scale in (:log10, :log2, :ln), n in 3:8
         pl = plot(exp, 1, 10; yscale = scale, yticks = n)
         ticks, = PlotsBase.get_ticks(pl[1], :y)
@@ -99,9 +99,14 @@ end
         @test all(amin .≤ ticks .≤ amax)
     end
 
-    # user limits win over the tick count
+    # user limits win over the tick count, `widen = false` does not
     pl = plot(sin, -π, π; xticks = 5, xlims = (-3, 3))
     @test PlotsBase.xlims(pl) == (-3, 3)
+
+    pl = plot(sin, -π, π; xticks = 5, widen = false)
+    ticks, = PlotsBase.get_ticks(pl[1], :x)
+    amin, amax = PlotsBase.xlims(pl)
+    @test length(ticks) == 5 && all(amin .≤ ticks .≤ amax)
 
     # no data can be hidden by the expansion
     pl = plot(sin, -π, π; xticks = 5)

--- a/PlotsBase/test/test_axes.jl
+++ b/PlotsBase/test/test_axes.jl
@@ -75,6 +75,36 @@ end
     @test PlotsBase.get_ticks(p3[1], p3[1][:xaxis])[2] == string.('A':'Z')
 end
 
+@testset "Integer number of ticks" begin
+    # github.com/JuliaPlots/Plots.jl/issues/5738: `ticks = n` requests `n` ticks, which
+    # `optimize_ticks` honors with a span wider than the data - the limits must be expanded
+    # accordingly, else the outermost ticks are clipped by the backend
+    for n in 3:8
+        pl = plot(sin, -π, π; xticks = n, yticks = n)
+        for letter in (:x, :y)
+            ticks, labels = PlotsBase.get_ticks(pl[1], letter)
+            amin, amax = PlotsBase.axis_limits(pl[1], letter)
+            @test length(ticks) == length(labels) == n
+            @test all(amin .≤ ticks .≤ amax)  # all requested ticks are visible
+        end
+    end
+
+    # user limits win over the tick count
+    pl = plot(sin, -π, π; xticks = 5, xlims = (-3, 3))
+    @test PlotsBase.xlims(pl) == (-3, 3)
+
+    # no data can be hidden by the expansion
+    pl = plot(sin, -π, π; xticks = 5)
+    amin, amax = PlotsBase.xlims(pl)
+    @test amin ≤ -π && amax ≥ π
+
+    # discrete axes index the categories instead (and must not swap ticks and labels)
+    pl = plot('A':'M', 1:13; xticks = 3)
+    ticks, labels = PlotsBase.get_ticks(pl[1], :x)
+    @test ticks isa AbstractVector{<:Real}
+    @test labels == ["A", "G", "M"]
+end
+
 @testset "Ticks getter functions" begin
     ticks1 = ([1, 2, 3], ("a", "b", "c"))
     ticks2 = ([4, 5], ("e", "f"))

--- a/PlotsBase/test/test_axes.jl
+++ b/PlotsBase/test/test_axes.jl
@@ -89,6 +89,16 @@ end
         end
     end
 
+    # `get_ticks` lays out the ticks over the expanded limits, so the expansion has to be a
+    # fixed point of the tick optimization - it is not reached in one pass on log scales
+    for scale in (:log10, :log2, :ln), n in 3:8
+        pl = plot(exp, 1, 10; yscale = scale, yticks = n)
+        ticks, = PlotsBase.get_ticks(pl[1], :y)
+        amin, amax = PlotsBase.axis_limits(pl[1], :y)
+        @test length(ticks) == n
+        @test all(amin .≤ ticks .≤ amax)
+    end
+
     # user limits win over the tick count
     pl = plot(sin, -π, π; xticks = 5, xlims = (-3, 3))
     @test PlotsBase.xlims(pl) == (-3, 3)


### PR DESCRIPTION
## Description

Fixes #5738 

`xticks` = 5 computes 5 ticks but some fall outside the axis limits and get clipped, so fewer show up:

```julia
julia> p = plot(sin, -π, π, xticks = 5);
julia> PlotsBase.get_ticks(p[1], :x)      # ([-4.0, -2.0, 0.0, 2.0, 4.0], ...)
julia> PlotsBase.axis_limits(p[1], :x)    # (-3.33, 3.33) → only 3 drawn
```

`optimize_ticks` returns the wider span it needs (`strict_span` = false) as its 2nd/3rd value & the code dropped it. It was assigned back to `axis[:lims]` until #3346 commented the line out during the colorbar refactor (I believe it is not intentional).

`axis_limits` now expands to that span, and `get_ticks` lays ticks out over the unexpanded limits (`expand_int_ticks = false`), so they always fit. Otherwise the two are mutually dependent & disagree on log scales. Both paths share `optimize_int_ticks` so they can't drift apart again. 

_**Skipped when explicit lims are given, on polar and on discrete axes.**_

Also fixes swapped parameters in `get_ticks(ticks::Int, dvals, cvals, ...)`, which returned tick positions and labels the wrong way round on discrete axes.

Note: an exact count of round ticks can widen limits noticeably (`xticks = 8` on sin gives (-10, 4)). `colorbar_ticks::Int` has the same clipping issue but needs a different fix, since expanding clims would change the colors.

## Attribution
- [x] I am listed in the appropriate version of `.zenodo.json` for [#5756 & #5757]
