### PR TITLE
Reformat for Runic 1.10

### DIFF
--- a/GraphRecipes/src/graphs.jl
+++ b/GraphRecipes/src/graphs.jl
@@ -1138,17 +1138,17 @@ more details.
                 seriestype := :scatter
                 append!(
                     edge_label_array, (
-                            x[i],
-                            y[i],
-                            names[
-                                ifelse(
-                                    i % length(names) == 0,
-                                    length(names),
-                                    i % length(names),
-                                ),
-                            ],
-                            fontsize,
-                        ) for i in eachindex(x)
+                        x[i],
+                        y[i],
+                        names[
+                            ifelse(
+                                i % length(names) == 0,
+                                length(names),
+                                i % length(names),
+                            ),
+                        ],
+                        fontsize,
+                    ) for i in eachindex(x)
                 )
                 colorbar_entry --> false
                 markersize := 0

--- a/GraphRecipes/src/utils.jl
+++ b/GraphRecipes/src/utils.jl
@@ -340,17 +340,17 @@ macro process_aliases(plotattributes, graph_aliases)
     attributes = getfield(__module__, graph_aliases) |> keys
     ex.args = [
         Expr(
-                :(=),
-                esc(sym),
-                :(
-                    $(esc(replacement_kwarg))(
-                        $(QuoteNode(sym)),
-                        $(esc(sym)),
-                        $(esc(plotattributes)),
-                        $(esc(graph_aliases)),
-                    )
-                ),
-            ) for sym in attributes
+            :(=),
+            esc(sym),
+            :(
+                $(esc(replacement_kwarg))(
+                    $(QuoteNode(sym)),
+                    $(esc(sym)),
+                    $(esc(plotattributes)),
+                    $(esc(graph_aliases)),
+                )
+            ),
+        ) for sym in attributes
     ]
     return ex
 end

--- a/PlotsBase/src/DataSeries.jl
+++ b/PlotsBase/src/DataSeries.jl
@@ -276,11 +276,11 @@ function series_segments(series::Series, seriestype::Symbol = :path; check = fal
     segments = if has_attribute_segments(series)
         (
             if seriestype ≡ :shape
-                    (SeriesSegment(segment, j),)
+                (SeriesSegment(segment, j),)
             elseif seriestype in (:scatter, :scatter3d)
-                    (SeriesSegment(i:i, i) for i in segment)
+                (SeriesSegment(i:i, i) for i in segment)
             else
-                    (SeriesSegment(i:(i + 1), i) for i in first(segment):(last(segment) - 1))
+                (SeriesSegment(i:(i + 1), i) for i in first(segment):(last(segment) - 1))
             end for (j, segment) in enumerate(nan_segments)
         ) |> Iterators.flatten
     else

--- a/PlotsBase/src/Subplots.jl
+++ b/PlotsBase/src/Subplots.jl
@@ -185,8 +185,8 @@ end
 
 needs_any_3d_axes(sp::Subplot) = any(
     RecipesPipeline.needs_3d_axes(
-            Commons._override_seriestype_check(s.plotattributes, s.plotattributes[:seriestype]),
-        ) for s in series_list(sp)
+        Commons._override_seriestype_check(s.plotattributes, s.plotattributes[:seriestype]),
+    ) for s in series_list(sp)
 )
 
 function PlotsBase.expand_extrema!(sp::Subplot, plotattributes::AKW)

--- a/PlotsBase/src/examples.jl
+++ b/PlotsBase/src/examples.jl
@@ -266,11 +266,11 @@ const _examples = PlotExample[
             closepct = rand(n)
             y = OHLC[
                 (
-                        openpct[i] * hgt[i] + bot[i],
-                        bot[i] + hgt[i],
-                        bot[i],
-                        closepct[i] * hgt[i] + bot[i],
-                    ) for i in 1:n
+                    openpct[i] * hgt[i] + bot[i],
+                    bot[i] + hgt[i],
+                    bot[i],
+                    closepct[i] * hgt[i] + bot[i],
+                ) for i in 1:n
             ]
             ohlc(y)
         end,


### PR DESCRIPTION
Runic 1.10 indents generator expressions differently, so the `format` job fails on v2 and on every PR against it. This is `runic --inplace` on the five affected files, nothing else: `git diff -w` is empty.
