### PR TITLE
Add PlotThemes to its own test project

### DIFF
--- a/PlotThemes/test/Project.toml
+++ b/PlotThemes/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+PlotThemes = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
 PlotUtils = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
## Description

`PlotThemes/test/runtests.jl` fails on every CI job with

```
ERROR: LoadError: ArgumentError: Package PlotThemes not found in current path.
```

Since 40f9c02 ("add test workspaces") `PlotThemes/Project.toml` declares `[workspace] projects = ["test"]`, which makes `PlotThemes/test` a standalone project — it no longer implicitly sees its parent package. `PlotThemes` just needs to be listed in the test project deps, as the other test workspaces (`RecipesPipeline`, `PlotsBase`, `Plots`, `GraphRecipes`) already do.

With this, `PlotThemes` tests pass again:

```
Test Summary: | Pass  Total  Time
basics        |    4      4  0.3s
```

Note this is only one of the two problems currently reddening CI on `v2`. The other is a broken conda-forge matplotlib in the `CondaPkg` env, which aborts the whole PlotsBase/Plots suite on linux and macos before any test runs and is not addressed here:

```
InitError: Python: ImportError: .../site-packages/matplotlib/../../../libraqm.so.0:
           undefined symbol: hb_ft_font_get_ft_face
```

## Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json` for [PRs against v2](https://github.com/JuliaPlots/Plots.jl/blob/v2/.zenodo.json) or [PRs against master](https://github.com/JuliaPlots/Plots.jl/blob/master/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?

Not applicable — test project metadata only, no library code touched.
