### PR TITLE
Fix duplicated log scale minor ticks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
   The previous spellings (`colorbar_titlefont`, `colorbar_tickfontsize`, `colorbar_fontfamily`, ...) still work when setting attributes
 
 ### Fixed
+- Log scale minor ticks are no longer duplicated, and no longer drawn on top of major ticks, when the
+  major ticks are more than one decade apart (#5789)
 - `hline`, `vline`, `hspan`, `vspan` and their `!` forms accept a single position, so `hline(0.73)` no
   longer errors and `vline(100)` draws one line instead of a hundred empty series (#2129).
   This is handled in the pipeline, so it also covers `plot(0.73; seriestype = :vline)` and a recipe

--- a/PlotsBase/src/Ticks.jl
+++ b/PlotsBase/src/Ticks.jl
@@ -93,12 +93,17 @@ function get_minor_ticks(sp, axis, ticks_and_labels)
         hi = ticks[i]
         (isfinite(lo) && isfinite(hi) && hi > lo) || continue
         if log_scaled
-            for e in 1:sub
+            # a pair can span several decades, and the phantom pairs added above span
+            # exactly one, so the count has to be taken per pair rather than once for
+            # the whole axis
+            for e in 1:round(Int, log(base, hi / lo))
                 lo_ = lo * base^(e - 1)
                 hi_ = lo_ * base
                 step = (hi_ - lo_) / n_minor_intervals
-                rng = (lo_ + (e > 1 ? 0 : step)):step:(hi_ - (e < sub ? 0 : step / 2))
-                append!(minorticks, collect(rng))
+                # a decade boundary inside the pair is itself a minor tick, the ones
+                # bounding the pair are major ticks
+                e > 1 && push!(minorticks, lo_)
+                append!(minorticks, collect((lo_ + step):step:(hi_ - step / 2)))
             end
         else
             step = (hi - lo) / n_minor_intervals

--- a/PlotsBase/test/test_axes.jl
+++ b/PlotsBase/test/test_axes.jl
@@ -336,6 +336,38 @@ end
     end
 end
 
+@testset "log minor ticks" begin
+    # github.com/JuliaPlots/Plots.jl/issues/5789
+    function minors(ylims, yticks; kw...)
+        pl = plot([1, 1]; yscale = :log10, minorgrid = true, ylims, yticks, kw...)
+        sp = first(pl)
+        t = PlotsBase.get_ticks(sp, sp[:yaxis], update = false)
+        first(t), PlotsBase.get_minor_ticks(sp, sp[:yaxis], t)
+    end
+
+    for (lims, ticks) in (
+            ((1, 1000), [1, 10, 100, 1000]),          # majors one decade apart
+            ((1, 10_000), [1, 100, 10_000]),          # two
+            ((1, 1_000_000), [1, 1000, 1_000_000]),   # three
+        )
+        majors, mt = minors(lims, ticks)
+        @test allunique(mt)
+        @test !any(x -> any(m -> isapprox(x, m; rtol = 1.0e-9), majors), mt)
+    end
+
+    # a decade boundary between two majors is a minor tick, and `:auto` still puts the
+    # usual eight in a decade
+    majors, mt = minors((1, 10_000), [1, 100, 10_000])
+    @test 10 ∈ mt
+    @test 1000 ∈ mt
+    _, mt = minors((1, 1000), [1, 10, 100, 1000])
+    @test count(x -> 1 < x < 10, mt) == 8
+    for n in (1, 3)
+        _, mt = minors((1, 1000), [1, 10, 100, 1000]; yminorticks = n)
+        @test count(x -> 1 < x < 10, mt) == n
+    end
+end
+
 @testset "axis guides (labels)" begin
     yguide(pl, idx = length(pl.subplots)) = PlotsBase.get_guide(pl.subplots[idx].attr[:yaxis])
 


### PR DESCRIPTION
Closes #5789.

`sub` was taken from the first two major ticks and then applied to every pair, including the phantom pairs added for the axis limits, which only span one decade. Those ran past their own `hi` into the next pair and emitted the same positions twice. The range also started exactly on the decade boundary for `e > 1`, so a major tick came back as a minor one.

Counting the decades per pair fixes both, and the interior decade boundaries are still kept as minor ticks. For majors at `[1, 100, 10000]`: 46 ticks with 11 duplicates before, 34 with none after.

## Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json` for [PRs against v2](https://github.com/JuliaPlots/Plots.jl/blob/v2/.zenodo.json) or [PRs against master](https://github.com/JuliaPlots/Plots.jl/blob/master/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [x] Does it work on log scales? That is the fix
- [x] Does it work in layouts? Reference images 68/68
- [x] Does it work in recipes? No recipe surface
- [x] Does it work with multiple series in one call? Ticks are per axis
- [x] PR includes or updates tests? New `log minor ticks` testset in `test_axes.jl` for one, two and three decade spacing
- [x] PR includes or updates documentation? NEWS entry
