### PR TITLE
PlotsBase: fix `atreplinit` hook registration

### DIFF
--- a/PlotsBase/src/init.jl
+++ b/PlotsBase/src/init.jl
@@ -47,17 +47,18 @@ function __init__()
         PlotsDisplay(),
     )
 
-    i ->
-    begin
-        while PlotsDisplay() in Base.Multimedia.displays
-            popdisplay(PlotsDisplay())
-        end
-        insert!(
-            Base.Multimedia.displays,
-            findlast(x -> x isa REPL.REPLDisplay, Base.Multimedia.displays) + 1,
-            PlotsDisplay(),
-        )
-    end |> atreplinit
+    atreplinit(
+        i -> begin
+            while PlotsDisplay() in Base.Multimedia.displays
+                popdisplay(PlotsDisplay())
+            end
+            insert!(
+                Base.Multimedia.displays,
+                findlast(x -> x isa REPL.REPLDisplay, Base.Multimedia.displays) + 1,
+                PlotsDisplay(),
+            )
+        end,
+    )
 
     return nothing
 end


### PR DESCRIPTION
Claude:

---

The REPL-init hook in `PlotsBase.__init__` that re-inserts `PlotsDisplay` above the REPL display is written as

```julia
i ->
begin
    ...
end |> atreplinit
```

Because `|>` binds tighter than `->`, this parses as `i -> (begin ... end |> atreplinit)`: the statement builds an anonymous function that is never called, so no hook is ever registered (`Base.repl_hooks` stays empty after `using Plots`).

The hook exists to handle Plots being loaded before the REPL starts, e.g. from `startup.jl` or `julia -i -e 'using Plots'`. In that case `__init__` runs while `Base.Multimedia.displays` has no REPL display yet, the REPL display is pushed on top afterwards, and without the hook `PlotsDisplay` never moves back above it, so `plot(...)` at the REPL only prints the text summary instead of opening the GUI display.

This passes the closure to `atreplinit` directly.
