### PR TITLE
Accept a single position in `hline` and `vline`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
   The previous spellings (`colorbar_titlefont`, `colorbar_tickfontsize`, `colorbar_fontfamily`, ...) still work when setting attributes
 
 ### Fixed
+- `hline`, `vline` and their `!` forms accept a single position, so `hline(0.73)` no longer errors and
+  `vline(100)` draws one line instead of a hundred empty series (#2129)
 - GR backend: `colorbar_ticks` no longer errors with `GR ≥ 0.73.25` (`GR.drawaxis` signature change)
 - GR backend: `colorbar_formatter` is now applied (it was ignored unless `colorbar_ticks` was given explicitly)
 - PGFPlotsX backend: the colorbar now shows custom tick labels, from either `colorbar_ticks` pairs or `colorbar_formatter`

--- a/PlotsBase/src/shorthands.jl
+++ b/PlotsBase/src/shorthands.jl
@@ -196,11 +196,12 @@ julia> sticks(1:10)
     hline!(y)
 
 Draw horizontal lines at positions specified by the values in
-the AbstractVector `y`.
+the AbstractVector `y`, or at a single position for a real `y`.
 
 # Example
 ```julia-repl
 julia> hline([-1,0,2])
+julia> hline(0.73)
 ```
 """
 @shorthands hline
@@ -210,14 +211,26 @@ julia> hline([-1,0,2])
     vline!(x)
 
 Draw vertical lines at positions specified by the values in
-the AbstractVector `x`.
+the AbstractVector `x`, or at a single position for a real `x`.
 
 # Example
 ```julia-repl
 julia> vline([-1,0,2])
+julia> vline(0.73)
 ```
 """
 @shorthands vline
+
+# a lone position is the common case, and without these a real would fall through to the
+# generic single-argument recipes: a float has none, and an integer means "n empty series"
+for func in (:hline, :vline)
+    bang = Symbol(func, :!)
+    @eval begin
+        $func(v::Real, args...; kw...) = $func([v], args...; kw...)
+        $bang(v::Real, args...; kw...) = $bang([v], args...; kw...)
+        $bang(plt::Plot, v::Real, args...; kw...) = $bang(plt, [v], args...; kw...)
+    end
+end
 
 """
     hspan(y)

--- a/PlotsBase/test/test_shorthands.jl
+++ b/PlotsBase/test/test_shorthands.jl
@@ -140,3 +140,32 @@ end
     yticks!(pl, yticks, ylabels)
     @test sp.attr[:yaxis][:ticks] == (yticks, ylabels)
 end
+
+@testset "hline / vline with a scalar" begin
+    # github.com/JuliaPlots/Plots.jl/issues/2129
+    xy(pl, i = 1) = (pl.series_list[i][:x], pl.series_list[i][:y])
+
+    for v in (0.73, 3, -2, 1 // 2, 2.5f0), f in (hline, vline)
+        pl = f(v)
+        @test length(pl.series_list) == 1
+        @test isequal(xy(pl), xy(f([v])))  # `isequal`, the separators are `NaN`
+    end
+
+    # an integer used to fall through to "add `n` empty series", so `vline(100)`
+    # drew a hundred lines instead of one
+    @test length(vline(100).series_list) == 1
+    @test all(==(100.0), filter(isfinite, xy(vline(100))[1]))
+    @test all(==(3.0), filter(isfinite, xy(hline(3))[2]))
+
+    # `plot(n)` still means `n` empty series
+    @test length(plot(3).series_list) == 3
+
+    pl = plot(1:5)
+    hline!(pl, 2.5)
+    vline!(pl, 3.5)
+    @test length(pl.series_list) == 3
+
+    plot(1:5)
+    hline!(2.5)
+    @test length(PlotsBase.current().series_list) == 2
+end

--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ This is the DOI for all Versions, please follow the link to get the DOI for a sp
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4725317.svg)](https://doi.org/10.5281/zenodo.4725317)
 
 This is the `Plots.jl` [monorepo](https://en.wikipedia.org/wiki/Monorepo) hosting the julia package `Plots`, its dependencies/subpackages : `RecipesBase`, `RecipesPipeline`, `PlotsBase`, and tools built on tops of `Plots` such as `GraphRecipes` and `StatsPlots`.
+


### PR DESCRIPTION
Closes #2129.

`hline(0.73)` errored with "No user recipe defined for Float64". An integer was worse than an error: it fell through to `@recipe f(n::Integer)` in RecipesPipeline, which adds `n` empty series, so `vline(100)` drew a hundred lines (reported on the thread in Nov 2024).

This is the scoped version AshtonSBradley suggested on the issue: `Real` methods on the four shorthands only, so a lone position wraps itself in a vector before it can reach the generic single-argument recipes. `plot(n)` is untouched and still adds `n` empty series, so the Lorenz example in the docs that daschw flagged keeps working.

One thing to rule on before merging. This changes what an integer means for these two functions specifically: `vline(3)` used to add three empty series and now draws one line at `x = 3`. I think that is the bug rather than a feature, and it is what the last comment on the issue reports, but it is a behaviour change and it is your call. If you would rather keep integers out of it, dispatching on `AbstractFloat` instead of `Real` fixes the reported case and leaves `vline(3)` alone, at the cost of `hline(1)` and `hline(1.0)` doing different things.

The broader change yha and AshtonSBradley discussed, dropping the integer to empty series recipe entirely, is not here: that one is genuinely breaking and needs its own decision.

## Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json` for [PRs against v2](https://github.com/JuliaPlots/Plots.jl/blob/v2/.zenodo.json) or [PRs against master](https://github.com/JuliaPlots/Plots.jl/blob/master/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [x] Does it work on log scales? The position is passed through unchanged, the recipes are the same ones a vector goes through
- [x] Does it work in layouts? `hline!(plt, v)` with an explicit plot has its own method and is tested
- [x] Does it work in recipes? No recipe surface, these are shorthand methods
- [x] Does it work with multiple series in one call? Vectors are unchanged, a scalar is just a one element vector
- [x] PR includes or updates tests? New testset in `test_shorthands.jl` checking scalar and one element vector agree for `Float64`, `Int`, `Rational` and `Float32`, both bang forms, and that `plot(3)` still gives three series
- [x] PR includes or updates documentation? Docstrings for `hline` and `vline` mention the scalar form, plus a NEWS entry
