### PR TITLE
fix `aspect_ratio` corrupting 3D axis limits

### DIFF
--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -163,7 +163,7 @@ function Commons.axis_limits(
             !has_user_lims &&
                 consider_aspect &&
                 letter in (:x, :y) &&
-                !(aspect_ratio ≡ :none || RecipesPipeline.is3d(:sp))
+                !(aspect_ratio ≡ :none || RecipesPipeline.is3d(sp))
         )
         aspect_ratio = aspect_ratio isa Number ? aspect_ratio : 1
         area = PlotsBase.plotarea(sp)

--- a/PlotsBase/test/test_axes.jl
+++ b/PlotsBase/test/test_axes.jl
@@ -141,6 +141,22 @@ end
 @testset "3D Axis" begin
     ql = quiver([1, 2], [2, 1], [3, 4], quiver = ([1, -1], [0, 0], [1, -0.5]), arrow = true)
     @test ql[1][:projection] == "3d"
+
+    @testset "#3419 - `aspect_ratio` must not alter 3D limits" begin
+        # `RecipesPipeline.is3d(:sp)` dispatched on a `Symbol` and so always returned
+        # `false`, letting the *2D* aspect correction - which derives its factor from the
+        # plot area's pixel width / height - leak into 3D subplots and silently widen the
+        # `x` / `y` limits.
+        x, y = range(0, 10, length = 10), range(0, 1, length = 10)
+        z = [xi * yi for xi in x, yi in y]
+        for ar in (:none, :equal, 1)
+            pl = surface(x, y, z, aspect_ratio = ar)
+            PlotsBase.prepare_output(pl)  # `plotarea` is degenerate until laid out
+            @test PlotsBase.xlims(pl) == (0, 10)
+            @test PlotsBase.ylims(pl) == (0, 1)
+            @test PlotsBase.zlims(pl) == (0, 10)
+        end
+    end
 end
 
 @testset "Twinx" begin


### PR DESCRIPTION
## Description

`axis_limits` passes the symbol `:sp` rather than the subplot:

```julia
!(aspect_ratio ≡ :none || RecipesPipeline.is3d(:sp))
```

`is3d(::Symbol)` resolves to `is3d(Val{:sp})` and hits the `is3d(st) = false` fallback, so
the guard never fires for 3D. The 2D aspect correction then runs on 3D subplots, widening
their x/y limits by a factor computed from the plot area's pixel width and height:

```julia
julia> using PlotsBase; import GR; gr()

julia> x, y = range(0, 10, length = 10), range(0, 1, length = 10);

julia> z = [xi * yi for xi in x, yi in y];

julia> pl = surface(x, y, z, aspect_ratio = :equal); PlotsBase.prepare_output(pl);

julia> PlotsBase.ylims(pl)
(-2.750533194953867, 3.750533194953867)
```

The y data spans 0 to 1. Nothing downstream uses these limits to set 3D box proportions,
so the widening shows up only as wrong ranges and ticks. I think this is what's behind
#3419, where x and y come out equalized against each other and z doesn't.

`is3d(sp::Subplot)` is defined in `Commons`, so `is3d(sp)` looks like what was meant.

This doesn't make `aspect_ratio` do anything useful in 3D, it just stops it doing damage.
#4148 is the PR for the former and this shouldn't conflict with it.

The test needs `prepare_output`, as `plotarea` is empty until the plot is laid out. It
fails without the one character change and passes with it. Full `test_axes.jl` passes
locally, runic clean.

Same typo is on `master` at `Plots/src/axes.jl:758`. Happy to open that one too.

## Attribution
- [x] I am listed in the appropriate version of `.zenodo.json`

Left out to keep the diff small, can add it here if you want.

## Things to consider
- [x] Does it work on log scales?
- [x] Does it work in layouts?
- [x] Does it work in recipes?
- [x] Does it work with multiple series in one call?
- [x] PR includes or updates tests?
- [ ] PR includes or updates documentation?

Checked each of these against a 3D subplot with `aspect_ratio` in `(:none, :equal, 1)`,
comparing limits to the same plot with no `aspect_ratio` set:

- `zscale = :log10`: limits identical, the log path is upstream of this block
- two 3D subplots in a `(1,2)` layout, which have different `plotarea`s and so used to
  drift apart from each other: both now match their references
- `aspect_ratio --> 1` set from inside a recipe rather than as a kwarg: unchanged
- multi series 3D call: unchanged

Also checked the other direction, that 2D is untouched. `plot(x, y, aspect_ratio = :equal)`
still widens ylims from `(-0.03, 1.03)` to `(-3.021, 4.021)` exactly as before.

No docs change: `aspect_ratio` is documented for the 2D case only, and that behaviour is
unchanged.
