### PR TITLE
fix `aspect_ratio` corrupting 3D axis limits (v1)

### DIFF
--- a/Plots/src/axes.jl
+++ b/Plots/src/axes.jl
@@ -755,7 +755,7 @@ function axis_limits(
             !has_user_lims &&
                 consider_aspect &&
                 letter in (:x, :y) &&
-                !(aspect_ratio === :none || RecipesPipeline.is3d(:sp))
+                !(aspect_ratio === :none || RecipesPipeline.is3d(sp))
         )
         aspect_ratio = aspect_ratio isa Number ? aspect_ratio : 1
         area = plotarea(sp)

--- a/Plots/test/test_axes.jl
+++ b/Plots/test/test_axes.jl
@@ -136,6 +136,22 @@ end
 @testset "3D Axis" begin
     ql = quiver([1, 2], [2, 1], [3, 4], quiver = ([1, -1], [0, 0], [1, -0.5]), arrow = true)
     @test ql[1][:projection] == "3d"
+
+    @testset "#3419 - `aspect_ratio` must not alter 3D limits" begin
+        # `RecipesPipeline.is3d(:sp)` dispatched on a `Symbol` and so always returned
+        # `false`, letting the *2D* aspect correction - which derives its factor from the
+        # plot area's pixel width / height - leak into 3D subplots and silently widen the
+        # `x` / `y` limits.
+        x, y = range(0, 10, length = 10), range(0, 1, length = 10)
+        z = [xi * yi for xi in x, yi in y]
+        for ar in (:none, :equal, 1)
+            pl = surface(x, y, z, aspect_ratio = ar)
+            Plots.prepare_output(pl)  # `plotarea` is degenerate until laid out
+            @test Plots.xlims(pl) == (0, 10)
+            @test Plots.ylims(pl) == (0, 1)
+            @test Plots.zlims(pl) == (0, 10)
+        end
+    end
 end
 
 @testset "Twinx" begin


### PR DESCRIPTION
## Description

Backport of #5774 to the v1 line. Same one character change, at `Plots/src/axes.jl:758`.

`axis_limits` passes the symbol `:sp` rather than the subplot:

```julia
!(aspect_ratio === :none || RecipesPipeline.is3d(:sp))
```

`is3d(::Symbol)` resolves to `is3d(Val{:sp})` and hits the `is3d(st) = false` fallback, so
the guard never fires for 3D. The 2D aspect correction then runs on 3D subplots, widening
their x/y limits by a factor computed from the plot area's pixel width and height:

```julia
julia> using Plots; gr()

julia> x, y = range(0, 10, length = 10), range(0, 1, length = 10);

julia> z = [xi * yi for xi in x, yi in y];

julia> pl = surface(x, y, z, aspect_ratio = :equal); Plots.prepare_output(pl);

julia> Plots.ylims(pl)
(-2.750533194953867, 3.750533194953867)
```

The y data spans 0 to 1. Nothing downstream uses these limits to set 3D box proportions,
so the widening shows up only as wrong ranges and ticks.

Note this does not make `aspect_ratio` do anything useful in 3D, it only stops it doing
damage. #4148 is the PR for the former.

Worth having on v1 given 2.0 isn't released yet.

## Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json`

Left out to keep the diff small, can add it here if you want.

## Things to consider
- [x] Does it work on log scales?
- [x] Does it work in layouts?
- [x] Does it work in recipes?
- [x] Does it work with multiple series in one call?
- [x] PR includes or updates tests?
- [ ] PR includes or updates documentation?

Checked each against a 3D subplot with `aspect_ratio` in `(:none, :equal, 1)`, comparing
limits to the same plot with no `aspect_ratio` set: `zscale = :log10`, two 3D subplots in a
`(1,2)` layout (they have different `plotarea`s so used to drift apart), `aspect_ratio --> 1`
set from inside a recipe, and a multi series 3D call. All unchanged.

Also checked that 2D is untouched: `plot(x, y, aspect_ratio = :equal)` still widens ylims
from `(-0.03, 1.03)` to `(-3.021, 4.021)` as before.

No docs change, `aspect_ratio` is documented for the 2D case only and that is unchanged.
