### PR TITLE
set `scene.aspectmode` for 3D `plotly` subplots

### DIFF
--- a/PlotsBase/src/plotly.jl
+++ b/PlotsBase/src/plotly.jl
@@ -259,6 +259,10 @@ function shrink_by(lo, sz, ratio)
 end
 
 function plotly_apply_aspect_ratio(sp::Subplot, plotarea, pcts)
+    # a 3D scene's box proportions come from `scene.aspectmode` (see `plotly_scene_aspect`),
+    # not from shrinking the domain rectangle it is drawn into - the ratio below is derived
+    # from the `x`/`y` data ranges alone and is meaningless under a 3D projection
+    RecipesPipeline.is3d(sp) && return pcts
     if (aspect_ratio = get_aspect_ratio(sp)) ≢ :none
         aspect_ratio ≡ :equal && (aspect_ratio = 1.0)
         xmin, xmax = axis_limits(sp, :x)
@@ -369,6 +373,46 @@ function plotly_polaraxis(sp::Subplot, axis::Axis)
     return ax
 end
 
+"""
+    plotly_scene_aspect(sp::Subplot)
+
+`plotly.js` defaults `scene.aspectmode` to `"auto"`, which proportions the 3D box to the
+data but falls back to `"cube"` once one axis spans more than four times the two others.
+That data dependent switch makes `plotly` the only backend whose 3D box proportions depend
+on the data: `GR` (`GR.setwindow3d`) and `PythonPlot` (`set_box_aspect`) always draw a cube
+unless told otherwise. Set the mode explicitly so the default no longer varies with the data.
+
+`aspect_ratio` maps onto `"manual"` rather than `"data"`. Despite its documentation,
+`plotly` derives `"data"` from the extent of the traces and ignores user `xlims`/`ylims`/
+`zlims`, so an explicitly limited subplot would silently get a box that does not match its
+own axes.
+"""
+function plotly_scene_aspect(sp::Subplot)
+    manual(x, y, z) =
+        KW(:aspectmode => "manual", :aspectratio => KW(:x => x, :y => y, :z => z))
+
+    ar = get_aspect_ratio(sp)
+    ar ≡ :equal && (ar = 1)
+    return if ar isa AbstractVector && length(ar) == 3
+        manual(ar...)  # matches `PythonPlot`'s `set_box_aspect(ratio)`
+    elseif ar isa Number && ar == 1
+        # equal units on every axis: size the box by the axis spans themselves, measured
+        # in the same scale `plotly_axis` reports the range in, so that a `:log10` axis is
+        # compared by decades rather than by its raw data span
+        spans = map((:x, :y, :z)) do letter
+            axis = sp[get_attr_symbol(letter, :axis)]
+            scale = RecipesPipeline.scale_func(axis[:scale])
+            amin, amax = axis_limits(sp, letter)
+            scale(amax) - scale(amin)
+        end
+        manual((spans ./ maximum(spans))...)
+    else
+        # `:none` (i.e. the `:auto` default) and numeric ratios, which have no meaning for
+        # a 3D box - see JuliaPlots/Plots.jl#4148 for `aspect_ratio` support in 3D
+        KW(:aspectmode => "cube")
+    end
+end
+
 function plotly_layout(plt::Plot)
     plotattributes_out = KW()
 
@@ -432,6 +476,7 @@ function plotly_layout(plt::Plot)
                     Symbol("xaxis$(spidx)") => plotly_axis(sp[:xaxis], sp),
                     Symbol("yaxis$(spidx)") => plotly_axis(sp[:yaxis], sp),
                     Symbol("zaxis$(spidx)") => plotly_axis(sp[:zaxis], sp),
+                    plotly_scene_aspect(sp)...,
 
                     #2.6 multiplier set camera eye such that whole plot can be seen
                     :camera => KW(

--- a/PlotsBase/test/test_plotly.jl
+++ b/PlotsBase/test/test_plotly.jl
@@ -64,6 +64,73 @@ Sys.isunix() && with(:plotly) do
         @test PlotsBase.plotly_layout(pl)[:test] == "me"
     end
 
+    @testset "3D scene aspect" begin
+        scene(pl) = PlotsBase.plotly_layout(pl)[:scene]
+
+        @testset "#5044 - default is data independent" begin
+            # `plotly.js` defaults `scene.aspectmode` to `"auto"`, which proportions the box
+            # to the data ranges but flips to `"cube"` once one axis spans more than 4x the
+            # two others - so the same code produced different boxes for different data
+            for zmax in (1, 2, 5, 100)  # crosses the `"auto"` 4x threshold
+                pl = plot(1:3, 1:3, range(0, zmax, length = 3))
+                @test scene(pl)[:aspectmode] == "cube"  # as `GR` and `PythonPlot` do
+            end
+        end
+
+        @testset "`aspect_ratio = :equal`" begin
+            # the box must follow the *axis limits*, so that one data unit is the same
+            # length on each axis. `"data"` cannot express this: `plotly` computes it from
+            # the traces and ignores these limits
+            for ar in (:equal, 1, 1 // 1, true)
+                sc = scene(
+                    plot(
+                        1:3, 1:3, 1:3;
+                        aspect_ratio = ar, xlims = (0, 10), ylims = (0, 5), zlims = (0, 1),
+                    ),
+                )
+                @test sc[:aspectmode] == "manual"
+                @test sc[:aspectratio][:x] ≈ 1
+                @test sc[:aspectratio][:y] ≈ 0.5
+                @test sc[:aspectratio][:z] ≈ 0.1
+            end
+            # equal limits collapse to a cube, matching `GR`
+            sc = scene(
+                plot(
+                    1:3, 1:3, 1:3;
+                    aspect_ratio = :equal, xlims = (0, 4), ylims = (1, 5), zlims = (-2, 2),
+                ),
+            )
+            @test sc[:aspectratio][:x] ≈ sc[:aspectratio][:y] ≈ sc[:aspectratio][:z] ≈ 1
+
+            @testset "log scales are measured in decades" begin
+                # `plotly_axis` reports a `:log10` range already scaled, so the box has to
+                # be sized the same way - a raw data span would stretch it by orders of
+                # magnitude (x here spans 3 decades, not 999 units)
+                sc = scene(
+                    plot(
+                        [1, 1000], [0, 1], [0, 1];
+                        seriestype = :surface, xscale = :log10, aspect_ratio = :equal,
+                    ),
+                )
+                @test collect(sc[:xaxis][:range]) ≈ [0, 3]
+                @test sc[:aspectratio][:x] / sc[:aspectratio][:y] ≈ 3
+            end
+        end
+
+        @testset "explicit `aspect_ratio`" begin
+            @test scene(plot(1:3, 1:3, 1:3, aspect_ratio = :none))[:aspectmode] == "cube"
+
+            sc = scene(plot(1:3, 1:3, 1:3, aspect_ratio = [1, 2, 3]))
+            @test sc[:aspectmode] == "manual"
+            @test sc[:aspectratio][:x] == 1
+            @test sc[:aspectratio][:y] == 2
+            @test sc[:aspectratio][:z] == 3
+        end
+
+        # 2D subplots have no `scene`
+        @test !haskey(PlotsBase.plotly_layout(plot(1:3, aspect_ratio = :equal)), :scene)
+    end
+
     @testset "Requirejs" begin
         pl = plot(sin, 0, 2pi)
         io = PipeBuffer()


### PR DESCRIPTION
## Description

The 3D scene layout never sets `aspectmode`:

```julia
julia> sort(collect(keys(Plots.plotly_layout(plot(1:3, 1:3, 1:3))[:scene])))
4-element Vector{Symbol}:  :camera, :domain, :xaxis, :yaxis, :zaxis
```

so plotly.js applies its own default of [`"auto"`](https://plotly.com/javascript/reference/layout/scene/): proportion the box to the data, except when one axis spans more than 4x the two others, where it silently falls back to `"cube"`.

That makes `plotly` the only backend whose 3D box proportions depend on the data. `GR` always cubes, since `GR.setwindow3d` maps the window onto a fixed cube, so these two render pixel identically apart from the tick labels:

```julia
gr(); t = range(0, 2pi, length = 200)
plot(cos.(t), sin.(t), range(0, 10, length = 200))   # z spans 10
plot(cos.(t), sin.(t), range(0,  1, length = 200))   # z spans 1
```

`PythonPlot` likewise cubes unless `aspect_ratio` says otherwise (`set_box_aspect`). So the same code changes proportions when you switch backends, and on `plotly` the 4x threshold flips mode without anything in the code saying so.

### Change

`plotly_scene_aspect` sets the mode explicitly:

| `get_aspect_ratio(sp)` | result |
| --- | --- |
| `:none` (the `:auto` default) | `"cube"`, matching `GR` and `PythonPlot` |
| `:equal`, `1` | `"manual"` with `aspectratio` taken from the axis spans |
| 3-element vector | `"manual"` with that ratio, mirroring `PythonPlot`'s `set_box_aspect` |

`:equal` deliberately does **not** map to `"data"`. Despite its documentation, plotly derives `"data"` from the extent of the traces and ignores `xlims`/`ylims`/`zlims`, so an explicitly limited subplot gets a box that does not match its own axes. Rendering a sphere whose data spans 2:2:2 inside limits 8:3.2:3.2, measured as the width/height of the silhouette (1.000 means true equal scale):

| `aspectmode` | sphere w/h |
| --- | --- |
| `"data"` | 0.820 |
| `"cube"` | 0.820 |
| `"manual"`, ratio from the limits | **1.000** |

Spans are measured through the axis's own `scale_func`, so a `:log10` axis is compared by decades. Measuring the raw data span instead stretched the box by orders of magnitude: x over `1 .. 1000` produced `aspectratio = (1.0, 0.001, 0.001)` rather than `(1.0, 0.333, 0.333)`.

Also skips `plotly_apply_aspect_ratio` for 3D subplots. It shrinks the scene's domain rectangle by a ratio derived from the x/y data ranges alone, which means nothing under a 3D projection, and it threw a `MethodError` on a vector `aspect_ratio`.

### Two things worth flagging

**This changes existing 3D `plotly` output.** The default becomes a cube rather than data proportional, and `aspect_ratio = :equal` becomes manual-from-limits rather than plotly's `"auto"`. Both are deliberate, but they are visible changes and deserve a maintainer opinion.

**`GR` still ignores `aspect_ratio` in 3D.** It has no box aspect control, so `:equal` remains `plotly` only until something like #4148 equalises the limits instead. This does not by itself close #3419 for every backend.

### Tests

`test_plotly.jl` gains a `3D scene aspect` testset: the data independent default across the 4x threshold, `:equal` pinned to the actual ratio numbers rather than just the mode string, the log scale case, the vector form, and that 2D subplots still have no `scene`.

Verified locally: 46 tests pass, `runic --check` clean, and every built-in example run through `plotly_layout`/`plotly_series` gives results identical to the unpatched baseline, so no regressions there.

## Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json`

## Things to consider
- [x] Does it work on log scales?
- [x] Does it work in layouts?
- [x] Does it work in recipes?
- [x] Does it work with multiple series in one call?
- [x] PR includes or updates tests?
- [ ] PR includes or updates documentation?

Log scales are covered above and by a test. Layouts and recipes reach this through the same
per subplot `get_aspect_ratio`/`axis_limits` calls as everything else, and the example sweep
covers multi series and layout cases. No docs change: `aspect_ratio` is documented for the
2D case only, and 3D remains undocumented until it works on every backend.
