### PR TITLE
Replace `widen` with a composable `limits_modifiers` axis attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,10 @@
   as with the other backends, and `colorbar_scale` now maps the colors, not just the tick labels
 
 ## Breaking changes
+- The `widen` axis attribute is replaced by `limits_modifiers`, which composes: `:widen`, `:round` and
+  `:symmetric` can be combined in a tuple and are applied left to right, as in
+  `xlimits_modifiers = (:widen, :round)`. A custom widening factor is written `:widen => 1.2`, and
+  `:none` applies nothing. `widen` still works with a deprecation warning and will be removed in v3 (#3556)
 - `minorticks` now counts minor ticks, not minor intervals, matching its name and its documentation.
   `minorticks = n` draws `n` ticks between two major ticks, where it used to draw `n - 1`.
   Passing `n + 1` where you passed `n` restores the old spacing; `:auto` and `true` are unchanged.

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,10 +30,10 @@
   as with the other backends, and `colorbar_scale` now maps the colors, not just the tick labels
 
 ## Breaking changes
-- The `widen` axis attribute is replaced by `limits_modifiers`, which composes: `:widen`, `:round` and
-  `:symmetric` can be combined in a tuple and are applied left to right, as in
-  `xlimits_modifiers = (:widen, :round)`. A custom widening factor is written `:widen => 1.2`, and
-  `:none` applies nothing. `widen` still works with a deprecation warning and will be removed in v3 (#3556)
+- The `widen` axis attribute is replaced by `limits_modifiers`, which composes. It takes a named tuple
+  of modifiers applied left to right, as in `xlimits_modifiers = (symmetric = true, widen = 1.2)`;
+  `:widen`, `:round` and `:symmetric` are available, a bare name switches one on, and `:none` applies
+  nothing. The default `:auto` behaves as `widen = :auto` did (#3556)
 - `minorticks` now counts minor ticks, not minor intervals, matching its name and its documentation.
   `minorticks = n` draws `n` ticks between two major ticks, where it used to draw `n - 1`.
   Passing `n + 1` where you passed `n` restores the old spacing; `:auto` and `true` are unchanged.

--- a/PlotThemes/src/ggplot2.jl
+++ b/PlotThemes/src/ggplot2.jl
@@ -36,7 +36,7 @@ const _ggplot2 = [
     :bglegend => _ggplot_colors[:gray92],
     :fglegend => :white,
     :fgguide => :black,
-    :widen => true,
+    :limits_modifiers => :widen,
     ## Axes / Ticks
     #framestyle => :grid,
     #foreground_color_tick => _ggplot_colors[:gray20], # tick color not yet implemented

--- a/PlotsBase/ext/GRExt.jl
+++ b/PlotsBase/ext/GRExt.jl
@@ -62,7 +62,7 @@ const _gr_attrs = PlotsBase.merge_with_base_supported(
         :title,
         :window_title,
         :guide,
-        :widen,
+        :limits_modifiers,
         :lims,
         :ticks,
         :scale,

--- a/PlotsBase/ext/GastonExt.jl
+++ b/PlotsBase/ext/GastonExt.jl
@@ -46,7 +46,7 @@ const _gaston_attrs = PlotsBase.merge_with_base_supported(
         :window_title,
         :guide,
         :guide_position,
-        :widen,
+        :limits_modifiers,
         :lims,
         :ticks,
         :scale,

--- a/PlotsBase/ext/HDF5Ext.jl
+++ b/PlotsBase/ext/HDF5Ext.jl
@@ -61,7 +61,7 @@ const _hdf5_attrs = PlotsBase.merge_with_base_supported(
         :titlefont,
         :window_title,
         :guide,
-        :widen,
+        :limits_modifiers,
         :lims,
         :ticks,
         :scale,

--- a/PlotsBase/ext/PGFPlotsXExt.jl
+++ b/PlotsBase/ext/PGFPlotsXExt.jl
@@ -66,7 +66,7 @@ const _pgfplotsx_attrs = PlotsBase.merge_with_base_supported(
         :title,
         :window_title,
         :guide,
-        :widen,
+        :limits_modifiers,
         :lims,
         :ticks,
         :scale,

--- a/PlotsBase/ext/PythonPlotExt.jl
+++ b/PlotsBase/ext/PythonPlotExt.jl
@@ -122,7 +122,7 @@ const _pythonplot_attrs = PlotsBase.merge_with_base_supported(
         :window_title,
         :guide,
         :guide_position,
-        :widen,
+        :limits_modifiers,
         :lims,
         :ticks,
         :scale,

--- a/PlotsBase/ext/UnicodePlotsExt.jl
+++ b/PlotsBase/ext/UnicodePlotsExt.jl
@@ -25,7 +25,7 @@ const _unicodeplots_attrs = PlotsBase.merge_with_base_supported(
         :annotations,
         :bins,
         :guide,
-        :widen,
+        :limits_modifiers,
         :grid,
         :label,
         :layout,

--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -246,19 +246,15 @@ function auto_limits_modifiers(axis::Axis)
 end
 
 """
-    limits_modifiers(axis)
-    limits_modifiers(axis, spec)
+    normalize_limits_modifiers(letter, spec)
 
-Resolve `limits_modifiers` into the named tuple of modifiers `axis_limits` folds over, left to
-right. Resolving an already resolved chain returns it unchanged.
+Validate `spec` and put it in the canonical form: a named tuple of the modifiers that are
+switched on, in the order they should be applied, or `:auto`. Warns about, and drops,
+anything invalid. `preprocess_attributes!` runs this once so `axis_limits` does not have to.
 """
-limits_modifiers(axis::Axis) = limits_modifiers(axis, axis[:limits_modifiers])
-
 # `(symmetric = true, widen = 1.2)`: named tuples keep their order, so the chain reads left
-# to right, and a modifier that takes a setting carries it as its value. Resolving drops the
-# invalid and the switched off, so resolving a resolved chain is a no-op.
-function limits_modifiers(axis::Axis, spec::NamedTuple)
-    letter = axis[:letter]
+# to right, and a modifier that takes a setting carries it as its value
+function normalize_limits_modifiers(letter, spec::NamedTuple)
     keep = filter(keys(spec)) do m
         valid_limits_modifier(letter, m) &&
             valid_limits_setting(letter, m, spec[m]) &&
@@ -267,18 +263,35 @@ function limits_modifiers(axis::Axis, spec::NamedTuple)
     return NamedTuple{keep}(spec)
 end
 # a bare modifier name is shorthand for switching it on
-limits_modifiers(axis::Axis, spec::Tuple{Vararg{Symbol}}) =
-    limits_modifiers(axis, NamedTuple{spec}(ntuple(_ -> true, length(spec))))
-limits_modifiers(axis::Axis, spec::Symbol) =
+normalize_limits_modifiers(letter, spec::Tuple{Vararg{Symbol}}) =
+    normalize_limits_modifiers(letter, NamedTuple{spec}(ntuple(_ -> true, length(spec))))
+normalize_limits_modifiers(letter, spec::Symbol) =
 if spec ≡ :auto
-    auto_limits_modifiers(axis)
+    :auto  # resolved per axis, it depends on the limits and the series types
 elseif spec ≡ :none
     (;)
 else
-    limits_modifiers(axis, (spec,))
+    normalize_limits_modifiers(letter, (spec,))
 end
-limits_modifiers(::Axis, ::Nothing) = (;)
-limits_modifiers(axis::Axis, spec) = (warn_invalid_modifier(axis[:letter], spec); (;))
+normalize_limits_modifiers(::Any, ::Nothing) = (;)
+normalize_limits_modifiers(letter, spec) = (warn_invalid_modifier(letter, spec); (;))
+
+"""
+    limits_modifiers(axis)
+    limits_modifiers(axis, spec)
+
+The named tuple of modifiers `axis_limits` folds over, left to right. Only `:auto` needs
+resolving here, everything else was normalized by `preprocess_attributes!`.
+"""
+limits_modifiers(axis::Axis) = limits_modifiers(axis, axis[:limits_modifiers])
+# already normalized, which is the usual case
+limits_modifiers(::Axis, spec::NamedTuple) = spec
+limits_modifiers(axis::Axis, spec::Symbol) =
+    spec ≡ :auto ? auto_limits_modifiers(axis) :
+    limits_modifiers(axis, normalize_limits_modifiers(axis[:letter], spec))
+# set straight into the defaults, by a theme or `default`, so never preprocessed
+limits_modifiers(axis::Axis, spec) =
+    limits_modifiers(axis, normalize_limits_modifiers(axis[:letter], spec))
 
 "`:widen` takes a factor, the others are on or off"
 valid_limits_setting(letter, m::Symbol, v) =

--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -224,15 +224,12 @@ end
 
 warn_invalid_modifier(letter, m) = @maxlog_warn """
 Invalid $(letter)limits modifier `$m`, ignored.
-Choose from $(_limits_modifier_names), a tuple of them, `:auto` or `:none`.
-`:widen` takes an optional factor, written `:widen => 1.2`.
+Choose from $(_limits_modifier_names), a named tuple such as `(symmetric = true, widen = 1.2)`,
+`:auto` or `:none`.
 """
 
 valid_limits_modifier(letter, m::Symbol) =
     m in _limits_modifier_names || (warn_invalid_modifier(letter, m); false)
-valid_limits_modifier(letter, m::Pair{Symbol}) =
-    # `:widen` is the only modifier taking an argument
-    (first(m) ≡ :widen && last(m) isa Real) || (warn_invalid_modifier(letter, m); false)
 valid_limits_modifier(letter, m) = (warn_invalid_modifier(letter, m); false)
 
 """
@@ -243,7 +240,7 @@ function auto_limits_modifiers(axis::Axis)
     lims = process_limits(axis[:lims], axis)
     (lims isa Tuple || lims ≡ :round) && return ()
     for sp in axis.sps, series in series_list(sp)
-        series.plotattributes[:seriestype] in _widen_seriestypes && return (:widen,)
+        series.plotattributes[:seriestype] in _widen_seriestypes && return (:widen => true,)
     end
     return ()
 end
@@ -256,9 +253,16 @@ Resolve `limits_modifiers` into the tuple of modifiers `axis_limits` folds over,
 right. Resolving an already resolved tuple returns it unchanged.
 """
 limits_modifiers(axis::Axis) = limits_modifiers(axis, axis[:limits_modifiers])
-limits_modifiers(axis::Axis, spec::Tuple) =
-    Tuple(m for m in spec if valid_limits_modifier(axis[:letter], m))
-limits_modifiers(axis::Axis, spec::Pair{Symbol}) = limits_modifiers(axis, (spec,))
+
+# `(symmetric = true, widen = 1.2)`: named tuples keep their order, so the chain reads left
+# to right, and a modifier that takes a setting carries it as its value
+limits_modifiers(axis::Axis, spec::NamedTuple) =
+    limits_modifiers(axis, Tuple(k => v for (k, v) in pairs(spec)))
+# a bare modifier name is shorthand for switching it on; resolving a resolved chain is a no-op
+limits_modifiers(axis::Axis, spec::Tuple) = Tuple(
+    p for p in map(m -> modifier_pair(axis[:letter], m), spec) if
+        p ≢ nothing && last(p) ≢ false
+)
 limits_modifiers(axis::Axis, spec::Symbol) =
 if spec ≡ :auto
     auto_limits_modifiers(axis)
@@ -267,22 +271,31 @@ elseif spec ≡ :none
 else
     limits_modifiers(axis, (spec,))
 end
-limits_modifiers(axis::Axis, spec::Bool) = spec ? (:widen,) : ()
-limits_modifiers(axis::Axis, spec::Real) = (:widen => spec,)
 limits_modifiers(::Axis, ::Nothing) = ()
 limits_modifiers(axis::Axis, spec) = (warn_invalid_modifier(axis[:letter], spec); ())
 
-apply_limits_modifier(amin, amax, m::Symbol, scale) =
-if m ≡ :widen
-    scale_lims(amin, amax, default_widen_factor[], scale)
-elseif m ≡ :round
-    round_limits(amin, amax, scale)
-else  # `:symmetric`
-    a = max(abs(amin), abs(amax))
-    (-a, a)
+"`:widen` takes a factor, the others are on or off"
+valid_limits_setting(letter, m::Symbol, v) =
+    (v isa Bool || (m ≡ :widen && v isa Real)) ||
+    (@maxlog_warn("Invalid setting `$v` for $(letter)limits modifier `$m`, ignored"); false)
+
+"normalize one entry of a chain to `modifier => setting`, or `nothing` if it is not valid"
+modifier_pair(letter, m::Symbol) = valid_limits_modifier(letter, m) ? m => true : nothing
+modifier_pair(letter, p::Pair{Symbol}) =
+    (valid_limits_modifier(letter, first(p)) && valid_limits_setting(letter, first(p), last(p))) ?
+    p : nothing
+modifier_pair(letter, m) = (warn_invalid_modifier(letter, m); nothing)
+
+function apply_limits_modifier(amin, amax, (m, v)::Pair{Symbol}, scale)
+    return if m ≡ :widen
+        scale_lims(amin, amax, v isa Bool ? default_widen_factor[] : v, scale)
+    elseif m ≡ :round
+        round_limits(amin, amax, scale)
+    else  # `:symmetric`
+        a = max(abs(amin), abs(amax))
+        (-a, a)
+    end
 end
-apply_limits_modifier(amin, amax, m::Pair{Symbol}, scale) =
-    scale_lims(amin, amax, last(m), scale)
 
 function round_limits(amin, amax, scale)
     base = get(_log_scale_bases, scale, 10.0)

--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -174,7 +174,7 @@ function Commons.axis_limits(
             amin, amax = 0, amax + 0.1abs(amax - amin)
         end
     elseif !isempty(chain)
-        for m in chain  # applied left to right
+        for m in pairs(chain)  # applied left to right
             amin, amax = apply_limits_modifier(amin, amax, m, axis[:scale])
         end
     elseif lims ≡ :round
@@ -238,53 +238,52 @@ or rounded, and only for series types that would otherwise clip at the border
 """
 function auto_limits_modifiers(axis::Axis)
     lims = process_limits(axis[:lims], axis)
-    (lims isa Tuple || lims ≡ :round) && return ()
+    (lims isa Tuple || lims ≡ :round) && return (;)
     for sp in axis.sps, series in series_list(sp)
-        series.plotattributes[:seriestype] in _widen_seriestypes && return (:widen => true,)
+        series.plotattributes[:seriestype] in _widen_seriestypes && return (widen = true,)
     end
-    return ()
+    return (;)
 end
 
 """
     limits_modifiers(axis)
     limits_modifiers(axis, spec)
 
-Resolve `limits_modifiers` into the tuple of modifiers `axis_limits` folds over, left to
-right. Resolving an already resolved tuple returns it unchanged.
+Resolve `limits_modifiers` into the named tuple of modifiers `axis_limits` folds over, left to
+right. Resolving an already resolved chain returns it unchanged.
 """
 limits_modifiers(axis::Axis) = limits_modifiers(axis, axis[:limits_modifiers])
 
 # `(symmetric = true, widen = 1.2)`: named tuples keep their order, so the chain reads left
-# to right, and a modifier that takes a setting carries it as its value
-limits_modifiers(axis::Axis, spec::NamedTuple) =
-    limits_modifiers(axis, Tuple(k => v for (k, v) in pairs(spec)))
-# a bare modifier name is shorthand for switching it on; resolving a resolved chain is a no-op
-limits_modifiers(axis::Axis, spec::Tuple) = Tuple(
-    p for p in map(m -> modifier_pair(axis[:letter], m), spec) if
-        p ≢ nothing && last(p) ≢ false
-)
+# to right, and a modifier that takes a setting carries it as its value. Resolving drops the
+# invalid and the switched off, so resolving a resolved chain is a no-op.
+function limits_modifiers(axis::Axis, spec::NamedTuple)
+    letter = axis[:letter]
+    keep = filter(keys(spec)) do m
+        valid_limits_modifier(letter, m) &&
+            valid_limits_setting(letter, m, spec[m]) &&
+            spec[m] ≢ false
+    end
+    return NamedTuple{keep}(spec)
+end
+# a bare modifier name is shorthand for switching it on
+limits_modifiers(axis::Axis, spec::Tuple{Vararg{Symbol}}) =
+    limits_modifiers(axis, NamedTuple{spec}(ntuple(_ -> true, length(spec))))
 limits_modifiers(axis::Axis, spec::Symbol) =
 if spec ≡ :auto
     auto_limits_modifiers(axis)
 elseif spec ≡ :none
-    ()
+    (;)
 else
     limits_modifiers(axis, (spec,))
 end
-limits_modifiers(::Axis, ::Nothing) = ()
-limits_modifiers(axis::Axis, spec) = (warn_invalid_modifier(axis[:letter], spec); ())
+limits_modifiers(::Axis, ::Nothing) = (;)
+limits_modifiers(axis::Axis, spec) = (warn_invalid_modifier(axis[:letter], spec); (;))
 
 "`:widen` takes a factor, the others are on or off"
 valid_limits_setting(letter, m::Symbol, v) =
     (v isa Bool || (m ≡ :widen && v isa Real)) ||
     (@maxlog_warn("Invalid setting `$v` for $(letter)limits modifier `$m`, ignored"); false)
-
-"normalize one entry of a chain to `modifier => setting`, or `nothing` if it is not valid"
-modifier_pair(letter, m::Symbol) = valid_limits_modifier(letter, m) ? m => true : nothing
-modifier_pair(letter, p::Pair{Symbol}) =
-    (valid_limits_modifier(letter, first(p)) && valid_limits_setting(letter, first(p), last(p))) ?
-    p : nothing
-modifier_pair(letter, m) = (warn_invalid_modifier(letter, m); nothing)
 
 function apply_limits_modifier(amin, amax, (m, v)::Pair{Symbol}, scale)
     return if m ≡ :widen

--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -1,6 +1,6 @@
 module Axes
 
-export Axis, Extrema, tickfont, guidefont, widen_factor, scale_inverse_scale_func
+export Axis, Extrema, tickfont, guidefont, limits_modifiers, scale_inverse_scale_func
 export sort_3d_axes, axes_letters, process_axis_arg!, has_ticks, get_axis, get_guide
 
 import ..PlotsBase: PlotsBase, Subplot, DefaultsDict
@@ -13,6 +13,9 @@ using ..Fonts
 using ..Dates
 
 const default_widen_factor = Ref(1.06)
+
+"modifiers accepted by the `limits_modifiers` axis attribute"
+const _limits_modifier_names = (:widen, :round, :symmetric)
 const _widen_seriestypes = (
     :line,
     :path,
@@ -129,7 +132,7 @@ end
 function Commons.axis_limits(
         sp,
         letter,
-        lims_factor = widen_factor(get_axis(sp, letter)),
+        modifiers = limits_modifiers(get_axis(sp, letter)),
         consider_aspect = true;
         expand_int_ticks = true,
     )
@@ -162,6 +165,7 @@ function Commons.axis_limits(
     if !isfinite(amin) && !isfinite(amax)
         amin, amax = zero(amin), one(amax)
     end
+    chain = limits_modifiers(axis, modifiers)
     if ispolar(axis.sps[1])
         if axis[:letter] ≡ :x
             amin, amax = 0, 2π
@@ -169,8 +173,10 @@ function Commons.axis_limits(
             # widen max radius so ticks dont overlap with theta axis
             amin, amax = 0, amax + 0.1abs(amax - amin)
         end
-    elseif lims_factor ≢ nothing
-        amin, amax = scale_lims(amin, amax, lims_factor, axis[:scale])
+    elseif !isempty(chain)
+        for m in chain  # applied left to right
+            amin, amax = apply_limits_modifier(amin, amax, m, axis[:scale])
+        end
     elseif lims ≡ :round
         amin, amax = round_limits(amin, amax, axis[:scale])
     end
@@ -197,11 +203,11 @@ function Commons.axis_limits(
         dist = amax - amin
 
         factor = if letter ≡ :x
-            ydist, = axis_limits(sp, :y, widen_factor(sp[:yaxis]), false) |> collect |> diff
+            ydist, = axis_limits(sp, :y, limits_modifiers(sp[:yaxis]), false) |> collect |> diff
             axis_ratio = aspect_ratio * ydist / dist
             axis_ratio / plot_ratio
         else
-            xdist, = axis_limits(sp, :x, widen_factor(sp[:xaxis]), false) |> collect |> diff
+            xdist, = axis_limits(sp, :x, limits_modifiers(sp[:xaxis]), false) |> collect |> diff
             axis_ratio = aspect_ratio * dist / xdist
             plot_ratio / axis_ratio
         end
@@ -216,26 +222,67 @@ function Commons.axis_limits(
     return amin, amax
 end
 
+warn_invalid_modifier(letter, m) = @maxlog_warn """
+Invalid $(letter)limits modifier `$m`, ignored.
+Choose from $(_limits_modifier_names), a tuple of them, `:auto` or `:none`.
+`:widen` takes an optional factor, written `:widen => 1.2`.
 """
-factor to widen axis limits by, or `nothing` if axis widening should be skipped
-"""
-function widen_factor(axis::Axis; factor = default_widen_factor[])
-    if (widen = axis[:widen]) isa Bool
-        return widen ? factor : nothing
-    elseif widen isa Number
-        return widen
-    else
-        widen ≡ :auto || @maxlog_warn "Invalid value specified for `widen`: $widen"
-    end
 
-    # automatic behavior: widen if limits aren't specified and series type is appropriate
+valid_limits_modifier(letter, m::Symbol) =
+    m in _limits_modifier_names || (warn_invalid_modifier(letter, m); false)
+valid_limits_modifier(letter, m::Pair{Symbol}) =
+    # `:widen` is the only modifier taking an argument
+    (first(m) ≡ :widen && last(m) isa Real) || (warn_invalid_modifier(letter, m); false)
+valid_limits_modifier(letter, m) = (warn_invalid_modifier(letter, m); false)
+
+"""
+the chain implied by `limits_modifiers = :auto`: widen, unless limits were given explicitly
+or rounded, and only for series types that would otherwise clip at the border
+"""
+function auto_limits_modifiers(axis::Axis)
     lims = process_limits(axis[:lims], axis)
-    (lims isa Tuple || lims ≡ :round) && return
+    (lims isa Tuple || lims ≡ :round) && return ()
     for sp in axis.sps, series in series_list(sp)
-        series.plotattributes[:seriestype] in _widen_seriestypes && return factor
+        series.plotattributes[:seriestype] in _widen_seriestypes && return (:widen,)
     end
-    return nothing
+    return ()
 end
+
+"""
+    limits_modifiers(axis)
+    limits_modifiers(axis, spec)
+
+Resolve `limits_modifiers` into the tuple of modifiers `axis_limits` folds over, left to
+right. Resolving an already resolved tuple returns it unchanged.
+"""
+limits_modifiers(axis::Axis) = limits_modifiers(axis, axis[:limits_modifiers])
+limits_modifiers(axis::Axis, spec::Tuple) =
+    Tuple(m for m in spec if valid_limits_modifier(axis[:letter], m))
+limits_modifiers(axis::Axis, spec::Pair{Symbol}) = limits_modifiers(axis, (spec,))
+limits_modifiers(axis::Axis, spec::Symbol) =
+if spec ≡ :auto
+    auto_limits_modifiers(axis)
+elseif spec ≡ :none
+    ()
+else
+    limits_modifiers(axis, (spec,))
+end
+limits_modifiers(axis::Axis, spec::Bool) = spec ? (:widen,) : ()
+limits_modifiers(axis::Axis, spec::Real) = (:widen => spec,)
+limits_modifiers(::Axis, ::Nothing) = ()
+limits_modifiers(axis::Axis, spec) = (warn_invalid_modifier(axis[:letter], spec); ())
+
+apply_limits_modifier(amin, amax, m::Symbol, scale) =
+if m ≡ :widen
+    scale_lims(amin, amax, default_widen_factor[], scale)
+elseif m ≡ :round
+    round_limits(amin, amax, scale)
+else  # `:symmetric`
+    a = max(abs(amin), abs(amax))
+    (-a, a)
+end
+apply_limits_modifier(amin, amax, m::Pair{Symbol}, scale) =
+    scale_lims(amin, amax, last(m), scale)
 
 function round_limits(amin, amax, scale)
     base = get(_log_scale_bases, scale, 10.0)

--- a/PlotsBase/src/Commons/aliases.jl
+++ b/PlotsBase/src/Commons/aliases.jl
@@ -234,6 +234,7 @@ add_aliases(:fillalpha, :fa, :falpha, :fα, :fillopacity, :fopacity)
 # axes attributes
 add_axes_aliases(:guide, :label, :lab, :l; generic = false)
 add_axes_aliases(:lims, :lim, :limit, :limits, :range)
+add_axes_aliases(:limits_modifiers, :limits_modifier, :lims_modifiers, :lims_modifier)
 add_axes_aliases(:ticks, :tick)
 add_axes_aliases(:rotation, :rot, :r)
 add_axes_aliases(:guidefontsize, :labelfontsize)

--- a/PlotsBase/src/Commons/aliases.jl
+++ b/PlotsBase/src/Commons/aliases.jl
@@ -234,7 +234,7 @@ add_aliases(:fillalpha, :fa, :falpha, :fα, :fillopacity, :fopacity)
 # axes attributes
 add_axes_aliases(:guide, :label, :lab, :l; generic = false)
 add_axes_aliases(:lims, :lim, :limit, :limits, :range)
-add_axes_aliases(:limits_modifiers, :limits_modifier, :lims_modifiers, :lims_modifier)
+add_axes_aliases(:limits_modifiers, :limits_modifier, :lims_modifiers, :lims_modifier, :lim_mod, :lims_mod)
 add_axes_aliases(:ticks, :tick)
 add_axes_aliases(:rotation, :rot, :r)
 add_axes_aliases(:guidefontsize, :labelfontsize)

--- a/PlotsBase/src/Commons/attrs.jl
+++ b/PlotsBase/src/Commons/attrs.jl
@@ -524,7 +524,7 @@ const _axis_defaults = KW(
     :minorticks => :auto,
     :minorgrid => false,
     :showaxis => true,
-    :widen => :auto,
+    :limits_modifiers => :auto,
     :draw_arrow => false,
     :unitformat => :round,
     :unit => nothing,
@@ -601,6 +601,28 @@ const _all_attrs =
     union(_lettered_all_axis_attrs, _all_subplot_attrs, _all_series_attrs, _all_plot_attrs)
 
 const _deprecated_attributes = Dict{Symbol, Symbol}()
+
+"""
+`widen` became `limits_modifiers` in v2. The value space is unchanged (`:auto`, a `Bool` or a
+factor), so this is a plain key rewrite. Remove in v3.
+"""
+function deprecate_widen!(plotattributes::AKW)
+    for k in collect(keys(plotattributes))
+        letter, rest = if (s = string(k)) in ("widen", "widens")
+            "", s
+        elseif length(s) > 1 && first(s) in ('x', 'y', 'z')
+            string(first(s)), lstrip(chop(s, head = 1, tail = 0), '_')
+        else
+            continue
+        end
+        rest in ("widen", "widens") || continue
+        nk = Symbol(letter, "limits_modifiers")
+        @maxlog_warn "`$k` is deprecated, use `$nk` instead"
+        v = pop!(plotattributes, k)
+        haskey(plotattributes, nk) || (plotattributes[nk] = v)
+    end
+    return nothing
+end
 const _all_defaults = KW[_series_defaults, _plot_defaults, _subplot_defaults]
 
 const _initial_defaults = deepcopy(_all_defaults)

--- a/PlotsBase/src/Commons/attrs.jl
+++ b/PlotsBase/src/Commons/attrs.jl
@@ -602,27 +602,6 @@ const _all_attrs =
 
 const _deprecated_attributes = Dict{Symbol, Symbol}()
 
-"""
-`widen` became `limits_modifiers` in v2. The value space is unchanged (`:auto`, a `Bool` or a
-factor), so this is a plain key rewrite. Remove in v3.
-"""
-function deprecate_widen!(plotattributes::AKW)
-    for k in collect(keys(plotattributes))
-        letter, rest = if (s = string(k)) in ("widen", "widens")
-            "", s
-        elseif length(s) > 1 && first(s) in ('x', 'y', 'z')
-            string(first(s)), lstrip(chop(s, head = 1, tail = 0), '_')
-        else
-            continue
-        end
-        rest in ("widen", "widens") || continue
-        nk = Symbol(letter, "limits_modifiers")
-        @maxlog_warn "`$k` is deprecated, use `$nk` instead"
-        v = pop!(plotattributes, k)
-        haskey(plotattributes, nk) || (plotattributes[nk] = v)
-    end
-    return nothing
-end
 const _all_defaults = KW[_series_defaults, _plot_defaults, _subplot_defaults]
 
 const _initial_defaults = deepcopy(_all_defaults)

--- a/PlotsBase/src/arg_desc.jl
+++ b/PlotsBase/src/arg_desc.jl
@@ -208,15 +208,16 @@ const _arg_desc = KW(
     :tick_direction => (Symbol, "Direction of the ticks. Choose from (`:in`, `:out`, `:none`)."),
     :showaxis => (Union{Bool, Symbol, AStr}, "Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`."),
     :limits_modifiers => (
-        Union{Symbol, Pair, Tuple}, """
+        Union{Symbol, NamedTuple, Tuple}, """
         How to modify the axis limits, applied left to right.
-        Choose from `:widen` (scale by the default factor of $(Axes.default_widen_factor[]), to avoid
-        cut-off markers and lines at the borders), `:round` (widen to the nearest round number) and
-        `:symmetric` (make the limits symmetric around zero), or a tuple of them such as
-        `(:widen, :round)`. `:widen` takes a factor, written `:widen => 1.2`.
+        A named tuple of modifiers and their settings, as in `(symmetric = true, widen = 1.2)`.
+        `:widen` scales by a factor (`true` uses the default of $(Axes.default_widen_factor[])) to keep
+        markers and lines off the borders, `:round` widens to the nearest round number, and
+        `:symmetric` makes the limits symmetric around zero.
+        A bare name switches a modifier on, so `:round` and `(:widen, :round)` are shorthand.
         Defaults to `:auto`, which widens unless limits were given explicitly or rounded.
-        `:none` applies nothing. Polar axes ignore this attribute.
-        In a recipe, parenthesize a pair: `limits_modifiers --> (:widen => 1.2)`.
+        `:none` applies nothing, and so does setting every modifier to `false`.
+        Polar axes ignore this attribute.
         See also `PlotsBase.scale_lims!` for scaling axis limits in an existing plot.""",
     ),
     :draw_arrow => (Bool, "Draw arrow at the end of the axis."),

--- a/PlotsBase/src/arg_desc.jl
+++ b/PlotsBase/src/arg_desc.jl
@@ -170,7 +170,7 @@ const _arg_desc = KW(
         Force axis limits. Only finite values are used (you can set only the right limit with `xlims = (-Inf, 2)` for example).
         `:round` widens the limit to the nearest round number, i.e. [0.1,3.6]=>[0.0,4.0].
         `:symmetric` sets the limits to be symmetric around zero.
-        Set `widen=true` to widen the specified limits (as occurs when lims are not specified).""",
+        See `limits_modifiers` for composing these, and for widening limits given explicitly.""",
     ),
     :ticks => (TicksType, "Tick values, (tickvalues, ticklabels), `:auto`/`true`, `:none`/`false`/`nothing` (ticks disabled), or `:native` (tells backend to calculate ticks by itself; good idea for interactive backends with mouse zooming)."),
     :scale => (Symbol, "Scale of the axis. Choose from $(Commons._all_scales)."),
@@ -207,13 +207,17 @@ const _arg_desc = KW(
     :minorgridlinewidth => (Real, "Width of the minor grid lines (in pixels)."),
     :tick_direction => (Symbol, "Direction of the ticks. Choose from (`:in`, `:out`, `:none`)."),
     :showaxis => (Union{Bool, Symbol, AStr}, "Show the axis. `true`, `false`, `:show`, `:hide`, `:yes`, `:no`, `:x`, `:y`, `:z`, `:xy`, ..., `:all`, `:off`."),
-    :widen => (
-        Union{Bool, Real, Symbol}, """
-        Widen the axis limits by a small factor to avoid cut-off markers and lines at the borders.
-        If set to `true`, scale the axis limits by the default factor of $(Axes.default_widen_factor).
-        A different factor may be specified by setting `widen` to a number.
-        Defaults to `:auto`, which widens by the default factor unless limits were manually set.
-        See also the `scale_limits!` function for scaling axis limits in an existing plot.""",
+    :limits_modifiers => (
+        Union{Symbol, Pair, Tuple}, """
+        How to modify the axis limits, applied left to right.
+        Choose from `:widen` (scale by the default factor of $(Axes.default_widen_factor[]), to avoid
+        cut-off markers and lines at the borders), `:round` (widen to the nearest round number) and
+        `:symmetric` (make the limits symmetric around zero), or a tuple of them such as
+        `(:widen, :round)`. `:widen` takes a factor, written `:widen => 1.2`.
+        Defaults to `:auto`, which widens unless limits were given explicitly or rounded.
+        `:none` applies nothing. Polar axes ignore this attribute.
+        In a recipe, parenthesize a pair: `limits_modifiers --> (:widen => 1.2)`.
+        See also `PlotsBase.scale_lims!` for scaling axis limits in an existing plot.""",
     ),
     :draw_arrow => (Bool, "Draw arrow at the end of the axis."),
     :unitformat => (Union{Bool, Nothing, Symbol, Char, String, NTuple{<:Union{Char, String}}, Function}, """Check examples in https://docs.juliaplots.org/stable/generated/unitfulext_examples/#Unit-formatting"""),

--- a/PlotsBase/src/plotly.jl
+++ b/PlotsBase/src/plotly.jl
@@ -90,7 +90,7 @@ const _plotly_attrs = PlotsBase.merge_with_base_supported(
         :window_title,
         :arrow,
         :guide,
-        :widen,
+        :limits_modifiers,
         :lims,
         :line,
         :ticks,

--- a/PlotsBase/src/recipes.jl
+++ b/PlotsBase/src/recipes.jl
@@ -423,7 +423,7 @@ end
         x = plotnames
         y = values_y
     end
-    ywiden --> false
+    ylimits_modifiers --> :none
     procx, procy, xscale, yscale, _ = _preprocess_barlike(plotattributes, x, y)
     nx, ny = length(procx), length(procy)
     axis = plotattributes[:subplot][:xaxis]
@@ -529,7 +529,7 @@ end
     z := nothing
     seriestype := :shape
     label := ""
-    widen --> false
+    limits_modifiers --> :none
     ()
 end
 @deps plots_heatmap shape
@@ -1535,7 +1535,7 @@ end
     rs, cs, zs = PlotsBase.find_nnz(z.surf)
     xlims := ignorenan_extrema(cs)
     ylims := ignorenan_extrema(rs)
-    widen --> true
+    limits_modifiers --> :widen
 
     markershape --> :circle
     markersize --> 1

--- a/PlotsBase/src/utils.jl
+++ b/PlotsBase/src/utils.jl
@@ -373,7 +373,6 @@ zlims(sp_idx::Int = 1) = zlims(current(), sp_idx)
 "Handle all preprocessing of args... break out colors/sizes/etc and replace aliases."
 function Commons.preprocess_attributes!(plotattributes::AKW)
     Commons.replaceAliases!(plotattributes, Commons._keyAliases)
-    Commons.deprecate_widen!(plotattributes)
 
     # handle axis args common to all axis
     args = wraptuple(RecipesPipeline.pop_kw!(plotattributes, :axis, ()))

--- a/PlotsBase/src/utils.jl
+++ b/PlotsBase/src/utils.jl
@@ -373,6 +373,7 @@ zlims(sp_idx::Int = 1) = zlims(current(), sp_idx)
 "Handle all preprocessing of args... break out colors/sizes/etc and replace aliases."
 function Commons.preprocess_attributes!(plotattributes::AKW)
     Commons.replaceAliases!(plotattributes, Commons._keyAliases)
+    Commons.deprecate_widen!(plotattributes)
 
     # handle axis args common to all axis
     args = wraptuple(RecipesPipeline.pop_kw!(plotattributes, :axis, ()))

--- a/PlotsBase/src/utils.jl
+++ b/PlotsBase/src/utils.jl
@@ -478,6 +478,14 @@ function Commons.preprocess_attributes!(plotattributes::AKW)
         end
     end
 
+    # validate the limits modifiers once here, so `axis_limits` only resolves `:auto`
+    for letter in (:x, :y, :z)
+        k = get_attr_symbol(letter, :limits_modifiers)
+        haskey(plotattributes, k) && (
+            plotattributes[k] = Axes.normalize_limits_modifiers(letter, plotattributes[k])
+        )
+    end
+
     # fonts
     for fontname in (
             :titlefont,

--- a/PlotsBase/test/test_axes.jl
+++ b/PlotsBase/test/test_axes.jl
@@ -99,11 +99,11 @@ end
         @test all(amin .≤ ticks .≤ amax)
     end
 
-    # user limits win over the tick count, `widen = false` does not
+    # user limits win over the tick count, `limits_modifiers = :none` does not
     pl = plot(sin, -π, π; xticks = 5, xlims = (-3, 3))
     @test PlotsBase.xlims(pl) == (-3, 3)
 
-    pl = plot(sin, -π, π; xticks = 5, widen = false)
+    pl = plot(sin, -π, π; xticks = 5, limits_modifiers = :none)
     ticks, = PlotsBase.get_ticks(pl[1], :x)
     amin, amax = PlotsBase.xlims(pl)
     @test length(ticks) == 5 && all(amin .≤ ticks .≤ amax)
@@ -134,7 +134,7 @@ end
     default_widen(from, to) =
         PlotsBase.Axes.scale_lims(from, to, PlotsBase.Axes.default_widen_factor)
 
-    pl = plot(1:5, xlims = :symmetric, widen = false)
+    pl = plot(1:5, xlims = :symmetric, limits_modifiers = :none)
     @test PlotsBase.xlims(pl) == (-5, 5)
 
     pl = plot(1:3)
@@ -146,11 +146,11 @@ end
     for x in (1:3, -10:10), xlims in ((1, 5), [1, 5])
         pl = plot(x; xlims)
         @test PlotsBase.xlims(pl) == (1, 5)
-        pl = plot(x; xlims, widen = true)
+        pl = plot(x; xlims, limits_modifiers = :widen)
         @test PlotsBase.xlims(pl) == default_widen(1, 5)
     end
 
-    pl = plot(1:5, lims = :symmetric, widen = false)
+    pl = plot(1:5, lims = :symmetric, limits_modifiers = :none)
     @test PlotsBase.xlims(pl) == PlotsBase.ylims(pl) == (-5, 5)
 
     for xlims in (0, 0.0, false, true, plot())
@@ -162,22 +162,83 @@ end
         @test plims == default_widen(1, 5)
     end
 
+    @testset "limits modifiers" begin
+        # github.com/JuliaPlots/Plots.jl/issues/3556
+        xl(; kw...) = PlotsBase.xlims(plot(1:5; kw...))
+
+        @test xl() == default_widen(1, 5)                              # `:auto`
+        @test xl(xlimits_modifiers = :round) == (1, 5)
+        @test xl(xlimits_modifiers = (:widen, :round)) == (0, 6)
+
+        # applied left to right, so these two differ
+        @test xl(xlimits_modifiers = (:symmetric, :widen)) == default_widen(-5, 5)
+        @test xl(xlimits_modifiers = (:widen, :symmetric)) == (-5.12, 5.12)
+
+        # `:widen` takes a factor
+        @test xl(xlimits_modifiers = :widen => 1.2) ==
+            PlotsBase.Axes.scale_lims(1, 5, 1.2)
+        @test xl(xlimits_modifiers = (:symmetric, :widen => 1.2)) ==
+            PlotsBase.Axes.scale_lims(-5, 5, 1.2)
+
+        # every spelling of "off"
+        for off in (:none, false, nothing, ())
+            @test xl(xlimits_modifiers = off) == (1, 5)
+        end
+        # and the `widen` value space, which the deprecation shim relies on
+        @test xl(xlimits_modifiers = true) == default_widen(1, 5)
+        @test xl(xlimits_modifiers = 1.2) == PlotsBase.Axes.scale_lims(1, 5, 1.2)
+
+        # letterless fans out to every axis
+        pl = plot(1:5, limits_modifiers = :symmetric)
+        @test PlotsBase.xlims(pl) == PlotsBase.ylims(pl) == (-5, 5)
+
+        # an explicit chain beats limits given by the user, `:auto` yields to them
+        @test PlotsBase.xlims(plot(1:5; xlims = (1, 5))) == (1, 5)
+        @test PlotsBase.xlims(
+            plot(1:5; xlims = (1, 5), xlimits_modifiers = :widen),
+        ) == default_widen(1, 5)
+
+        # `xlims = :round` and `:symmetric` keep working, and are not the same as the
+        # modifiers of the same name: they run before the degenerate span fixup
+        @test PlotsBase.ylims(plot([1.05, 2.0, 2.95], ylims = :round)) == (1, 3)
+        @test xl(xlims = :symmetric) == default_widen(-5, 5)
+
+        for bad in (:typo, (:widen, 1.2), :round => 2, [:widen, :round])
+            @test_logs (:warn, r"Invalid xlimits modifier") match_mode = :any xl(
+                xlimits_modifiers = bad,
+            )
+        end
+    end
+
+    @testset "deprecated `widen`" begin
+        for (old, new) in ((false, :none), (true, :widen), (1.2, 1.2))
+            pl = @test_logs (:warn, r"`widen` is deprecated") match_mode = :any plot(
+                1:5; widen = old,
+            )
+            @test PlotsBase.xlims(pl) == PlotsBase.xlims(plot(1:5; limits_modifiers = new))
+        end
+        pl = @test_logs (:warn, r"`xwiden` is deprecated") match_mode = :any plot(
+            1:5; xwiden = false,
+        )
+        @test PlotsBase.xlims(pl) == (1, 5)
+    end
+
     @testset "#4379" begin
         for ylims in ((-5, :auto), [-5, :auto])
-            pl = plot([-2, 3], ylims = ylims, widen = false)
+            pl = plot([-2, 3], ylims = ylims, limits_modifiers = :none)
             @test PlotsBase.ylims(pl) == (-5.0, 3.0)
         end
         for ylims in ((:auto, 4), [:auto, 4])
-            pl = plot([-2, 3], ylims = ylims, widen = false)
+            pl = plot([-2, 3], ylims = ylims, limits_modifiers = :none)
             @test PlotsBase.ylims(pl) == (-2.0, 4.0)
         end
 
         for xlims in ((-3, :auto), [-3, :auto])
-            pl = plot([-2, 3], [-1, 1], xlims = xlims, widen = false)
+            pl = plot([-2, 3], [-1, 1], xlims = xlims, limits_modifiers = :none)
             @test PlotsBase.xlims(pl) == (-3.0, 3.0)
         end
         for xlims in ((:auto, 4), [:auto, 4])
-            pl = plot([-2, 3], [-1, 1], xlims = xlims, widen = false)
+            pl = plot([-2, 3], [-1, 1], xlims = xlims, limits_modifiers = :none)
             @test PlotsBase.xlims(pl) == (-2.0, 4.0)
         end
     end

--- a/PlotsBase/test/test_axes.jl
+++ b/PlotsBase/test/test_axes.jl
@@ -175,18 +175,19 @@ end
         @test xl(xlimits_modifiers = (:widen, :symmetric)) == (-5.12, 5.12)
 
         # `:widen` takes a factor
-        @test xl(xlimits_modifiers = :widen => 1.2) ==
+        @test xl(xlimits_modifiers = (widen = 1.2,)) ==
             PlotsBase.Axes.scale_lims(1, 5, 1.2)
-        @test xl(xlimits_modifiers = (:symmetric, :widen => 1.2)) ==
+        @test xl(xlimits_modifiers = (symmetric = true, widen = 1.2)) ==
             PlotsBase.Axes.scale_lims(-5, 5, 1.2)
 
+        # a modifier can be switched off individually
+        @test xl(xlimits_modifiers = (widen = false,)) == (1, 5)
+        @test xl(xlimits_modifiers = (symmetric = true, widen = false)) == (-5, 5)
+
         # every spelling of "off"
-        for off in (:none, false, nothing, ())
+        for off in (:none, nothing, (), NamedTuple())
             @test xl(xlimits_modifiers = off) == (1, 5)
         end
-        # and the `widen` value space, which the deprecation shim relies on
-        @test xl(xlimits_modifiers = true) == default_widen(1, 5)
-        @test xl(xlimits_modifiers = 1.2) == PlotsBase.Axes.scale_lims(1, 5, 1.2)
 
         # letterless fans out to every axis
         pl = plot(1:5, limits_modifiers = :symmetric)
@@ -203,25 +204,13 @@ end
         @test PlotsBase.ylims(plot([1.05, 2.0, 2.95], ylims = :round)) == (1, 3)
         @test xl(xlims = :symmetric) == default_widen(-5, 5)
 
-        for bad in (:typo, (:widen, 1.2), :round => 2, [:widen, :round])
+        for bad in (:typo, (:widen, 1.2), (typo = true,), [:widen, :round])
             @test_logs (:warn, r"Invalid xlimits modifier") match_mode = :any xl(
                 xlimits_modifiers = bad,
             )
         end
     end
 
-    @testset "deprecated `widen`" begin
-        for (old, new) in ((false, :none), (true, :widen), (1.2, 1.2))
-            pl = @test_logs (:warn, r"`widen` is deprecated") match_mode = :any plot(
-                1:5; widen = old,
-            )
-            @test PlotsBase.xlims(pl) == PlotsBase.xlims(plot(1:5; limits_modifiers = new))
-        end
-        pl = @test_logs (:warn, r"`xwiden` is deprecated") match_mode = :any plot(
-            1:5; xwiden = false,
-        )
-        @test PlotsBase.xlims(pl) == (1, 5)
-    end
 
     @testset "#4379" begin
         for ylims in ((-5, :auto), [-5, :auto])

--- a/PlotsBase/test/test_dates.jl
+++ b/PlotsBase/test/test_dates.jl
@@ -4,7 +4,7 @@
 
     rx = [x[3], x[5]]
 
-    pl = plot(x, y, widen = false)
+    pl = plot(x, y, limits_modifiers = :none)
     vspan!(pl, rx, label = "", alpha = 0.2)
 
     ref_ylims = (y[1], y[end])
@@ -20,7 +20,7 @@ end
 
     ref_xlims = map(date -> date.instant.periods.value, span)
 
-    pl = plot(x, y, xlims = span, widen = false)
+    pl = plot(x, y, xlims = span, limits_modifiers = :none)
 end
 
 @testset "DateTime xlims" begin
@@ -30,6 +30,6 @@ end
 
     ref_xlims = map(date -> date.instant.periods.value, span)
 
-    pl = plot(x, y, xlims = span, widen = false)
+    pl = plot(x, y, xlims = span, limits_modifiers = :none)
     @test PlotsBase.xlims(pl) == ref_xlims
 end

--- a/PlotsBase/test/test_misc.jl
+++ b/PlotsBase/test/test_misc.jl
@@ -279,7 +279,7 @@ with(:gr) do
         @test plot([1, 2, 5], seriestype = :scatterpath) isa PlotsBase.Plot
         @test plot(1:2, 1:2, 1:2, seriestype = :scatter3d) isa PlotsBase.Plot
 
-        let pl = plot(1:2, -1:1, widen = false)
+        let pl = plot(1:2, -1:1, limits_modifiers = :none)
             PlotsBase.abline!([0, 3], [5, -5])
             @test xlims(pl) == (+1, +2)
             @test ylims(pl) == (-1, +1)

--- a/PlotsBase/test/test_recipes.jl
+++ b/PlotsBase/test/test_recipes.jl
@@ -34,20 +34,20 @@ end
 end
 
 @testset "vline, vspan" begin
-    vl = vline([1], widen = false)
+    vl = vline([1], limits_modifiers = :none)
     @test PlotsBase.xlims(vl) == (1, 2)
     @test PlotsBase.ylims(vl) == (1, 2)
-    vl = vline([1], xlims = (0, 2), widen = false)
+    vl = vline([1], xlims = (0, 2), limits_modifiers = :none)
     @test PlotsBase.xlims(vl) == (0, 2)
-    vl = vline([1], ylims = (-3, 5), widen = false)
+    vl = vline([1], ylims = (-3, 5), limits_modifiers = :none)
     @test PlotsBase.ylims(vl) == (-3, 5)
 
-    vsp = vspan([1, 3], widen = false)
+    vsp = vspan([1, 3], limits_modifiers = :none)
     @test PlotsBase.xlims(vsp) == (1, 3)
     @test PlotsBase.ylims(vsp) == (0, 1) # TODO: might be problematic on log-scales
-    vsp = vspan([1, 3], xlims = (-2, 5), widen = false)
+    vsp = vspan([1, 3], xlims = (-2, 5), limits_modifiers = :none)
     @test PlotsBase.xlims(vsp) == (-2, 5)
-    vsp = vspan([1, 3], ylims = (-2, 5), widen = false)
+    vsp = vspan([1, 3], ylims = (-2, 5), limits_modifiers = :none)
     @test PlotsBase.ylims(vsp) == (-2, 5)
 end
 


### PR DESCRIPTION
Closes #3556.

`limits_modifiers` replaces `widen`. It takes a named tuple of modifiers applied left to right, so the setting rides on the modifier and order is whatever you wrote:

```julia
plot(1:5)                                                       # (0.88, 5.12), the default `:auto`
plot(1:5, xlimits_modifiers = (widen = false,))                 # (1, 5)
plot(1:5, xlimits_modifiers = (widen = true, round = true))     # (0, 6)
plot(1:5, xlimits_modifiers = (symmetric = true, widen = true)) # (-5.3, 5.3)
```

`:widen`, `:round` and `:symmetric` are the modifiers; a bare name is shorthand for switching one on, so `:round` and `(:widen, :round)` work too. `:none` applies nothing. The default `:auto` behaves as `widen = :auto` did, so nothing renders differently unless you ask for it. `widen` is removed rather than deprecated, per the discussion; master keeps it.

Two things to flag:

- Your last example in the issue annotates `(symmetric, widen)` as `(-5.12, 5.12)`, but left to right that is `(-5.3, 5.3)`; `(-5.12, 5.12)` is widen then symmetric. Both orders are tested side by side.
- `xlims = :round` and `xlims = :symmetric` are untouched. They are not quite the same as the modifiers of the same name (`:symmetric` as a limit runs before the degenerate span fixup), so folding them in is worth its own PR.

## Attribution
- [ ] I am listed in the appropriate version of `.zenodo.json` for [PRs against v2](https://github.com/JuliaPlots/Plots.jl/blob/v2/.zenodo.json) or [PRs against master](https://github.com/JuliaPlots/Plots.jl/blob/master/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [x] Does it work on log scales? `:widen` and `:round` go through the existing scale aware `scale_lims` and `round_limits`
- [x] Does it work in layouts? Reference images 68/68
- [x] Does it work in recipes? `spy`, `bar` and the shape recipes were ported
- [x] Does it work with multiple series in one call? The `:auto` heuristic still scans every series on the axis
- [x] PR includes or updates tests? New `limits modifiers` testset in `test_axes.jl`, plus the existing `widen` call sites ported across four test files
- [x] PR includes or updates documentation? `arg_desc` entry for `limits_modifiers`, `lims` updated to point at it, NEWS under breaking changes
