### PR TITLE
Take limits only in `lims`, rounding and symmetry are modifiers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,9 @@
   as with the other backends, and `colorbar_scale` now maps the colors, not just the tick labels
 
 ## Breaking changes
+- `lims` takes limits only: `:auto`, or a two-element tuple or vector. `xlims = :round` and
+  `xlims = :symmetric` are now `xlimits_modifiers = (round = true,)` and `(symmetric = true,)`,
+  which also compose with `:widen` (#3556)
 - The `widen` axis attribute is replaced by `limits_modifiers`, which composes. It takes a named tuple
   of modifiers applied left to right, as in `xlimits_modifiers = (symmetric = true, widen = 1.2)`;
   `:widen`, `:round` and `:symmetric` are available, a bare name switches one on, and `:none` applies

--- a/PlotsBase/src/Axes.jl
+++ b/PlotsBase/src/Axes.jl
@@ -155,10 +155,6 @@ function Commons.axis_limits(
             lmax ≡ :auto || @maxlog_warn "Invalid max $(letter)limit" lmax
         end
     end
-    if lims ≡ :symmetric
-        amax = max(abs(amin), abs(amax))
-        amin = -amax
-    end
     if amax ≤ amin && isfinite(amin)
         amax = amin + 1.0
     end
@@ -173,12 +169,10 @@ function Commons.axis_limits(
             # widen max radius so ticks dont overlap with theta axis
             amin, amax = 0, amax + 0.1abs(amax - amin)
         end
-    elseif !isempty(chain)
+    else
         for m in pairs(chain)  # applied left to right
             amin, amax = apply_limits_modifier(amin, amax, m, axis[:scale])
         end
-    elseif lims ≡ :round
-        amin, amax = round_limits(amin, amax, axis[:scale])
     end
 
     if expand_int_ticks &&
@@ -238,7 +232,7 @@ or rounded, and only for series types that would otherwise clip at the border
 """
 function auto_limits_modifiers(axis::Axis)
     lims = process_limits(axis[:lims], axis)
-    (lims isa Tuple || lims ≡ :round) && return (;)
+    lims isa Tuple && return (;)
     for sp in axis.sps, series in series_list(sp)
         series.plotattributes[:seriestype] in _widen_seriestypes && return (widen = true,)
     end
@@ -319,14 +313,15 @@ end
 
 # NOTE: cannot use `NTuple` here ↓
 process_limits(lims::Tuple{<:Union{Symbol, Real}, <:Union{Symbol, Real}}, axis) = lims
-process_limits(lims::Symbol, axis) = lims
+process_limits(lims::Symbol, axis) = lims ≡ :auto ? lims : nothing
 process_limits(lims::AVec, axis) =
     length(lims) == 2 && all(map(x -> x isa Union{Symbol, Real}, lims)) ? Tuple(lims) :
     nothing
 process_limits(lims, axis) = nothing
 
 warn_invalid_limits(lims, letter) = @maxlog_warn """
-Invalid limits for $letter axis. Limits should be a symbol, or a two-element tuple or vector of numbers.
+Invalid limits for $letter axis. Limits should be `:auto`, or a two-element tuple or vector of numbers.
+Use `$(letter)limits_modifiers` to round or symmetrize them.
 $(letter)lims = $lims
 """
 function scale_lims(from, to, factor)

--- a/PlotsBase/src/arg_desc.jl
+++ b/PlotsBase/src/arg_desc.jl
@@ -168,9 +168,8 @@ const _arg_desc = KW(
     :lims => (
         Union{NTuple{2, Real}, Symbol}, """
         Force axis limits. Only finite values are used (you can set only the right limit with `xlims = (-Inf, 2)` for example).
-        `:round` widens the limit to the nearest round number, i.e. [0.1,3.6]=>[0.0,4.0].
-        `:symmetric` sets the limits to be symmetric around zero.
-        See `limits_modifiers` for composing these, and for widening limits given explicitly.""",
+        `:auto` leaves them to the data.
+        To round or symmetrize the limits, or to widen limits given explicitly, use `limits_modifiers`.""",
     ),
     :ticks => (TicksType, "Tick values, (tickvalues, ticklabels), `:auto`/`true`, `:none`/`false`/`nothing` (ticks disabled), or `:native` (tells backend to calculate ticks by itself; good idea for interactive backends with mouse zooming)."),
     :scale => (Symbol, "Scale of the axis. Choose from $(Commons._all_scales)."),

--- a/PlotsBase/test/test_axes.jl
+++ b/PlotsBase/test/test_axes.jl
@@ -134,13 +134,13 @@ end
     default_widen(from, to) =
         PlotsBase.Axes.scale_lims(from, to, PlotsBase.Axes.default_widen_factor)
 
-    pl = plot(1:5, xlims = :symmetric, limits_modifiers = :none)
+    pl = plot(1:5, limits_modifiers = (symmetric = true,))
     @test PlotsBase.xlims(pl) == (-5, 5)
 
     pl = plot(1:3)
     @test PlotsBase.xlims(pl) == default_widen(1, 3)
 
-    pl = plot([1.05, 2.0, 2.95], ylims = :round)
+    pl = plot([1.05, 2.0, 2.95], ylimits_modifiers = (round = true,))
     @test PlotsBase.ylims(pl) == (1, 3)
 
     for x in (1:3, -10:10), xlims in ((1, 5), [1, 5])
@@ -150,7 +150,7 @@ end
         @test PlotsBase.xlims(pl) == default_widen(1, 5)
     end
 
-    pl = plot(1:5, lims = :symmetric, limits_modifiers = :none)
+    pl = plot(1:5, limits_modifiers = (symmetric = true,))
     @test PlotsBase.xlims(pl) == PlotsBase.ylims(pl) == (-5, 5)
 
     for xlims in (0, 0.0, false, true, plot())
@@ -199,10 +199,12 @@ end
             plot(1:5; xlims = (1, 5), xlimits_modifiers = :widen),
         ) == default_widen(1, 5)
 
-        # `xlims = :round` and `:symmetric` keep working, and are not the same as the
-        # modifiers of the same name: they run before the degenerate span fixup
-        @test PlotsBase.ylims(plot([1.05, 2.0, 2.95], ylims = :round)) == (1, 3)
-        @test xl(xlims = :symmetric) == default_widen(-5, 5)
+        # `lims` takes limits only now, rounding and symmetrizing are modifiers
+        for gone in (:round, :symmetric)
+            @test_logs (:warn, r"Invalid limits for x axis") match_mode = :any xl(
+                xlims = gone,
+            )
+        end
 
         for bad in (:typo, (:widen, 1.2), (typo = true,), [:widen, :round])
             @test_logs (:warn, r"Invalid xlimits modifier") match_mode = :any xl(


### PR DESCRIPTION
Follows #5794 and https://github.com/JuliaPlots/Plots.jl/pull/5786#issuecomment-5614054743.

`lims` now takes limits only, `:auto` or a two element tuple or vector. `:round` and `:symmetric` moved to `limits_modifiers`, so there is one spelling each:

```julia
plot([1.05, 2.0, 2.95], ylimits_modifiers = (round = true,))   # was ylims = :round
plot(1:5, xlimits_modifiers = (symmetric = true,))             # was xlims = :symmetric
```

Passing the old values warns and falls back to the data limits.

This also fixes the ordering difference: `lims = :symmetric` ran before the degenerate span fixup and the modifier after, so `plot([3,3], ylims = :symmetric)` gave `(-3.18, 3.18)` against the modifier's `(-4, 4)`. There is only one path now.

Note the modifier does not widen unless asked, where `lims = :symmetric` left `:auto` on. `(symmetric = true, widen = true)` is the old behaviour.
